### PR TITLE
Use event-driven XML parsing; standardize code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 
 # Development and build files
 .coverage*
+.mypy_cache
 .pytest_cache
 build
 coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script: >
   pytest
   -ra
   --verbose
-  --remote-data
+  -m "not experimental"
   --cov sdmx --cov-report term-missing
 
 after_success:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -97,7 +97,7 @@ Reader API
 
 :func:`.to_pandas` implements a dispatch pattern according to the type of *obj*.
 Some of the internal methods take specific arguments and return varying values.
-These arguments can be passed to :meth:`to_pandas` when `obj` is of the appropriate type:
+These arguments can be passed to :func:`.to_pandas` when `obj` is of the appropriate type:
 
 .. autosummary::
    sdmx.writer.pandas.write_dataset

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -50,6 +50,7 @@ Top-level methods and classes
 
 SDMX-ML
 :::::::
+
 .. currentmodule:: sdmx.reader.sdmxml
 
 :mod:`sdmx` supports the several types of SDMX-ML messages.
@@ -66,6 +67,18 @@ SDMX-JSON
 .. autoclass:: sdmx.reader.sdmxjson.Reader
     :members:
     :undoc-members:
+
+
+Reader API
+::::::::::
+
+.. currentmodule:: sdmx.reader
+
+.. automodule:: sdmx.reader
+   :members:
+
+.. autoclass:: sdmx.reader.base.BaseReader
+   :members:
 
 
 ``writer``: Convert ``sdmx`` objects to other formats

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,8 +8,8 @@ import sdmx
 
 # -- Project information -----------------------------------------------------
 
-project = 'sdmx'
-copyright = '2014–2020 SDMX Python developers'
+project = "sdmx"
+copyright = "2014–2020 SDMX Python developers"
 # The major project version, used as the replacement for |version|.
 version = sdmx.__version__[:3]
 # The full project version, used as the replacement for |release|.
@@ -22,39 +22,36 @@ release = sdmx.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "IPython.sphinxext.ipython_directive",
 ]
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 
 # -- Options for sphinx.ext.extlinks -----------------------------------------
 
-extlinks = {
-    'pull': ('https://github.com/khaeru/sdmx/pull/%s', 'PR #'),
-}
+extlinks = {"pull": ("https://github.com/khaeru/sdmx/pull/%s", "PR #")}
 
 
 # -- Options for sphinx.ext.intersphinx --------------------------------------
 
 intersphinx_mapping = {
-    'np': ('https://docs.scipy.org/doc/numpy/', None),
-    'pd': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'py': ('https://docs.python.org/3/', None),
-    'requests': ('http://2.python-requests.org/en/master/', None),
-    'requests-cache': ('https://requests-cache.readthedocs.io/en/latest/',
-                       None),
+    "np": ("https://docs.scipy.org/doc/numpy/", None),
+    "pd": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "py": ("https://docs.python.org/3/", None),
+    "requests": ("http://2.python-requests.org/en/master/", None),
+    "requests-cache": ("https://requests-cache.readthedocs.io/en/latest/", None),
 }
 
 
@@ -68,4 +65,4 @@ todo_include_todos = True
 
 # Specify if the embedded Sphinx shell should import Matplotlib and set the
 # backend.
-ipython_mplbackend = ''
+ipython_mplbackend = ""

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,13 +22,12 @@ Get started
 ===========
 
 SDMX was designed to be flexible enough to accommodate almost *any* data.
-This also means it is complex, with many abstract concepts for describing data,
-metadata, and their relationships.
-These are called the “SDMX Information Model” (IM).
+To do this, it includes a large number of abstract concepts for describing data, metadata, and their relationships.
+These are collectively called the “SDMX Information Model” (IM).
 
 .. _not-the-standard:
 
-This documentation does not repeat full descriptions of SDMX, the IM, or SDMX web services; it focuses on functionality provided by :mod:`sdmx` itself.
+This documentation does not repeat full descriptions of SDMX, the IM, or SDMX web services; it focuses on the Python implementation in :mod:`sdmx` itself.
 Detailed knowledge of the IM is not needed to use :mod:`sdmx`; see a
 :doc:`usage example in only 10 lines of code <example>`, and then the longer, narrative :doc:`walkthrough <walkthrough>`.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -28,8 +28,7 @@ Optional dependencies for extra features
   Redis, and more: `requests-cache <https://requests-cache.readthedocs.io>`_.
 - for ``docs``, to build the documentation: `sphinx <https://sphinx-doc.org>`_
   and `IPython <https://ipython.org>`_.
-- for ``tests``, to run the test suite: `pytest <https://pytest.org>`_,
-  `pytest-remotedata <https://github.com/astropy/pytest-remotedata>`_, and
+- for ``tests``, to run the test suite: `pytest <https://pytest.org>`_, and
   `requests-mock <https://requests-mock.readthedocs.io>`_.
 
 Instructions

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -1,12 +1,62 @@
-Development roadmap
-===================
+Development
+***********
 
-This page describes some possible future enhancements to :mod:`sdmx`.
+This page gives development guidelines and some possible future enhancements to :mod:`sdmx`.
 For current development priorities, see the list of `GitHub milestones <https://github.com/khaeru/sdmx/milestones>`_ and issues/PRs targeted to each.
 Contributions are welcome!
 
-Using pd.DataFrame for internal storage
-----------------------------------------
+Code style
+==========
+
+- Apply the following to new or modified code::
+
+    isort -rc . && black . && mypy . && flake8
+
+  Respectively, these:
+
+  - **isort**: sort import lines at the top of code files in a consistent way, using `isort <https://pypi.org/project/isort/>`_.
+  - **black**: apply `black <https://black.readthedocs.io>`_ code style.
+  - **mypy**: check typing using `mypy <https://mypy.readthedocs.io>`_.
+  - **flake8**: check code style against `PEP 8 <https://www.python.org/dev/peps/pep-0008>`_ using `flake8 <https://flake8.pycqa.org>`_.
+
+- Write docstrings in the `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ style.
+
+Roadmap
+=======
+
+SDMX features & miscellaneous
+-----------------------------
+
+- Serialize :class:`Message` objects as SDMX-CSV (simplest), -JSON, or -ML (most complex).
+
+- Parse SDMX-JSON structure messages.
+
+- Selective/partial parsing of SDMX-ML messages.
+
+- sdmx.api.Request._resources only contains a subset of: https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1 (see "NOT SUPPORTED OPERATIONS"); provide the rest.
+
+- Get a set of API keys for testing UNESCO and encrypt them for use in CI: https://docs.travis-ci.com/user/encryption-keys/
+
+- Use the `XML Schema <https://en.wikipedia.org/wiki/XML_Schema_(W3C)>`_ definitions of SDMX-ML to validate messages and snippets.
+
+- Implement SOAP web service APIs.
+  This would allow access to, e.g., a broader set of :ref:`IMF` data.
+
+- Support SDMX-ML 2.0.
+  Several data providers still exist which only return SDMX-ML 2.0 messages.
+
+- Performance.
+  Parsing some messages can be slow.
+  Install pytest-profiling_ and run, for instance::
+
+      $ py.test --profile --profile-svg -k xml_structure_insee
+      $ python3 -m pstats prof/combined.prof
+      % sort cumulative
+      % stats
+
+
+Use pd.DataFrame for internal storage
+-------------------------------------
 
 :mod:`sdmx` handles :class:`Observations <sdmx.model.Observation>` as individual object instances.
 An alternative is to use :mod:`pandas` or other data structures internally.
@@ -24,53 +74,8 @@ To that end, note that the experimental DataSet involves three conversions:
 
 For a fair comparison, the API between the readers and DataSet could be changed to eliminate the round trip in #1/#2, but *without* sacrificing the data model consistency provided by pydantic on Observation instances.
 
-Optimize parsing
-----------------
-
-The current readers implement depth-first parsing of XML or JSON SDMX messages.
-This ensures the returned objects confirm rigorously to the SDMX Information Model, but can be slow for very large messages (both Structure and Data).
-
-There are some ways this performance could be improved:
-
-- Create-on-access: don't immediately parse an entire document, but only as requested to construct other objects.
-  This would make some internals more complex:
-
-  - Observation association with GroupKeys is determined by comparing the Observation key with the GroupKey.
-    In order to have a complete list of all Observations associated with a GroupKey, at least the dimension of each Observation would need to be parsed immediately.
-
-  - In sdmx.sdmxml.reader, references are determined to be internal or external by checking against an _index of already-parsed objects.
-    This index would need to represent existing-but-not-parsed objects.
-
-- Parallelize parsing, e.g. at the level of Series or other mostly-separate collections of objects.
-
-SDMX features & miscellaneous
------------------------------
-
-- sdmx.api.Request._resources only contains a small subset of: https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1 (see "NOT SUPPORTED OPERATIONS"); provide the rest.
-
-- Get a set of API keys for testing UNESCO and encrypt them for use in CI: https://docs.travis-ci.com/user/encryption-keys/
-
-- Serialize :class:`Message` objects SDMX-CSV (simplest), -JSON, or -ML (most complex).
-
-- Use the `XML Schema <https://en.wikipedia.org/wiki/XML_Schema_(W3C)>`_ definitions of SDMX-ML to validate messages and snippets.
-
-- SOAP APIs. Currently only REST APIs are supported.
-  This would allow access to, e.g., a broader set of :ref:`IMF` data.
-
-- Support SDMX-ML 2.0.
-  Several data providers still exist which only return SDMX-ML 2.0 messages.
-
-- Performance.
-  Parsing some messages can be slow.
-  Install pytest-profiling_ and run, for instance::
-
-      $ py.test --profile --profile-svg -k xml_structure_insee
-      $ python3 -m pstats prof/combined.prof
-      % sort cumulative
-      % stats
-
 Inline TODOs
-~~~~~~~~~~~~
+------------
 
 .. todolist::
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,9 +6,27 @@ What's new?
 Next release (vX.Y.0)
 =====================
 
+- Data model changes, to bring :mod:`sdmx` into closer alignment with the standard Information Model (:pull:`4`):
+
+  - Change :attr:`.Header.receiver` and :attr:`.Header.sender` to optional :class:`.Agency`, not :class:`str`.
+  - Add :attr:`.Header.source` and :attr:`~.Header.test`.
+  - :attr:`.IdentifiableArtefact.id` is strictly typed as :class:`str`, with a a singleton object (analogous to :obj:`None`) used for missing IDs.
+  - :attr:`.IdentifiableArtefact.id`, :attr:`.VersionableArtefact.version`, and :attr:`.MaintainableArtefact.maintainer` are inferred from a URN if one is passed during construction.
+  - :meth:`.VersionableArtefact.identical` and :meth:`.MaintainableArtefact.identical` compare on version and maintainer attributes, respectively.
+  - :class:`.Facet`, :class:`.Representation`, and :class:`.ISOConceptReference` are strictly validated, i.e. cannot be assigned non-IM attributes.
+  - Add :class:`.OrganisationScheme`, :class:`.NoSpecifiedRelationship`, :class:`.PrimaryMeasureRelationship`, :class:`.DimensionRelationship`, and :class:`.GroupRelationship` as distinct classes.
+  - Type of :attr:`.DimensionRelationship.dimensions` is :class:`.DimensionComponent`, not the narrower :class:`.Dimension`.
+  - :attr:`.DataStructureDefinition.measures` is an empty :class:`.MeasureDescriptor` by default, not :obj:`None`.
+  - :meth:`.DataSet.add_obs` now accepts :class:`Observations <.Observation>` with no :class:`.SeriesKey` association, and sets this association to the one provided as an argument.
+  - String representations are simplified but contain more information.
+
 - New features:
 
-  - :pull:`3`: Add :meth:`to_xml` to generate SDMX-ML for a subset of the IM.
+  - :attr:`.Item.hierarchical_id` and :meth:`.ItemScheme.get_hierarchical` create and search on IDs like ‘A.B.C’ for Item ‘A’ with child/grandchild Items ‘B’ and ‘C’ (:pull:`4`).
+  - New methods :func:`.parent_class`, :func:`.get_reader_for_path`, :func:`.detect_content_reader`, and :func:`.reader.register` (:pull:`4`).
+  - :class:`.sdmxml.Reader` uses an event-driven, rather than recursive/tree iterating, parser (:pull:`4`).
+  - The codebase is improved to pass static type checking with `mypy <https://mypy.readthedocs.io>`_ (:pull:`4`).
+  - Add :func:`.to_xml` to generate SDMX-ML for a subset of the IM (:pull:`3`).
 
 - Test suite:
 

--- a/sdmx/__init__.py
+++ b/sdmx/__init__.py
@@ -1,6 +1,7 @@
 import pkg_resources
 
-from sdmx.api import Request, read_sdmx, read_url
+from sdmx.api import Request, read_url
+from sdmx.reader import read_sdmx
 from sdmx.source import add_source, list_sources
 from sdmx.util import Resource
 from sdmx.writer import to_pandas, to_xml

--- a/sdmx/__init__.py
+++ b/sdmx/__init__.py
@@ -7,23 +7,23 @@ from sdmx.writer import to_pandas, to_xml
 import logging
 
 __all__ = [
-    'Request',
-    'Resource',
-    'add_source',
-    'list_sources',
-    'logger',
-    'read_sdmx',
-    'read_url',
-    'to_pandas',
-    'to_xml',
-    ]
+    "Request",
+    "Resource",
+    "add_source",
+    "list_sources",
+    "logger",
+    "read_sdmx",
+    "read_url",
+    "to_pandas",
+    "to_xml",
+]
 
 
 try:
-    __version__ = pkg_resources.get_distribution('sdmx').version
+    __version__ = pkg_resources.get_distribution("sdmx").version
 except Exception:
     # Local copy or not installed with setuptools
-    __version__ = '999'
+    __version__ = "999"
 
 
 #: Top-level logger.
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 
 def _init_logger():
     handler = logging.StreamHandler()
-    fmt = '{asctime} {name} - {levelname}: {message}'
-    handler.setFormatter(logging.Formatter(fmt, style='{'))
+    fmt = "{asctime} {name} - {levelname}: {message}"
+    handler.setFormatter(logging.Formatter(fmt, style="{"))
     logger.addHandler(handler)
     logger.setLevel(logging.ERROR)
 

--- a/sdmx/api.py
+++ b/sdmx/api.py
@@ -552,13 +552,14 @@ def read_sdmx(filename_or_obj, format=None, **kwargs):
         first_line = filename_or_obj.readline().strip()
         filename_or_obj.seek(pos)
 
-        if first_line.startswith("{"):
+        if first_line.startswith(b"{"):
             reader = readers["JSON"]
-        elif first_line.startswith("<"):
+        elif first_line.startswith(b"<"):
             reader = readers["XML"]
         else:
-            msg = f"cannot infer SDMX message format from '{first_line[:5]}..'"
-            raise RuntimeError(msg)
+            raise RuntimeError(
+                f"cannot infer SDMX message format from '{first_line[:5].decode()}..'"
+            )
 
         obj = filename_or_obj
 

--- a/sdmx/api.py
+++ b/sdmx/api.py
@@ -13,10 +13,10 @@ from warnings import warn
 import requests
 
 from sdmx import remote
+from sdmx.reader import get_reader_for_content_type
 
 from .message import Message
 from .model import DataStructureDefinition, MaintainableArtefact
-from sdmx.reader import get_reader_for_content_type
 from .source import NoSource, list_sources, sources
 from .util import Resource
 

--- a/sdmx/api.py
+++ b/sdmx/api.py
@@ -8,9 +8,11 @@ guidelines.
 from functools import partial
 import logging
 from pathlib import Path
+from typing import Dict
 from warnings import warn
 
 from sdmx import remote
+from .message import Message
 from .model import DataStructureDefinition, MaintainableArtefact
 from .reader import get_reader_for_content_type
 from .source import NoSource, list_sources, sources
@@ -36,7 +38,7 @@ class Request:
         :class:`.Session`.
 
     """
-    cache = {}
+    cache: Dict[str, Message] = {}
 
     #: :class:`.source.Source` for requests sent from the instance.
     source = None

--- a/sdmx/exceptions.py
+++ b/sdmx/exceptions.py
@@ -4,37 +4,10 @@ from requests import HTTPError  # noqa: F401
 class ParseError(Exception):
     """:class:`~.reader.Reader` is unable to parse a message."""
 
-    pass
 
-
-class XMLParseError(ParseError):
-    """Error in parsing SDMX-ML.
-
-    Parameters
-    ----------
-    reader : sdmxml.Reader
-    elem : lxml.etree.Element
-    """
-
-    def __init__(self, reader, elem, message=None):
-        self.stack = reader._stack
-        self.elem = elem
-        self.message = message
-        self.__suppress_context__ = True
+class XMLParseError(Exception):
+    """:class:`.sdmxml.Reader` is unable to parse a message."""
 
     def __str__(self):
-        from lxml import etree
-
-        msg = "\n\n".join(
-            filter(
-                None,
-                [
-                    self.message,
-                    "{}: {}".format(self.__cause__.__class__.__name__, self.__cause__),
-                    "Stack:\n" + "\n> ".join(self.stack),
-                    etree.tostring(self.elem, pretty_print=True).decode(),
-                ],
-            )
-        )
-        self.__cause__ = None
-        return msg
+        c = str(self.__cause__)
+        return f"{self.__cause__.__class__.__name__}{': ' + c if c else ''}"

--- a/sdmx/exceptions.py
+++ b/sdmx/exceptions.py
@@ -3,6 +3,7 @@ from requests import HTTPError  # noqa: F401
 
 class ParseError(Exception):
     """:class:`~.reader.Reader` is unable to parse a message."""
+
     pass
 
 
@@ -14,6 +15,7 @@ class XMLParseError(ParseError):
     reader : sdmxml.Reader
     elem : lxml.etree.Element
     """
+
     def __init__(self, reader, elem, message=None):
         self.stack = reader._stack
         self.elem = elem
@@ -23,12 +25,16 @@ class XMLParseError(ParseError):
     def __str__(self):
         from lxml import etree
 
-        msg = '\n\n'.join(filter(None, [
-            self.message,
-            '{}: {}'.format(self.__cause__.__class__.__name__,
-                            self.__cause__),
-            'Stack:\n' + '\n> '.join(self.stack),
-            etree.tostring(self.elem, pretty_print=True).decode(),
-            ]))
+        msg = "\n\n".join(
+            filter(
+                None,
+                [
+                    self.message,
+                    "{}: {}".format(self.__cause__.__class__.__name__, self.__cause__),
+                    "Stack:\n" + "\n> ".join(self.stack),
+                    etree.tostring(self.elem, pretty_print=True).decode(),
+                ],
+            )
+        )
         self.__cause__ = None
         return msg

--- a/sdmx/experimental.py
+++ b/sdmx/experimental.py
@@ -12,7 +12,7 @@ are stored internally as a pd.DataFrame. test_experimental.py verifies that
 this implementation exposes the same API as the default DataSet.
 
 """
-from typing import Text
+from typing import Optional, Text
 
 import pandas as pd
 from sdmx.model import (
@@ -29,10 +29,10 @@ from sdmx.util import DictLike
 
 class DataSet(AnnotableArtefact):
     # SDMX-IM features
-    action: ActionType = None
+    action: Optional[ActionType] = None
     attrib: DictLike[str, AttributeValue] = DictLike()
-    valid_from: Text = None
-    structured_by: DataStructureDefinition = None
+    valid_from: Optional[Text] = None
+    structured_by: Optional[DataStructureDefinition] = None
 
     # Internal storage: a pd.DataFrame with columns:
     # - 'value': the Observation value.

--- a/sdmx/experimental.py
+++ b/sdmx/experimental.py
@@ -15,6 +15,7 @@ this implementation exposes the same API as the default DataSet.
 from typing import Optional, Text
 
 import pandas as pd
+
 from sdmx.model import (
     ActionType,
     AnnotableArtefact,
@@ -23,7 +24,7 @@ from sdmx.model import (
     DataStructureDefinition,
     Key,
     Observation,
-    )
+)
 from sdmx.util import DictLike
 
 
@@ -52,17 +53,17 @@ class DataSet(AnnotableArtefact):
         obs_dict = {}
         for obs in observations:
             # DataFrame row for this Observation
-            row = {'value': obs.value}
+            row = {"value": obs.value}
 
             # Store attributes
             for attr_id, av in obs.attached_attribute.items():
-                row[('attr_obs', attr_id)] = av.value
+                row[("attr_obs", attr_id)] = av.value
 
             # Store the row
             obs_dict[obs.key.order().get_values()] = row
 
         # Convert to pd.DataFrame. Note similarity to sdmx.writer
-        self._data = pd.DataFrame.from_dict(obs_dict, orient='index')
+        self._data = pd.DataFrame.from_dict(obs_dict, orient="index")
 
         if len(obs_dict):
             self._data.index.names = obs.key.order().values.keys()
@@ -77,8 +78,7 @@ class DataSet(AnnotableArtefact):
     def _make_obs(self, key, data):
         """Create an Observation from tuple *key* and pd.Series *data."""
         # Create the Key
-        key = Key({dim: value for dim, value in
-                   zip(self._data.index.names, key)})
+        key = Key({dim: value for dim, value in zip(self._data.index.names, key)})
         attrs = {}
 
         # Handle columns of ._data
@@ -89,10 +89,9 @@ class DataSet(AnnotableArtefact):
             except ValueError:
                 # Not a tuple → the 'value' column, handled below
                 continue
-            if group == 'attr_obs':
+            if group == "attr_obs":
                 # Create a DataAttribute
                 attrs[attr_id] = AttributeValue(
-                    value_for=DataAttribute(id=attr_id),
-                    value=value)
-        return Observation(dimension=key, value=data['value'],
-                           attached_attribute=attrs)
+                    value_for=DataAttribute(id=attr_id), value=value
+                )
+        return Observation(dimension=key, value=data["value"], attached_attribute=attrs)

--- a/sdmx/format/protobuf_pb2.py
+++ b/sdmx/format/protobuf_pb2.py
@@ -1,0 +1,2 @@
+def Envelope():
+    raise NotImplementedError(__name__)

--- a/sdmx/format/xml.py
+++ b/sdmx/format/xml.py
@@ -2,19 +2,18 @@ from functools import lru_cache
 
 from lxml.etree import QName
 
-
 # XML Namespaces
-_base_ns = 'http://www.sdmx.org/resources/sdmxml/schemas/v2_1'
+_base_ns = "http://www.sdmx.org/resources/sdmxml/schemas/v2_1"
 NS = {
-    'com': f'{_base_ns}/common',
-    'data': f'{_base_ns}/data/structurespecific',
-    'str': f'{_base_ns}/structure',
-    'mes': f'{_base_ns}/message',
-    'gen': f'{_base_ns}/data/generic',
-    'footer': f'{_base_ns}/message/footer',
-    'xml': 'http://www.w3.org/XML/1998/namespace',
-    'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-    }
+    "com": f"{_base_ns}/common",
+    "data": f"{_base_ns}/data/structurespecific",
+    "str": f"{_base_ns}/structure",
+    "mes": f"{_base_ns}/message",
+    "gen": f"{_base_ns}/data/generic",
+    "footer": f"{_base_ns}/message/footer",
+    "xml": "http://www.w3.org/XML/1998/namespace",
+    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+}
 
 
 @lru_cache()

--- a/sdmx/format/xml.py
+++ b/sdmx/format/xml.py
@@ -2,9 +2,12 @@ from functools import lru_cache
 
 from lxml.etree import QName
 
+from sdmx import message
+
 # XML Namespaces
 _base_ns = "http://www.sdmx.org/resources/sdmxml/schemas/v2_1"
 NS = {
+    "": None,
     "com": f"{_base_ns}/common",
     "data": f"{_base_ns}/data/structurespecific",
     "str": f"{_base_ns}/structure",
@@ -17,6 +20,18 @@ NS = {
 
 
 @lru_cache()
-def qname(ns, name):
+def qname(ns_or_name, name=None):
     """Return a fully-qualified tag *name* in namespace *ns*."""
+    ns, name = ns_or_name.split(":") if name is None else (ns_or_name, name)
     return QName(NS[ns], name)
+
+
+# Mapping tag names → Message classes
+MESSAGE = {
+    "Structure": message.StructureMessage,
+    "GenericData": message.DataMessage,
+    "GenericTimeSeriesData": message.DataMessage,
+    "StructureSpecificData": message.DataMessage,
+    "StructureSpecificTimeSeriesData": message.DataMessage,
+    "Error": message.ErrorMessage,
+}

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -11,21 +11,7 @@ from typing import List, Optional, Text, Union
 
 from requests import Response
 
-from sdmx.model import (
-    AgencyScheme,
-    CategoryScheme,
-    Codelist,
-    ConceptScheme,
-    ContentConstraint,
-    DataflowDefinition,
-    DataSet,
-    DataStructureDefinition,
-    DimensionComponent,
-    InternationalString,
-    Item,
-    ProvisionAgreement,
-    _AllDimensions,
-)
+from sdmx import model
 from sdmx.util import BaseModel, DictLike, summarize_dictlike
 
 
@@ -35,7 +21,7 @@ def _summarize(obj, fields):
         attr = getattr(obj, name)
         if attr is None:
             continue
-        yield f"{name}: {attr!r}"
+        yield f"{name}: {repr(attr)}"
 
 
 class Header(BaseModel):
@@ -52,9 +38,13 @@ class Header(BaseModel):
     prepared: Optional[Text] = None
     #: Intended recipient of the message, e.g. the user's name for an
     #: authenticated service.
-    receiver: Optional[Text] = None
+    receiver: Optional[model.Agency] = None
     #: The :class:`.Agency` associated with the data :class:`~.source.Source`.
-    sender: Optional[Union[Item, Text]] = None
+    sender: Optional[model.Agency] = None
+    #:
+    source: model.InternationalString = model.InternationalString()
+    #:
+    test: bool = False
 
     def __repr__(self):
         """String representation."""
@@ -70,11 +60,11 @@ class Footer(BaseModel):
     """
 
     #:
-    severity: Text
+    severity: Optional[str] = None
     #: The body text of the Footer contains zero or more blocks of text.
-    text: List[InternationalString] = []
+    text: List[model.InternationalString] = []
     #:
-    code: int
+    code: Optional[int] = None
 
 
 class Message(BaseModel):
@@ -109,21 +99,21 @@ class ErrorMessage(Message):
 
 class StructureMessage(Message):
     #: Collection of :class:`.CategoryScheme`.
-    category_scheme: DictLike[str, CategoryScheme] = DictLike()
+    category_scheme: DictLike[str, model.CategoryScheme] = DictLike()
     #: Collection of :class:`.Codelist`.
-    codelist: DictLike[str, Codelist] = DictLike()
+    codelist: DictLike[str, model.Codelist] = DictLike()
     #: Collection of :class:`.ConceptScheme`.
-    concept_scheme: DictLike[str, ConceptScheme] = DictLike()
+    concept_scheme: DictLike[str, model.ConceptScheme] = DictLike()
     #: Collection of :class:`.ContentConstraint`.
-    constraint: DictLike[str, ContentConstraint] = DictLike()
+    constraint: DictLike[str, model.ContentConstraint] = DictLike()
     #: Collection of :class:`.DataflowDefinition`.
-    dataflow: DictLike[str, DataflowDefinition] = DictLike()
+    dataflow: DictLike[str, model.DataflowDefinition] = DictLike()
     #: Collection of :class:`.DataStructureDefinition`.
-    structure: DictLike[str, DataStructureDefinition] = DictLike()
+    structure: DictLike[str, model.DataStructureDefinition] = DictLike()
     #: Collection of :class:`.AgencyScheme`.
-    organisation_scheme: DictLike[str, AgencyScheme] = DictLike()
+    organisation_scheme: DictLike[str, model.AgencyScheme] = DictLike()
     #: Collection of :class:`.ProvisionAgreement`.
-    provisionagreement: DictLike[str, ProvisionAgreement] = DictLike()
+    provisionagreement: DictLike[str, model.ProvisionAgreement] = DictLike()
 
     def __repr__(self):
         """String representation."""
@@ -147,12 +137,16 @@ class DataMessage(Message):
     """
 
     #: :class:`list` of :class:`.DataSet`.
-    data: List[DataSet] = []
+    data: List[model.DataSet] = []
     #: :class:`.DataflowDefinition` that contains the data.
-    dataflow: DataflowDefinition = DataflowDefinition()
+    dataflow: model.DataflowDefinition = model.DataflowDefinition()
     #: The "dimension at observation level".
     observation_dimension: Optional[
-        Union[_AllDimensions, DimensionComponent, List[DimensionComponent]]
+        Union[
+            model._AllDimensions,
+            model.DimensionComponent,
+            List[model.DimensionComponent],
+        ]
     ] = None
 
     # Convenience access

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -9,6 +9,7 @@ returned by data sources.
 """
 from typing import (
     List,
+    Optional,
     Text,
     Union,
     )
@@ -47,16 +48,16 @@ class Header(BaseModel):
     SDMX-JSON messages do not have headers.
     """
     #: (optional) Error code for the message.
-    error: Text = None
+    error: Optional[Text] = None
     #: Identifier for the message.
-    id: Text = None
+    id: Optional[Text] = None
     #: Date and time at which the message was generated.
-    prepared: Text = None
+    prepared: Optional[Text] = None
     #: Intended recipient of the message, e.g. the user's name for an
     #: authenticated service.
-    receiver: Text = None
+    receiver: Optional[Text] = None
     #: The :class:`.Agency` associated with the data :class:`~.source.Source`.
-    sender: Union[Item, Text] = None
+    sender: Optional[Union[Item, Text]] = None
 
     def __repr__(self):
         """String representation."""
@@ -86,10 +87,10 @@ class Message(BaseModel):
     #: :class:`Header` instance.
     header: Header = Header()
     #: (optional) :class:`Footer` instance.
-    footer: Footer = None
+    footer: Optional[Footer] = None
     #: :class:`requests.Response` instance for the response to the HTTP request
     #: that returned the Message. This is not part of the SDMX standard.
-    response: Response = None
+    response: Optional[Response] = None
 
     def __str__(self):
         return repr(self)
@@ -151,8 +152,8 @@ class DataMessage(Message):
     #: :class:`.DataflowDefinition` that contains the data.
     dataflow: DataflowDefinition = DataflowDefinition()
     #: The "dimension at observation level".
-    observation_dimension: Union[_AllDimensions, DimensionComponent,
-                                 List[DimensionComponent]] = None
+    observation_dimension: Optional[Union[_AllDimensions, DimensionComponent,
+                                          List[DimensionComponent]]] = None
 
     # Convenience access
     @property

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -7,30 +7,26 @@
 :mod:`sdmx` also uses :class:`DataMessage` to encapsulate SDMX-JSON data
 returned by data sources.
 """
-from typing import (
-    List,
-    Optional,
-    Text,
-    Union,
-    )
+from typing import List, Optional, Text, Union
+
+from requests import Response
 
 from sdmx.model import (
-    _AllDimensions,
     AgencyScheme,
     CategoryScheme,
     Codelist,
     ConceptScheme,
     ContentConstraint,
-    DataSet,
     DataflowDefinition,
+    DataSet,
     DataStructureDefinition,
     DimensionComponent,
     InternationalString,
     Item,
     ProvisionAgreement,
-    )
+    _AllDimensions,
+)
 from sdmx.util import BaseModel, DictLike, summarize_dictlike
-from requests import Response
 
 
 def _summarize(obj, fields):
@@ -39,7 +35,7 @@ def _summarize(obj, fields):
         attr = getattr(obj, name)
         if attr is None:
             continue
-        yield f'{name}: {attr!r}'
+        yield f"{name}: {attr!r}"
 
 
 class Header(BaseModel):
@@ -47,6 +43,7 @@ class Header(BaseModel):
 
     SDMX-JSON messages do not have headers.
     """
+
     #: (optional) Error code for the message.
     error: Optional[Text] = None
     #: Identifier for the message.
@@ -61,9 +58,9 @@ class Header(BaseModel):
 
     def __repr__(self):
         """String representation."""
-        lines = ['<Header>']
+        lines = ["<Header>"]
         lines.extend(_summarize(self, self.__fields__.keys()))
-        return '\n  '.join(lines)
+        return "\n  ".join(lines)
 
 
 class Footer(BaseModel):
@@ -71,6 +68,7 @@ class Footer(BaseModel):
 
     SDMX-JSON messages do not have footers.
     """
+
     #:
     severity: Text
     #: The body text of the Footer contains zero or more blocks of text.
@@ -98,11 +96,11 @@ class Message(BaseModel):
     def __repr__(self):
         """String representation."""
         lines = [
-            f'<sdmx.{self.__class__.__name__}>',
-            repr(self.header).replace('\n', '\n  '),
+            f"<sdmx.{self.__class__.__name__}>",
+            repr(self.header).replace("\n", "\n  "),
         ]
-        lines.extend(_summarize(self, ['footer', 'response']))
-        return '\n  '.join(lines)
+        lines.extend(_summarize(self, ["footer", "response"]))
+        return "\n  ".join(lines)
 
 
 class ErrorMessage(Message):
@@ -136,7 +134,7 @@ class StructureMessage(Message):
             if isinstance(attr, DictLike) and attr:
                 lines.append(summarize_dictlike(attr))
 
-        return '\n  '.join(lines)
+        return "\n  ".join(lines)
 
 
 class DataMessage(Message):
@@ -147,13 +145,15 @@ class DataMessage(Message):
        data set in the message, access the first element of the list:
        ``msg.data[0]``.
     """
+
     #: :class:`list` of :class:`.DataSet`.
     data: List[DataSet] = []
     #: :class:`.DataflowDefinition` that contains the data.
     dataflow: DataflowDefinition = DataflowDefinition()
     #: The "dimension at observation level".
-    observation_dimension: Optional[Union[_AllDimensions, DimensionComponent,
-                                          List[DimensionComponent]]] = None
+    observation_dimension: Optional[
+        Union[_AllDimensions, DimensionComponent, List[DimensionComponent]]
+    ] = None
 
     # Convenience access
     @property
@@ -167,7 +167,7 @@ class DataMessage(Message):
 
         # DataMessage contents
         if self.data:
-            lines.append('DataSet ({})'.format(len(self.data)))
-        lines.extend(_summarize(self, ('dataflow', 'observation_dimension')))
+            lines.append("DataSet ({})".format(len(self.data)))
+        lines.extend(_summarize(self, ("dataflow", "observation_dimension")))
 
-        return '\n  '.join(lines)
+        return "\n  ".join(lines)

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -1186,7 +1186,7 @@ class DataStructureDefinition(Structure, ConstrainableArtefact):
         attr = getattr(self.attributes, get_method)
 
         # Arguments for creating the Key
-        args = dict(described_by=self.dimensions)
+        args: Dict[str, Any] = dict(described_by=self.dimensions)
 
         if key_cls is GroupKey:
             # Get the GroupDimensionDescriptor, if indicated by group_id

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -18,12 +18,8 @@ Details of the implementation:
   appear out of order so that dependent classes are defined first.
 
 """
-# TODO:
-# - For a complete implementation of the spec:
-#   - Enforce TimeKeyValue (instead of KeyValue) for
-#     {Generic,StructureSpecific} TimeSeriesDataSet.
-# - For convenience:
-#   - Guess URNs using the standard format.
+# TODO for complete implementation of the IM, enforce TimeKeyValue (instead of
+#      KeyValue) for {Generic,StructureSpecific} TimeSeriesDataSet.
 
 from collections import ChainMap
 from collections.abc import Collection
@@ -55,7 +51,7 @@ from sdmx.util import BaseModel, DictLike, validate_dictlike, validator
 DEFAULT_LOCALE = "en"
 
 
-# 3.2: Base structures
+# §3.2: Base structures
 
 
 class InternationalString:
@@ -350,7 +346,7 @@ class MaintainableArtefact(VersionableArtefact):
         return "<{cls} {maint}{id}{version}{name}>".format(**self._repr_kw())
 
 
-# 3.4: Data Types
+# §3.4: Data Types
 
 ActionType = Enum("ActionType", "delete replace append information")
 
@@ -376,7 +372,7 @@ FacetValueType = Enum(
 ConstraintRoleType = Enum("ConstraintRoleType", "allowable actual")
 
 
-# 3.5: Item Scheme
+# §3.5: Item Scheme
 
 
 class Item(NameableArtefact):
@@ -578,7 +574,7 @@ class ItemScheme(MaintainableArtefact, Generic[IT]):
         return obj
 
 
-# 3.6: Structure
+# §3.6: Structure
 
 
 class FacetType(BaseModel):
@@ -640,7 +636,7 @@ class Representation(BaseModel):
         )
 
 
-# 4.4: Concept Scheme
+# §4.4: Concept Scheme
 
 
 class ISOConceptReference(BaseModel):
@@ -666,7 +662,7 @@ class ConceptScheme(ItemScheme[Concept]):
     _Item = Concept
 
 
-# 3.3: Basic Inheritance
+# §3.3: Basic Inheritance
 
 
 class Component(IdentifiableArtefact):
@@ -782,7 +778,7 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
         return super().__hash__()
 
 
-# 4.3: Codelist
+# §4.3: Codelist
 
 
 class Code(Item):
@@ -793,7 +789,7 @@ class Codelist(ItemScheme[Code]):
     _Item = Code
 
 
-# 4.5: Category Scheme
+# §4.5: Category Scheme
 
 
 class Category(Item):
@@ -811,7 +807,7 @@ class Categorisation(MaintainableArtefact):
     artefact: Optional[IdentifiableArtefact] = None
 
 
-# 4.6: Organisations
+# §4.6: Organisations
 
 
 class Contact(BaseModel):
@@ -851,6 +847,7 @@ class Agency(Organisation):
 
 # DataProvider delayed until after ConstrainableArtefact, below
 
+
 # Update forward references to 'Agency'
 for cls in list(locals().values()):
     if isclass(cls) and issubclass(cls, MaintainableArtefact):
@@ -867,7 +864,8 @@ class AgencyScheme(ItemScheme[Agency], OrganisationScheme):
 
 # DataProviderScheme delayed until after DataProvider, below
 
-# 10.2: Constraint inheritance
+
+# §10.2: Constraint inheritance
 
 
 class ConstrainableArtefact(BaseModel):
@@ -882,7 +880,7 @@ class DataProviderScheme(ItemScheme[DataProvider], OrganisationScheme):
     _Item = DataProvider
 
 
-# 10.3: Constraints
+# §10.3: Constraints
 
 
 class ConstraintRole(BaseModel):
@@ -1022,7 +1020,7 @@ class AttachmentConstraint(Constraint):
     attachment: Set[ConstrainableArtefact] = set()
 
 
-# 5.2: Data Structure Definition
+# §5.2: Data Structure Definition
 
 
 class DimensionComponent(Component):
@@ -1072,8 +1070,8 @@ class DimensionRelationship(AttributeRelationship):
     group_key: Optional["GroupDimensionDescriptor"] = None
 
 
-# 'Retained for compatibility reasons' in SDMX 2.1; not used by pandaSDMX
 class GroupRelationship(AttributeRelationship):
+    # 'Retained for compatibility reasons' in SDMX 2.1; not used by pandaSDMX.
     #:
     group_key: Optional["GroupDimensionDescriptor"] = None
 
@@ -1371,7 +1369,7 @@ class DataflowDefinition(StructureUsage, ConstrainableArtefact):
     structure: DataStructureDefinition = DataStructureDefinition()
 
 
-# 5.4: Data Set
+# §5.4: Data Set
 
 
 def value_for_dsd_ref(kind, args, kwargs):
@@ -1782,7 +1780,7 @@ class _AllDimensions:
 AllDimensions = _AllDimensions()
 
 
-# 11. Data Provisioning
+# §11: Data Provisioning
 
 
 class Datasource(BaseModel):

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -672,7 +672,8 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
         )
 
     # Must be reset because __eq__ is defined
-    __hash__ = IdentifiableArtefact.__hash__
+    def __hash__(self):
+        return super().__hash__()
 
 
 # 4.3: Codelist

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -47,9 +47,8 @@ from typing import (
 )
 from warnings import warn
 
-from pydantic import validator
+from sdmx.util import BaseModel, DictLike, validate_dictlike, validator
 
-from sdmx.util import BaseModel, DictLike, validate_dictlike
 
 # TODO read this from the environment, or use any value set in the SDMX XML
 # spec. Currently set to 'en' because test_dsd.py expects it

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -328,13 +328,13 @@ class MaintainableArtefact(VersionableArtefact):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         try:
-            if self.maintainer.id != self.urn_group["agency"]:
+            if self.maintainer and self.maintainer.id != self.urn_group["agency"]:
                 raise ValueError(
                     f"Maintainer {self.maintainer} does not match URN {self.urn}"
                 )
             else:
                 self.maintainer = Agency(id=self.urn_group["agency"])
-        except (AttributeError, KeyError):
+        except KeyError:
             pass
 
     def identical(self, other):

--- a/sdmx/reader/__init__.py
+++ b/sdmx/reader/__init__.py
@@ -1,16 +1,17 @@
 from pathlib import Path
+from typing import List, Mapping, Type
 
 from . import sdmxjson, sdmxml
 
 
 #: Reader classes
-READERS = []
+READERS: List[Type] = []
 
 #: Mapping from HTTP content type to reader class.
-CTYPE_READER = {}
+CTYPE_READER: Mapping[str, Type] = {}
 
 #: Mapping from file path suffix to reader class.
-SUFFIX_READER = {}
+SUFFIX_READER: Mapping[str, Type] = {}
 
 
 def detect_content_reader(content):

--- a/sdmx/reader/__init__.py
+++ b/sdmx/reader/__init__.py
@@ -17,29 +17,31 @@ class BaseReader(ABC):
 
 # TODO make an attribute of Reader
 CONTENT_TYPES = {
-    'xml': [
-        'application/xml',
-        'application/vnd.sdmx.genericdata+xml',
-        'application/vnd.sdmx.structure+xml',
-        'application/vnd.sdmx.structurespecificdata+xml',
-        'text/xml',
+    "xml": [
+        "application/xml",
+        "application/vnd.sdmx.genericdata+xml",
+        "application/vnd.sdmx.structure+xml",
+        "application/vnd.sdmx.structurespecificdata+xml",
+        "text/xml",
     ],
-    'json': [
-        'text/json',
+    "json": [
+        "text/json",
         # For e.g. OECD
-        'draft-sdmx-json',
-        'application/vnd.sdmx.draft-sdmx-json+json',
+        "draft-sdmx-json",
+        "application/vnd.sdmx.draft-sdmx-json+json",
     ],
 }
 
 
 def get_reader_for_content_type(ctype):
-    ctype = str(ctype).split(';')[0].strip()
-    if ctype in CONTENT_TYPES['xml']:
+    ctype = str(ctype).split(";")[0].strip()
+    if ctype in CONTENT_TYPES["xml"]:
         from .sdmxml import Reader
+
         return Reader
-    elif ctype in CONTENT_TYPES['json']:
+    elif ctype in CONTENT_TYPES["json"]:
         from .sdmxjson import Reader
+
         return Reader
     else:
         raise ValueError(ctype)

--- a/sdmx/reader/__init__.py
+++ b/sdmx/reader/__init__.py
@@ -1,47 +1,147 @@
-from abc import ABC, abstractmethod
+from pathlib import Path
+
+from . import sdmxjson, sdmxml
 
 
-class BaseReader(ABC):
-    @abstractmethod
-    def read_message(self, source, dsd=None):
-        """Read message from *source*.
+#: Reader classes
+READERS = []
 
-        Must return an instance of a model.Message subclass.
-        """
-        pass  # pragma: no cover
+#: Mapping from HTTP content type to reader class.
+CTYPE_READER = {}
 
-    # Backwards-compatibility
-    def initialize(self, source):
-        return self.read_message(source)
+#: Mapping from file path suffix to reader class.
+SUFFIX_READER = {}
 
 
-# TODO make an attribute of Reader
-CONTENT_TYPES = {
-    "xml": [
-        "application/xml",
-        "application/vnd.sdmx.genericdata+xml",
-        "application/vnd.sdmx.structure+xml",
-        "application/vnd.sdmx.structurespecificdata+xml",
-        "text/xml",
-    ],
-    "json": [
-        "text/json",
-        # For e.g. OECD
-        "draft-sdmx-json",
-        "application/vnd.sdmx.draft-sdmx-json+json",
-    ],
-}
+def detect_content_reader(content):
+    """Return a reader class for `content`.
+
+    The :meth:`.BaseReader.detect` method for each class in :data:`READERS` is called;
+    if a reader signals that it is compatible with `content`, then that class is
+    returned.
+
+    Raises
+    ------
+    ValueError
+        If no reader class matches.
+    """
+    for cls in READERS:
+        if cls.detect(content):
+            return cls
+
+    raise ValueError(f"{repr(content)} not recognized by any of {READERS}")
 
 
 def get_reader_for_content_type(ctype):
+    """Return a reader class for HTTP content type `content`.
+
+    Raises
+    ------
+    ValueError
+        If no reader class matches.
+
+    See also
+    --------
+    CTYPE_READER
+    """
+    # Split off e.g. "; version=2.1"
     ctype = str(ctype).split(";")[0].strip()
-    if ctype in CONTENT_TYPES["xml"]:
-        from .sdmxml import Reader
 
-        return Reader
-    elif ctype in CONTENT_TYPES["json"]:
-        from .sdmxjson import Reader
+    try:
+        return CTYPE_READER[ctype]
+    except KeyError:
+        raise ValueError(f"Unsupported content type: {ctype}") from None
 
-        return Reader
-    else:
-        raise ValueError(ctype)
+
+def get_reader_for_path(path):
+    """Return a reader class for file `path`.
+
+    Raises
+    ------
+    ValueError
+        If no reader class matches.
+
+    See also
+    --------
+    SUFFIX_READER
+    """
+    try:
+        return SUFFIX_READER[path.suffix.lower()]
+    except KeyError:
+        raise ValueError(f"Unsupported file suffix: {path.suffix}") from None
+
+
+def register(reader_cls):
+    """Register `reader_cls`."""
+    global READERS, CTYPE_READER, SUFFIX_READER
+
+    READERS.append(reader_cls)
+
+    for ctype in reader_cls.content_types:
+        CTYPE_READER[ctype] = reader_cls
+
+    for suffix in reader_cls.suffixes:
+        SUFFIX_READER[suffix] = reader_cls
+
+
+# Register built-in readers
+register(sdmxjson.Reader)
+register(sdmxml.Reader)
+
+
+def read_sdmx(filename_or_obj, format=None, **kwargs):
+    """Load a SDMX-ML or SDMX-JSON message from a file or file-like object.
+
+    Parameters
+    ----------
+    filename_or_obj : str or :class:`~os.PathLike` or file
+    format : 'XML' or 'JSON', optional
+
+    Other Parameters
+    ----------------
+    dsd : :class:`~.DataStructureDefinition`
+        For “structure-specific” `format`=``XML`` messages only.
+    """
+    reader = None
+
+    try:
+        path = Path(filename_or_obj)
+
+        # Open the file
+        obj = open(path, "rb")
+    except TypeError:
+        # Not path-like → opened file
+        path = None
+        obj = filename_or_obj
+
+    if path:
+        try:
+            # Use the file extension to guess the reader
+            reader = get_reader_for_path(filename_or_obj)
+        except ValueError:
+            pass
+
+    if not reader:
+        try:
+            reader = get_reader_for_path(Path(f"dummy.{format.lower()}"))
+        except (AttributeError, ValueError):
+            pass
+
+    if not reader:
+        # Read a line and then return the cursor to the initial position
+        pos = obj.tell()
+        first_line = obj.readline().strip()
+        obj.seek(pos)
+
+        try:
+            reader = detect_content_reader(first_line)
+        except ValueError:
+            pass
+
+    if not reader:
+        raise RuntimeError(
+            f"cannot infer SDMX message format from path {repr(path)}, "
+            f"format={format}, or content '{first_line[:5].decode()}..'"
+        )
+
+    return reader().read_message(obj, **kwargs)

--- a/sdmx/reader/base.py
+++ b/sdmx/reader/base.py
@@ -1,15 +1,16 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 
 class BaseReader(ABC):
     #: List of HTTP content types handled by the reader.
-    content_types = []
+    content_types: List[str] = []
 
     #: List of file name suffixes handled by the reader.
-    suffixes = []
+    suffixes: List[str] = []
 
     @classmethod
-    def detect(cls, content: bytes):
+    def detect(cls, content: bytes) -> bool:
         """Detect whether the reader can handle `content`.
 
         Returns

--- a/sdmx/reader/base.py
+++ b/sdmx/reader/base.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+
+
+class BaseReader(ABC):
+    #: List of HTTP content types handled by the reader.
+    content_types = []
+
+    #: List of file name suffixes handled by the reader.
+    suffixes = []
+
+    @classmethod
+    def detect(cls, content: bytes):
+        """Detect whether the reader can handle `content`.
+
+        Returns
+        -------
+        bool
+            :obj:`True` if the reader can handle the content.
+        """
+        return False
+
+    @abstractmethod
+    def read_message(self, source, dsd=None):
+        """Read message from *source*.
+
+        Parameters
+        ----------
+        source : file-like
+            Message content.
+        dsd : DataStructureDefinition, optional
+            DSD for aid in reading `source`.
+
+        Returns
+        -------
+        :class:`.Message`
+            An instance of a Message subclass.
+        """
+        pass  # pragma: no cover

--- a/sdmx/reader/sdmxjson.py
+++ b/sdmx/reader/sdmxjson.py
@@ -14,11 +14,23 @@ from sdmx.model import (
     Observation,
     SeriesKey,
 )
-from sdmx.reader import BaseReader
+from sdmx.reader.base import BaseReader
 
 
 class Reader(BaseReader):
     """Read SDMXJSON 2.1 and expose it as instances from :mod:`sdmx.model`."""
+    content_types = [
+        "application/vnd.sdmx.draft-sdmx-json+json",
+        # For e.g. OECD
+        "draft-sdmx-json",
+        "text/json",
+    ]
+
+    suffixes = [".json"]
+
+    @classmethod
+    def detect(cls, content):
+        return content.startswith(b"{")
 
     def read_message(self, source, dsd=None):
         # Initialize message instance

--- a/sdmx/reader/sdmxjson.py
+++ b/sdmx/reader/sdmxjson.py
@@ -1,6 +1,7 @@
 """SDMX-JSON v2.1 reader"""
 import json
 
+from sdmx import model
 from sdmx.message import DataMessage, Header
 from sdmx.model import (
     ActionType,
@@ -8,7 +9,6 @@ from sdmx.model import (
     AttributeValue,
     Concept,
     DataSet,
-    Item,
     Key,
     KeyValue,
     Observation,
@@ -36,7 +36,9 @@ class Reader(BaseReader):
         # TODO handle KeyError here
         elem = tree["header"]
         msg.header = Header(
-            id=elem["id"], prepared=elem["prepared"], sender=Item(**elem["sender"])
+            id=elem["id"],
+            prepared=elem["prepared"],
+            sender=model.Agency(**elem["sender"]),
         )
 
         # pre-fetch some structures for efficient use in series and obs

--- a/sdmx/reader/sdmxjson.py
+++ b/sdmx/reader/sdmxjson.py
@@ -19,6 +19,7 @@ from sdmx.reader.base import BaseReader
 
 class Reader(BaseReader):
     """Read SDMXJSON 2.1 and expose it as instances from :mod:`sdmx.model`."""
+
     content_types = [
         "application/vnd.sdmx.draft-sdmx-json+json",
         # For e.g. OECD

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -88,6 +88,7 @@ PARSE = {k: None for k in product(to_tags(SKIP), ["start", "end"])}
 
 def start(*args, only=True):
     """Decorator for a function that parses "start" events for XML elements."""
+
     def decorator(func):
         for tag in to_tags(*args):
             PARSE[tag, "start"] = func
@@ -100,6 +101,7 @@ def start(*args, only=True):
 
 def end(*args, only=True):
     """Decorator for a function that parses "end" events for XML elements."""
+
     def decorator(func):
         for tag in to_tags(*args):
             PARSE[tag, "end"] = func
@@ -111,6 +113,7 @@ def end(*args, only=True):
 
 
 # filter() conditions; see get_unique() and pop_single()
+
 
 def matching_class(cls):
     return lambda item: isinstance(item, type) and issubclass(item, cls)
@@ -135,6 +138,7 @@ class Reference:
     `cls_hint` is an optional hint for when the object is instantiated, i.e. a more
     specific override for `cls`/`target_cls`.
     """
+
     def __init__(self, elem, cls_hint=None):
         try:
             # Use the first child
@@ -248,8 +252,8 @@ class Reader(BaseReader):
                     result = func(self, element)
                 except TypeError:
                     if func is None:  # Explicitly no parser for this (element, event)
-                        continue      # Skip
-                    else:             # Some other TypeError
+                        continue  # Skip
+                    else:  # Some other TypeError
                         raise
                 else:
                     # Store the result

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -6,7 +6,7 @@ from inspect import isclass
 from itertools import chain
 import logging
 import re
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 from lxml import etree
 from lxml.etree import QName, XPath
@@ -205,7 +205,7 @@ class Reader(BaseReader):
 
     # Stack (0 = top) of tag names being parsed by _parse().
     # Tag parsers may examine the stack to determine context for parsing.
-    _stack = []
+    _stack: List[str] = []
 
     # Map of (class name, id) → sdmx.model object.
     # Only IdentifiableArtefacts should be stored. See _maintained().

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -15,7 +15,7 @@ import sdmx.urn
 from sdmx import message, model
 from sdmx.exceptions import XMLParseError  # noqa: F401
 from sdmx.format.xml import MESSAGE, qname
-from sdmx.reader import BaseReader
+from sdmx.reader.base import BaseReader
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -227,6 +227,19 @@ class Reference:
 
 
 class Reader(BaseReader):
+    content_types = [
+        "application/xml",
+        "application/vnd.sdmx.genericdata+xml",
+        "application/vnd.sdmx.structure+xml",
+        "application/vnd.sdmx.structurespecificdata+xml",
+        "text/xml",
+    ]
+    suffixes = [".xml"]
+
+    @classmethod
+    def detect(cls, content):
+        return content.startswith(b"<")
+
     def read_message(self, source, dsd=None):
         # Initialize stacks
         self.stack = defaultdict(list)

--- a/sdmx/remote.py
+++ b/sdmx/remote.py
@@ -1,5 +1,5 @@
-from io import BufferedIOBase, BytesIO
 import logging
+from io import BufferedIOBase, BytesIO
 from warnings import warn
 
 import requests
@@ -7,8 +7,11 @@ import requests
 try:
     from requests_cache import CachedSession as MaybeCachedSession
 except ImportError:  # pragma: no cover
-    warn('optional dependency requests_cache is not installed; cache options '
-         'to Session() have no effect', RuntimeWarning)
+    warn(
+        "optional dependency requests_cache is not installed; cache options "
+        "to Session() have no effect",
+        RuntimeWarning,
+    )
     from requests import Session as MaybeCachedSession
 
 
@@ -27,19 +30,21 @@ class Session(MaybeCachedSession):
             # Using requests_cache.CachedSession
 
             # No cache keyword arguments supplied = don't use the cache
-            disabled = set(kwargs.keys()) <= {'get_footer_url'}
+            disabled = set(kwargs.keys()) <= {"get_footer_url"}
 
             if disabled:
                 # Avoid creating any file
-                kwargs['backend'] = 'memory'
+                kwargs["backend"] = "memory"
 
             super(Session, self).__init__(**kwargs)
 
             # Overwrite value from requests_cache.CachedSession.__init__()
             self._is_cache_disabled = disabled
         elif len(kwargs):
-            raise ValueError('Cache arguments have no effect without '
-                             'requests_session: %s' % kwargs)
+            raise ValueError(
+                "Cache arguments have no effect without "
+                "requests_session: %s" % kwargs
+            )
         else:
             # Plain requests.Session
             super(Session, self).__init__()
@@ -51,12 +56,11 @@ class Session(MaybeCachedSession):
 
 
 class ResponseIO(BufferedIOBase):
-    """Read  data from a :class:`requests.Response` object, into an in-memory or on-disk file 
-    and expose it as a file-like object.
+    """Buffered wrapper for :class:`requests.Response` with optional file output.
 
     :class:`ResponseIO` wraps a :class:`requests.Response` object's 'content'
-    attribute, providing a file-like object from which bytes can be
-    :meth:`read` incrementally.
+    attribute, providing a file-like object from which bytes can be :meth:`read`
+    incrementally.
 
     Parameters
     ----------
@@ -71,11 +75,11 @@ class ResponseIO(BufferedIOBase):
         if tee is None:
             tee = BytesIO()
         # If tee is a file-like object or tempfile, then use it as cache
-        if isinstance(tee, BufferedIOBase) or hasattr(tee, 'file'):
+        if isinstance(tee, BufferedIOBase) or hasattr(tee, "file"):
             self.tee = tee
         else:
             # So tee must be str or os.FilePath
-            self.tee = open(tee, 'w+b')    
+            self.tee = open(tee, "w+b")
         self.tee.write(response.content)
         self.tee.seek(0)
 
@@ -83,11 +87,5 @@ class ResponseIO(BufferedIOBase):
         return True
 
     def read(self, size=-1):
-        """Read and return up to *size* bytes by calling *self.tee.read()*.
-
-        *size* Defaults to -1. In this case,   reads and
-        returns all data until EOF. 
-
-        Returns an empty bytes object on EOF.
-        """
+        """Read and return up to `size` bytes by calling ``self.tee.read()``."""
         return self.tee.read(size)

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -2,11 +2,7 @@ from enum import Enum
 from importlib import import_module
 from io import TextIOWrapper
 import json
-from typing import (
-    Any,
-    Dict,
-    Union,
-    )
+from typing import Any, Dict, Union
 
 from pkg_resources import resource_stream
 
@@ -15,9 +11,9 @@ from sdmx.util import BaseModel, Resource
 from pydantic import validator
 
 
-sources: Dict[str, 'Source'] = {}
+sources: Dict[str, "Source"] = {}
 
-DataContentType = Enum('DataContentType', 'XML JSON')
+DataContentType = Enum("DataContentType", "XML JSON")
 
 
 class Source(BaseModel):
@@ -33,6 +29,7 @@ class Source(BaseModel):
        modify_request_args
 
     """
+
     #: ID of the data source
     id: str
 
@@ -65,9 +62,10 @@ class Source(BaseModel):
         super().__init__(**kwargs)
 
         # Set default supported features
-        for feature in list(Resource) + ['preview', 'structure-specific data']:
+        for feature in list(Resource) + ["preview", "structure-specific data"]:
             self.supports.setdefault(
-                feature, self.data_content_type == DataContentType.XML)
+                feature, self.data_content_type == DataContentType.XML
+            )
 
     # Hooks
     def handle_response(self, response, content):
@@ -108,20 +106,20 @@ class Source(BaseModel):
         None
         """
         if self.data_content_type is DataContentType.XML:
-            dsd = kwargs.get('dsd', None)
+            dsd = kwargs.get("dsd", None)
             if isinstance(dsd, DataStructureDefinition):
-                kwargs.setdefault('headers', {})
-                kwargs['headers'].setdefault(
-                    'Accept',
-                    'application/vnd.sdmx.structurespecificdata+xml;'
-                    'version=2.1')
+                kwargs.setdefault("headers", {})
+                kwargs["headers"].setdefault(
+                    "Accept",
+                    "application/vnd.sdmx.structurespecificdata+xml;" "version=2.1",
+                )
 
-    @validator('id')
+    @validator("id")
     def _validate_id(cls, value):
-        assert getattr(cls, '_id', value) == value
+        assert getattr(cls, "_id", value) == value
         return value
 
-    @validator('data_content_type', pre=True)
+    @validator("data_content_type", pre=True)
     def _validate_dct(cls, value):
         if isinstance(value, DataContentType):
             return value
@@ -130,9 +128,9 @@ class Source(BaseModel):
 
 
 class _NoSource(Source):
-    id = ''
-    url = ''
-    name = ''
+    id = ""
+    url = ""
+    name = ""
 
 
 NoSource = _NoSource()
@@ -173,18 +171,17 @@ def add_source(info, id=None, override=False, **kwargs):
     if isinstance(info, str):
         info = json.loads(info)
 
-    id = info['id'] if id is None else id
+    id = info["id"] if id is None else id
 
     info.update(kwargs)
 
     if id in sources:
-        raise ValueError("Data source '%s' already defined; use override=True",
-                         id)
+        raise ValueError("Data source '%s' already defined; use override=True", id)
 
     # Maybe import a subclass that defines a hook
     SourceClass = Source
     try:
-        mod = import_module('.' + id.lower(), 'sdmx.source')
+        mod = import_module("." + id.lower(), "sdmx.source")
     except ImportError:
         pass
     else:
@@ -203,7 +200,7 @@ def list_sources():
 
 def load_package_sources():
     """Discover all sources listed in ``sources.json``."""
-    with resource_stream('sdmx', 'sources.json') as f:
+    with resource_stream("sdmx", "sources.json") as f:
         # TextIOWrapper is for Python 3.5 compatibility
         for info in json.load(TextIOWrapper(f)):
             add_source(info)

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, Union
 from pkg_resources import resource_stream
 
 from sdmx.model import DataStructureDefinition
-from sdmx.util import BaseModel, Resource
-from pydantic import validator
+from sdmx.util import BaseModel, Resource, validator
 
 
 sources: Dict[str, "Source"] = {}

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -15,7 +15,7 @@ from sdmx.util import BaseModel, Resource
 from pydantic import validator
 
 
-sources = {}
+sources: Dict[str, 'Source'] = {}
 
 DataContentType = Enum('DataContentType', 'XML JSON')
 

--- a/sdmx/source/abs.py
+++ b/sdmx/source/abs.py
@@ -2,18 +2,17 @@ import re
 
 from . import Source as BaseSource
 
-
 re_500 = re.compile(r"(An error has occurred)\.")
 
 
 class Source(BaseSource):
-    _id = 'ABS'
+    _id = "ABS"
 
     def handle_response(self, response, content):
         """Handle ABS' own text/html error page for some endpoints."""
-        ctype = response.headers.get('content-type', '')
-        if 'text/html' in ctype:
-            buf = ''
+        ctype = response.headers.get("content-type", "")
+        if "text/html" in ctype:
+            buf = ""
             while True:
                 chunk = content.read().decode()
                 if len(chunk) == 0:
@@ -24,7 +23,7 @@ class Source(BaseSource):
                 match = re_500.search(buf)
                 if match:
                     # Overwrite the original response
-                    response.reason, = match.groups()
+                    (response.reason,) = match.groups()
                     response.status_code = 500
                     response.raise_for_status()
 

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -1,9 +1,9 @@
 from time import sleep
 from tempfile import NamedTemporaryFile
+from urllib.parse import urlparse
 from zipfile import ZipFile
 
 import requests
-from requests.compat import urlparse
 
 from . import Source as BaseSource
 

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -1,5 +1,5 @@
-from time import sleep
 from tempfile import NamedTemporaryFile
+from time import sleep
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -21,15 +21,15 @@ class Source(BaseSource):
     .. versionadded:: 0.2.1
 
     """
-    _id = 'ESTAT'
+
+    _id = "ESTAT"
 
     def modify_request_args(self, kwargs):
         super().modify_request_args(kwargs)
 
-        kwargs.pop('get_footer_url', None)
+        kwargs.pop("get_footer_url", None)
 
-    def finish_message(self, message, request, get_footer_url=(30, 3),
-                       **kwargs):
+    def finish_message(self, message, request, get_footer_url=(30, 3), **kwargs):
         """Handle the initial response.
 
         This hook identifies the URL in the footer of the initial response,
@@ -45,7 +45,7 @@ class Source(BaseSource):
         """
         # Check the message footer for a text element that is a valid URL
         url = None
-        for text in getattr(message.footer, 'text', []):
+        for text in getattr(message.footer, "text", []):
             if urlparse(str(text)).scheme:
                 url = str(text)
                 break
@@ -57,7 +57,7 @@ class Source(BaseSource):
         wait_seconds, attempts = get_footer_url
 
         # Create a temporary file to store the ZIP response
-        ntf = NamedTemporaryFile(prefix='pandasdmx-')
+        ntf = NamedTemporaryFile(prefix="pandasdmx-")
         # Make a limited number of attempts to retrieve the file
         for a in range(attempts):
             sleep(wait_seconds)
@@ -69,7 +69,7 @@ class Source(BaseSource):
             except requests.HTTPError:
                 raise
         ntf.close()
-        raise RuntimeError('Maximum attempts exceeded')
+        raise RuntimeError("Maximum attempts exceeded")
 
     def handle_response(self, response, content):
         """Handle the polled response.
@@ -80,7 +80,7 @@ class Source(BaseSource):
 
         """
 
-        if response.headers['content-type'] != 'application/octet-stream':
+        if response.headers["content-type"] != "application/octet-stream":
             return response, content
 
         # Read all the input, forcing it to be copied to
@@ -90,13 +90,13 @@ class Source(BaseSource):
                 break
 
         # Open the zip archive
-        with ZipFile(content.tee, mode='r') as zf:
+        with ZipFile(content.tee, mode="r") as zf:
             # The archive should contain only one file
             infolist = zf.infolist()
             assert len(infolist) == 1
 
             # Set the new content type
-            response.headers['content-type'] = 'application/xml'
+            response.headers["content-type"] = "application/xml"
 
             # Use the unzipped archive member as the response content
             return response, zf.open(infolist[0])

--- a/sdmx/source/ilo.py
+++ b/sdmx/source/ilo.py
@@ -2,7 +2,7 @@ from . import Source as BaseSource
 
 
 class Source(BaseSource):
-    _id = 'ILO'
+    _id = "ILO"
 
     def modify_request_args(self, kwargs):
         """Handle two limitations of ILO's REST service.
@@ -19,6 +19,6 @@ class Source(BaseSource):
         """
         super().modify_request_args(kwargs)
 
-        kwargs.setdefault('params', {})
-        kwargs['params'].setdefault('format', 'generic_2_1')
-        kwargs['params'].setdefault('references', 'none')
+        kwargs.setdefault("params", {})
+        kwargs["params"].setdefault("format", "generic_2_1")
+        kwargs["params"].setdefault("references", "none")

--- a/sdmx/source/istat.py
+++ b/sdmx/source/istat.py
@@ -2,7 +2,7 @@ from . import Source as BaseSource
 
 
 class Source(BaseSource):
-    _id = 'ISTAT'
+    _id = "ISTAT"
 
     def modify_request_args(self, kwargs):
         """Supply explicit provider agency ID for ISTAT.
@@ -17,5 +17,5 @@ class Source(BaseSource):
         # NB this is an indirect test for resource_type != 'data'; because of
         #    the way the hook is called, resource_type is not available
         #    directly.
-        if 'key' not in kwargs:
-            kwargs.setdefault('provider', 'all')
+        if "key" not in kwargs:
+            kwargs.setdefault("provider", "all")

--- a/sdmx/source/sgr.py
+++ b/sdmx/source/sgr.py
@@ -2,12 +2,12 @@ from . import Source as BaseSource
 
 
 class Source(BaseSource):
-    _id = 'SGR'
+    _id = "SGR"
 
     def handle_response(self, response, content):
         """SGR responses do not specify content-type; set it directly."""
-        if response.headers.get('content-type', None) is None:
-            response.headers['content-type'] = 'application/xml'
+        if response.headers.get("content-type", None) is None:
+            response.headers["content-type"] = "application/xml"
         return response, content
 
     def modify_request_args(self, kwargs):
@@ -18,4 +18,4 @@ class Source(BaseSource):
         """
         super().modify_request_args(kwargs)
 
-        kwargs.setdefault('provider', 'all')
+        kwargs.setdefault("provider", "all")

--- a/sdmx/source/wb.py
+++ b/sdmx/source/wb.py
@@ -2,10 +2,10 @@ from . import Source as BaseSource
 
 
 class Source(BaseSource):
-    _id = 'WB'
+    _id = "WB"
 
     def modify_request_args(self, kwargs):
         """World Bank's agency ID."""
         super().modify_request_args(kwargs)
 
-        kwargs.setdefault('provider', 'WBG_WITS')
+        kwargs.setdefault("provider", "WBG_WITS")

--- a/sdmx/tests/__init__.py
+++ b/sdmx/tests/__init__.py
@@ -1,5 +1,6 @@
 import importlib
 from distutils import version
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -21,8 +22,8 @@ def assert_pd_equal(left, right, **kwargs):
 
 
 class MessageTest:
-    path = BASE_PATH
-    filename = None
+    path: Path = BASE_PATH
+    filename: str
 
     @pytest.fixture(scope='class')
     def msg(self):

--- a/sdmx/tests/__init__.py
+++ b/sdmx/tests/__init__.py
@@ -17,7 +17,7 @@ def assert_pd_equal(left, right, **kwargs):
         pd.Series: pd.testing.assert_series_equal,
         pd.DataFrame: pd.testing.assert_frame_equal,
         np.ndarray: np.testing.assert_array_equal,
-        }[left.__class__]
+    }[left.__class__]
     method(left, right, **kwargs)
 
 
@@ -25,9 +25,10 @@ class MessageTest:
     path: Path = BASE_PATH
     filename: str
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def msg(self):
         import sdmx
+
         return sdmx.read_sdmx(self.path / self.filename)
 
 
@@ -38,18 +39,18 @@ def _importorskip(modname, minversion=None):
         has = True
         if minversion is not None:
             if LooseVersion(mod.__version__) < LooseVersion(minversion):
-                raise ImportError('Minimum version not satisfied')
+                raise ImportError("Minimum version not satisfied")
     except ImportError:
         has = False
-    func = pytest.mark.skipif(not has, reason='requires {}'.format(modname))
+    func = pytest.mark.skipif(not has, reason="requires {}".format(modname))
     return has, func
 
 
 def LooseVersion(vstring):
     # When the development version is something like '0.10.9+aac7bfc', this
     # function will just discard the git commit id.
-    vstring = vstring.split('+')[0]
+    vstring = vstring.split("+")[0]
     return version.LooseVersion(vstring)
 
 
-has_requests_cache, requires_requests_cache = _importorskip('requests_cache')
+has_requests_cache, requires_requests_cache = _importorskip("requests_cache")

--- a/sdmx/tests/conftest.py
+++ b/sdmx/tests/conftest.py
@@ -2,5 +2,4 @@ import logging
 
 import sdmx
 
-
 sdmx.logger.setLevel(logging.INFO)

--- a/sdmx/tests/conftest.py
+++ b/sdmx/tests/conftest.py
@@ -4,5 +4,3 @@ import sdmx
 
 
 sdmx.logger.setLevel(logging.INFO)
-
-sdmx.writer.DEFAULT_RTYPE = 'rows'

--- a/sdmx/tests/data/__init__.py
+++ b/sdmx/tests/data/__init__.py
@@ -115,7 +115,7 @@ def specimen(pattern="", opened=True):
     """Open the test specimen file with *pattern* in the name."""
     for path, f, k in TEST_FILES:
         if path.match("*" + pattern + "*"):
-            yield open(path) if opened else path
+            yield open(path, "br") if opened else path
             return
     raise ValueError(pattern)
 

--- a/sdmx/tests/data/__init__.py
+++ b/sdmx/tests/data/__init__.py
@@ -40,43 +40,39 @@ BASE_PATH = Path(__file__).parent
 
 # List of specimen files.
 # Each is a tuple: (path, format (xml|json), kind (data|structure))
-TEST_FILES = [
-    (BASE_PATH / 'INSEE' / 'IPI-2010-A21.xml', 'xml', 'data'),
-]
+TEST_FILES = [(BASE_PATH / "INSEE" / "IPI-2010-A21.xml", "xml", "data")]
 
 # XML data files for the ECB exchange rate data flow
-for path in (BASE_PATH / 'ECB_EXR').rglob('*.xml'):
-    kind = 'data'
-    if 'structure' in path.name or 'common' in path.name:
-        kind = 'structure'
-    TEST_FILES.append((path, 'xml', kind))
+for path in (BASE_PATH / "ECB_EXR").rglob("*.xml"):
+    kind = "data"
+    if "structure" in path.name or "common" in path.name:
+        kind = "structure"
+    TEST_FILES.append((path, "xml", kind))
 
 # JSON data files for the ECB exchange rate data flow
-for fp in (BASE_PATH / 'ECB_EXR').rglob('*.json'):
-    TEST_FILES.append((fp, 'json', 'data'))
+for fp in (BASE_PATH / "ECB_EXR").rglob("*.json"):
+    TEST_FILES.append((fp, "json", "data"))
 
 # Miscellaneous XML data files
-TEST_FILES.append(
-    (BASE_PATH / 'ESTAT' / 'footer.xml', 'xml', 'data'),
-    )
+TEST_FILES.append((BASE_PATH / "ESTAT" / "footer.xml", "xml", "data"))
 
 
 # Miscellaneous XML structure files
 TEST_FILES.extend(
-    (BASE_PATH.joinpath(*parts), 'xml', 'structure') for parts in [
-        ('ECB', 'orgscheme.xml'),
-        ('ESTAT', 'apro_mk_cola-structure.xml'),
-
+    (BASE_PATH.joinpath(*parts), "xml", "structure")
+    for parts in [
+        ("ECB", "orgscheme.xml"),
+        ("ESTAT", "apro_mk_cola-structure.xml"),
         # Manually reduced subset of the response for this DSD. Test for
         # <str:CubeRegion> containing both <com:KeyValue> and <com:Attribute>
-        ('IMF', 'ECOFIN_DSD-structure.xml'),
-
-        ('INSEE', 'CNA-2010-CONSO-SI-A17-structure.xml'),
-        ('INSEE', 'dataflow.xml'),
-        ('INSEE', 'IPI-2010-A21-structure.xml'),
-        ('UNSD', 'codelist_partial.xml'),
-        ('SGR', 'common-structure.xml'),
-        ])
+        ("IMF", "ECOFIN_DSD-structure.xml"),
+        ("INSEE", "CNA-2010-CONSO-SI-A17-structure.xml"),
+        ("INSEE", "dataflow.xml"),
+        ("INSEE", "IPI-2010-A21-structure.xml"),
+        ("UNSD", "codelist_partial.xml"),
+        ("SGR", "common-structure.xml"),
+    ]
+)
 
 # Expected to_pandas() results for data files above; see expected_data()
 # - Keys are the file name (above) with '.' -> '-': 'foo.xml' -> 'foo-xml'
@@ -84,16 +80,16 @@ TEST_FILES.extend(
 # - Values are either argument to pd.read_csv(); or a dict(use='other-key'),
 #   in which case the info for other-key is used instead.
 EXPECTED = {
-    'ng-flat-xml': dict(index_col=[0, 1, 2, 3, 4, 5]),
-    'ng-ts-gf-xml': dict(use='ng-flat-xml'),
-    'ng-ts-xml': dict(use='ng-flat-xml'),
-    'ng-xs-xml': dict(index_col=[0, 1, 2, 3, 4, 5]),
+    "ng-flat-xml": dict(index_col=[0, 1, 2, 3, 4, 5]),
+    "ng-ts-gf-xml": dict(use="ng-flat-xml"),
+    "ng-ts-xml": dict(use="ng-flat-xml"),
+    "ng-xs-xml": dict(index_col=[0, 1, 2, 3, 4, 5]),
     # Excluded: this file contains two DataSets, and expected_data() currently
     # only supports specimens with one DataSet
     # 'action-delete-json': dict(header=[0, 1, 2, 3, 4]),
-    'xs-json': dict(index_col=[0, 1, 2, 3, 4, 5]),
-    'flat-json': dict(index_col=[0, 1, 2, 3, 4, 5]),
-    'ts-json': dict(use='flat-json'),
+    "xs-json": dict(index_col=[0, 1, 2, 3, 4, 5]),
+    "flat-json": dict(index_col=[0, 1, 2, 3, 4, 5]),
+    "ts-json": dict(use="flat-json"),
 }
 
 
@@ -109,16 +105,16 @@ def test_files(format=None, kind=None):
     for path, f, k in TEST_FILES:
         if (format and format != f) or (kind and kind != k):
             continue
-        result['argvalues'].append(path)
-        result['ids'].append(path.name)
+        result["argvalues"].append(path)
+        result["ids"].append(path.name)
     return result
 
 
 @contextmanager
-def specimen(pattern='', opened=True):
+def specimen(pattern="", opened=True):
     """Open the test specimen file with *pattern* in the name."""
     for path, f, k in TEST_FILES:
-        if path.match('*' + pattern + '*'):
+        if path.match("*" + pattern + "*"):
             yield open(path) if opened else path
             return
     raise ValueError(pattern)
@@ -127,23 +123,23 @@ def specimen(pattern='', opened=True):
 def expected_data(path):
     """Return the expected to_pandas() result for *path*."""
     try:
-        key = path.name.replace('.', '-')
+        key = path.name.replace(".", "-")
         info = EXPECTED[key]
-        if 'use' in info:
+        if "use" in info:
             # Use the same expected data as another file
-            key = info['use']
+            key = info["use"]
             info = EXPECTED[key]
     except KeyError:
         return None
 
-    args = dict(sep=r'\s+', index_col=[0], header=[0])
+    args = dict(sep=r"\s+", index_col=[0], header=[0])
     args.update(info)
 
-    expected_path = (BASE_PATH / 'expected' / key).with_suffix('.txt')
+    expected_path = (BASE_PATH / "expected" / key).with_suffix(".txt")
     result = pd.read_csv(expected_path, **args)
 
     # A series; unwrap
-    if set(result.columns) == {'value'}:
-        result = result['value']
+    if set(result.columns) == {"value"}:
+        result = result["value"]
 
     return result

--- a/sdmx/tests/data/__init__.py
+++ b/sdmx/tests/data/__init__.py
@@ -69,6 +69,7 @@ TEST_FILES.extend(
         ("INSEE", "CNA-2010-CONSO-SI-A17-structure.xml"),
         ("INSEE", "dataflow.xml"),
         ("INSEE", "IPI-2010-A21-structure.xml"),
+        ("ISTAT", "47_850-structure.xml"),
         ("UNSD", "codelist_partial.xml"),
         ("SGR", "common-structure.xml"),
     ]

--- a/sdmx/tests/reader/test_json.py
+++ b/sdmx/tests/reader/test_json.py
@@ -1,15 +1,16 @@
 import pytest
+
 import sdmx
 from sdmx.tests.data import specimen, test_files
 
 
-@pytest.mark.parametrize('path', **test_files(format='json'))
+@pytest.mark.parametrize("path", **test_files(format="json"))
 def test_json_read(path):
     """Test that the samples from the SDMX-JSON spec can be read."""
     sdmx.read_sdmx(path)
 
 
 def test_header():
-    with specimen('flat.json') as f:
+    with specimen("flat.json") as f:
         resp = sdmx.read_sdmx(f)
-    assert resp.header.id == '62b5f19d-f1c9-495d-8446-a3661ed24753'
+    assert resp.header.id == "62b5f19d-f1c9-495d-8446-a3661ed24753"

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -1,46 +1,46 @@
-from lxml.etree import Element
 import pytest
+from lxml.etree import Element
+
 import sdmx
-from sdmx.model import (
-    Facet, FacetType, FacetValueType,
-    )
-from sdmx.reader.sdmxml import XMLParseError, Reader
+from sdmx.model import Facet, FacetType, FacetValueType
+from sdmx.reader.sdmxml import Reader, XMLParseError
 from sdmx.tests.data import specimen, test_files
 
 
 # Read example data files
-@pytest.mark.parametrize('path', **test_files(format='xml', kind='data'))
+@pytest.mark.parametrize("path", **test_files(format="xml", kind="data"))
 def test_read_xml(path):
     sdmx.read_sdmx(path)
 
 
 # Read example structure files
-@pytest.mark.parametrize('path', **test_files(format='xml', kind='structure'))
+@pytest.mark.parametrize("path", **test_files(format="xml", kind="structure"))
 def test_read_xml_structure(path):
     sdmx.read_sdmx(path)
 
 
 def test_read_xml_structure_insee():
-    with specimen('IPI-2010-A21-structure.xml') as f:
+    with specimen("IPI-2010-A21-structure.xml") as f:
         msg = sdmx.read_sdmx(f)
 
     # Same objects referenced
-    assert (id(msg.dataflow['IPI-2010-A21'].structure) ==
-            id(msg.structure['IPI-2010-A21']))
+    assert id(msg.dataflow["IPI-2010-A21"].structure) == id(
+        msg.structure["IPI-2010-A21"]
+    )
 
     # Number of dimensions loaded correctly
-    dsd = msg.structure['IPI-2010-A21']
+    dsd = msg.structure["IPI-2010-A21"]
     assert len(dsd.dimensions) == 4
 
 
 # Read structure-specific messages
 def test_read_ss_xml():
-    with specimen('M.USD.EUR.SP00.A.xml', opened=False) as f:
+    with specimen("M.USD.EUR.SP00.A.xml", opened=False) as f:
         msg_path = f
-        dsd_path = f.parent / 'structure.xml'
+        dsd_path = f.parent / "structure.xml"
 
     # Read the DSD
-    dsd = sdmx.read_sdmx(dsd_path).structure['ECB_EXR1']
+    dsd = sdmx.read_sdmx(dsd_path).structure["ECB_EXR1"]
 
     # Read a data message
     msg = sdmx.read_sdmx(msg_path, dsd=dsd)
@@ -54,8 +54,7 @@ def test_read_ss_xml():
     s0_key = list(ds.series.keys())[0]
 
     # AttributeValue.value_for
-    assert s0_key.attrib['DECIMALS'].value_for \
-        is dsd.attributes.get('DECIMALS')
+    assert s0_key.attrib["DECIMALS"].value_for is dsd.attributes.get("DECIMALS")
 
     # SeriesKey.described_by
     assert s0_key.described_by is dsd.dimensions
@@ -64,12 +63,11 @@ def test_read_ss_xml():
     assert ds.obs[0].key.described_by is dsd.dimensions
 
     # KeyValue.value_for
-    assert ds.obs[0].key.values[0].value_for \
-        is dsd.dimensions.get('FREQ')
+    assert ds.obs[0].key.values[0].value_for is dsd.dimensions.get("FREQ")
 
     # DSD information that is not in the data message can be looked up through
     # navigating object relationships
-    TIME_FORMAT = s0_key.attrib['TIME_FORMAT'].value_for
+    TIME_FORMAT = s0_key.attrib["TIME_FORMAT"].value_for
     assert len(TIME_FORMAT.related_to.dimensions) == 5
 
 
@@ -84,19 +82,26 @@ E = Element
 #     an exception matching the string.
 ELEMENTS = [
     # Reader.parse_facet
-    (E('Facet', isSequence='False', startValue='3.4', endValue='1'), None),
+    (E("Facet", isSequence="False", startValue="3.4", endValue="1"), None),
     # …attribute names are munged; default textType is supplied
-    (E('EnumerationFormat', minLength='1', maxLength='6'),
-     Facet(type=FacetType(min_length=1, max_length=6),
-           value_type=FacetValueType['string'])),
+    (
+        E("EnumerationFormat", minLength="1", maxLength="6"),
+        Facet(
+            type=FacetType(min_length=1, max_length=6),
+            value_type=FacetValueType["string"],
+        ),
+    ),
     # …invalid attributes cause an exception
-    (E('TextFormat', invalidFacetTypeAttr='foo'),
-     'ValueError: "FacetType" object has no field "invalid_facet_type_attr"'),
+    (
+        E("TextFormat", invalidFacetTypeAttr="foo"),
+        'ValueError: "FacetType" object has no field "invalid_facet_type_attr"',
+    ),
 ]
 
 
-@pytest.mark.parametrize('elem, expected', ELEMENTS,
-                         ids=list(map(str, range(len(ELEMENTS)))))
+@pytest.mark.parametrize(
+    "elem, expected", ELEMENTS, ids=list(map(str, range(len(ELEMENTS))))
+)
 def test_parse_elem(elem, expected):
     """Test individual XML elements.
 
@@ -106,7 +111,7 @@ def test_parse_elem(elem, expected):
     """
     # _parse() operates on the child elements of the first argument. Create a
     # temporary element to contain *elem*
-    tmp = Element('root')
+    tmp = Element("root")
     tmp.append(elem)
 
     # Create a reader

--- a/sdmx/tests/test_api.py
+++ b/sdmx/tests/test_api.py
@@ -1,5 +1,5 @@
 import logging
-from io import StringIO
+from io import BytesIO
 
 import pandas as pd
 import pytest
@@ -31,7 +31,7 @@ def test_read_sdmx(tmp_path):
         sdmx.read_sdmx(f)
 
     # Exception raised when the file contents don't allow to guess the format
-    bad_file = StringIO("#! neither XML nor JSON")
+    bad_file = BytesIO(b"#! neither XML nor JSON")
     exc = "cannot infer SDMX message format from '#! ne..'"
     with pytest.raises(RuntimeError, match=exc):
         sdmx.read_sdmx(bad_file)

--- a/sdmx/tests/test_api.py
+++ b/sdmx/tests/test_api.py
@@ -1,34 +1,37 @@
-from io import StringIO
 import logging
+from io import StringIO
 
 import pandas as pd
-import sdmx
 import pytest
+
+import sdmx
 
 from .data import specimen
 
 
 def test_read_sdmx(tmp_path):
     # Copy the file to a temporary file with an urecognizable suffix
-    target = tmp_path / 'foo.badsuffix'
-    with specimen('flat.json', opened=False) as original:
-        target.open('w').write(original.read_text())
+    target = tmp_path / "foo.badsuffix"
+    with specimen("flat.json", opened=False) as original:
+        target.open("w").write(original.read_text())
 
     # Can't infer message type for unknown file extension
-    exc = ("cannot identify SDMX message format from file name 'foo.badsuffix'"
-           "; use  format='...'")
+    exc = (
+        "cannot identify SDMX message format from file name 'foo.badsuffix'"
+        "; use  format='...'"
+    )
     with pytest.raises(RuntimeError, match=exc):
         sdmx.read_sdmx(target)
 
     # Using the format= kwarg suppresses the error
-    sdmx.read_sdmx(target, format='JSON')
+    sdmx.read_sdmx(target, format="JSON")
 
     # Format can be inferred from an already-open file without extension
-    with specimen('flat.json') as f:
+    with specimen("flat.json") as f:
         sdmx.read_sdmx(f)
 
     # Exception raised when the file contents don't allow to guess the format
-    bad_file = StringIO('#! neither XML nor JSON')
+    bad_file = StringIO("#! neither XML nor JSON")
     exc = "cannot infer SDMX message format from '#! ne..'"
     with pytest.raises(RuntimeError, match=exc):
         sdmx.read_sdmx(bad_file)
@@ -40,7 +43,7 @@ def test_request():
 
     # Invalid source name raise an exception
     with pytest.raises(ValueError):
-        sdmx.Request('noagency')
+        sdmx.Request("noagency")
 
     # Regular methods
     r.clear_cache()
@@ -49,52 +52,68 @@ def test_request():
     assert r.timeout == 300
 
     # dir() includes convenience methods for resource endpoints
-    expected = {'cache', 'clear_cache', 'get', 'preview_data', 'series_keys',
-                'session', 'source', 'timeout'}
+    expected = {
+        "cache",
+        "clear_cache",
+        "get",
+        "preview_data",
+        "series_keys",
+        "session",
+        "source",
+        "timeout",
+    }
     expected |= set(ep.name for ep in sdmx.Resource)
-    assert set(filter(lambda s: not s.startswith('_'), dir(r))) == expected
+    assert set(filter(lambda s: not s.startswith("_"), dir(r))) == expected
 
 
 def test_request_get_exceptions():
     """Tests of Request.get() that don't require remote data."""
-    req = sdmx.Request('ESTAT')
+    req = sdmx.Request("ESTAT")
 
     # Exception is raised on unrecognized arguments
     exc = "unrecognized arguments: {'foo': 'bar'}"
     with pytest.raises(ValueError, match=exc):
-        req.get('datastructure', foo='bar')
+        req.get("datastructure", foo="bar")
 
     with pytest.raises(ValueError, match=exc):
-        sdmx.read_url('https://example.com', foo='bar')
+        sdmx.read_url("https://example.com", foo="bar")
 
 
 @pytest.mark.remote_data
 def test_request_get_args():
-    req = sdmx.Request('ESTAT')
+    req = sdmx.Request("ESTAT")
 
     # Request._make_key accepts '+'-separated values
-    args = dict(resource_id='une_rt_a', key={'GEO': 'EL+ES+IE'},
-                params={'startPeriod': '2007'}, dry_run=True, use_cache=True)
+    args = dict(
+        resource_id="une_rt_a",
+        key={"GEO": "EL+ES+IE"},
+        params={"startPeriod": "2007"},
+        dry_run=True,
+        use_cache=True,
+    )
     # Store the URL
     url = req.data(**args).url
 
     # Using an iterable of key values gives the same URL
-    args['key'] = {'GEO': ['EL', 'ES', 'IE']}
+    args["key"] = {"GEO": ["EL", "ES", "IE"]}
     assert req.data(**args).url == url
 
     # Using a direct string for a key gives the same URL
-    args['key'] = '....EL+ES+IE'  # No specified values for first 4 dimensions
+    args["key"] = "....EL+ES+IE"  # No specified values for first 4 dimensions
     assert req.data(**args).url == url
 
     # Giving 'provider' is redundant for a data request, causes a warning
     with pytest.warns(UserWarning, match="'provider' argument is redundant"):
-        req.data('une_rt_a', key={'GEO': 'EL+ES+IE'},
-                 params={'startPeriod': '2007'},
-                 provider='ESTAT')
+        req.data(
+            "une_rt_a",
+            key={"GEO": "EL+ES+IE"},
+            params={"startPeriod": "2007"},
+            provider="ESTAT",
+        )
 
     # Using an unknown endpoint is an exception
     with pytest.raises(ValueError):
-        req.get('badendpoint', 'id')
+        req.get("badendpoint", "id")
 
     # TODO test req.get(obj) with IdentifiableArtefact subclasses
 
@@ -102,23 +121,25 @@ def test_request_get_args():
 @pytest.mark.remote_data
 def test_read_url():
     # URL can be queried without instantiating Request
-    sdmx.read_url('http://sdw-wsrest.ecb.int/service/datastructure/ECB/'
-                  'ECB_EXR1/latest?references=all')
+    sdmx.read_url(
+        "http://sdw-wsrest.ecb.int/service/datastructure/ECB/"
+        "ECB_EXR1/latest?references=all"
+    )
 
 
 @pytest.mark.remote_data
 def test_request_preview_data():
-    req = sdmx.Request('ECB')
+    req = sdmx.Request("ECB")
 
     # List of keys can be retrieved
-    keys = req.preview_data('EXR')
+    keys = req.preview_data("EXR")
     assert isinstance(keys, list)
 
     # Count of keys can be determined
     assert len(keys) > 1000
 
     # A filter can be provided, resulting in fewer keys
-    keys = req.preview_data('EXR', {'CURRENCY': 'CAD+CHF+CNY'})
+    keys = req.preview_data("EXR", {"CURRENCY": "CAD+CHF+CNY"})
     assert len(keys) == 24
 
     # Result can be converted to pandas object

--- a/sdmx/tests/test_api.py
+++ b/sdmx/tests/test_api.py
@@ -1,6 +1,6 @@
-from io import BytesIO
 import json
 import logging
+from io import BytesIO
 
 import pandas as pd
 import pytest

--- a/sdmx/tests/test_api.py
+++ b/sdmx/tests/test_api.py
@@ -79,7 +79,7 @@ def test_request_get_exceptions():
         sdmx.read_url("https://example.com", foo="bar")
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_request_get_args():
     req = sdmx.Request("ESTAT")
 
@@ -118,7 +118,7 @@ def test_request_get_args():
     # TODO test req.get(obj) with IdentifiableArtefact subclasses
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_read_url():
     # URL can be queried without instantiating Request
     sdmx.read_url(
@@ -127,7 +127,7 @@ def test_read_url():
     )
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_request_preview_data():
     req = sdmx.Request("ECB")
 

--- a/sdmx/tests/test_compat.py
+++ b/sdmx/tests/test_compat.py
@@ -9,22 +9,22 @@ def pd_obj(name):
     """Return the specimen at *name* read, then converted to pandas."""
     with specimen(name) as f:
         data_msg = sdmx.read_sdmx(f)
-    return sdmx.to_pandas(data_msg, rtype='compat')
+    return sdmx.to_pandas(data_msg, rtype="compat")
 
 
 def test_xml():
     """Test that objects have the expected layout with rtype='compat'."""
     # GenericData with non-time Dimension at observation → data frame
-    df1 = pd_obj('ng-xs.xml')
-    assert isinstance(df1.index, pd.Index) and df1.index.name == 'CURRENCY'
+    df1 = pd_obj("ng-xs.xml")
+    assert isinstance(df1.index, pd.Index) and df1.index.name == "CURRENCY"
     assert isinstance(df1.columns, pd.MultiIndex)
 
     # TimeSeriesData → data frame with DatetimeIndex
-    df2 = pd_obj('ng-ts.xml')
+    df2 = pd_obj("ng-ts.xml")
     assert isinstance(df2.index, pd.DatetimeIndex)
     assert isinstance(df2.columns, pd.MultiIndex)
 
     # GenericData with AllDimensions at observation → series
-    df3 = pd_obj('ng-flat.xml')
+    df3 = pd_obj("ng-flat.xml")
     assert isinstance(df3, pd.Series)
     assert isinstance(df3.index, pd.MultiIndex)

--- a/sdmx/tests/test_dataset.py
+++ b/sdmx/tests/test_dataset.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandas.testing as pdt
+
 import sdmx
 from sdmx import message, model
 
@@ -8,21 +9,21 @@ from .data import specimen
 
 
 class DataMessageTest(MessageTest):
-    path = MessageTest.path / 'ECB_EXR'
+    path = MessageTest.path / "ECB_EXR"
 
 
 class TestGenericFlatDataSet(DataMessageTest):
-    filename = 'ng-flat.xml'
+    filename = "ng-flat.xml"
 
     def test_msg_type(self, msg):
         assert isinstance(msg, message.DataMessage)
 
     def test_header_attributes(self, msg):
         # Internal reference of the StructureUsage is available
-        assert msg.dataflow.id == 'STR1'
+        assert msg.dataflow.id == "STR1"
 
         # Maintained ID of the DataStructureDefinition is available
-        assert msg.structure.id == 'ECB_EXR_NG'
+        assert msg.structure.id == "ECB_EXR_NG"
         assert msg.observation_dimension == model.AllDimensions
 
     def test_generic_obs(self, msg):
@@ -37,12 +38,12 @@ class TestGenericFlatDataSet(DataMessageTest):
         o0 = data.obs[0]
 
         assert isinstance(o0.key, model.Key)
-        assert o0.key.FREQ == 'M'
-        assert o0.key.CURRENCY == 'CHF'
-        assert o0.value == '1.3413'
+        assert o0.key.FREQ == "M"
+        assert o0.key.CURRENCY == "CHF"
+        assert o0.value == "1.3413"
 
-        assert o0.attrib.OBS_STATUS == 'A'
-        assert o0.attrib.DECIMALS == '4'
+        assert o0.attrib.OBS_STATUS == "A"
+        assert o0.attrib.DECIMALS == "4"
 
     def test_to_pandas(self, msg):
         # Single data series is converted to pd.Series
@@ -57,12 +58,12 @@ class TestGenericFlatDataSet(DataMessageTest):
 
 
 class TestGenericSeriesDataSet(DataMessageTest):
-    filename = 'ng-ts-gf.xml'
+    filename = "ng-ts-gf.xml"
 
     def test_header_attributes(self, msg):
-        assert msg.dataflow.id == 'STR1'
-        assert msg.structure.id == 'ECB_EXR_NG'
-        assert msg.observation_dimension == 'TIME_PERIOD'
+        assert msg.dataflow.id == "STR1"
+        assert msg.structure.id == "ECB_EXR_NG"
+        assert msg.observation_dimension == "TIME_PERIOD"
 
     def test_generic_obs(self, msg):
         data = msg.data[0]
@@ -79,10 +80,10 @@ class TestGenericSeriesDataSet(DataMessageTest):
         # Observations in series have .series_key with correct length & values
         assert isinstance(s3[0].series_key, model.Key)
         assert len(s3[0].series_key) == 5
-        assert s3[0].series_key.CURRENCY == 'USD'
+        assert s3[0].series_key.CURRENCY == "USD"
 
         # Observations in series have attributes
-        assert s3[0].attrib.DECIMALS == '4'
+        assert s3[0].attrib.DECIMALS == "4"
 
         # Number of observations in the series
         assert len(s3) == 3
@@ -91,10 +92,10 @@ class TestGenericSeriesDataSet(DataMessageTest):
         o0 = list(reversed(s3))[2]
 
         # Series observations have expected value
-        assert o0.dim == '2010-08'
-        assert o0.value == '1.2894'
+        assert o0.dim == "2010-08"
+        assert o0.value == "1.2894"
 
-        assert o0.attrib.OBS_STATUS == 'A'
+        assert o0.attrib.OBS_STATUS == "A"
 
     def test_pandas(self, msg):
         data = msg.data[0]
@@ -116,7 +117,7 @@ class TestGenericSeriesDataSet(DataMessageTest):
         assert len(s3.index.names) == 6
 
         # Convert again, with attributes
-        pd_data = sdmx.to_pandas(data, attributes='osgd')
+        pd_data = sdmx.to_pandas(data, attributes="osgd")
 
         # Select one SeriesKey's data out of the DataFrame
         keys, levels = zip(*[(kv.value, kv.id) for kv in s3_key])
@@ -129,7 +130,7 @@ class TestGenericSeriesDataSet(DataMessageTest):
         assert len(s3.index.names) == 6
 
         # Number of attributes available
-        assert len(set(s3.columns) - {'value'}) == 7
+        assert len(set(s3.columns) - {"value"}) == 7
 
         # Access an attribute of the first value.
         # NB that this uses…
@@ -139,32 +140,32 @@ class TestGenericSeriesDataSet(DataMessageTest):
         #    key in the index
         # 2. the AttributeValue.__eq__() comparison operator;
         #    s3.iloc[0].OBS_STATUS is a full AttributeValue, rather than a str.
-        assert s3.iloc[0].OBS_STATUS == 'A'
-        assert s3.iloc[0].OBS_STATUS.value_for == 'OBS_STATUS'  # consistency!
+        assert s3.iloc[0].OBS_STATUS == "A"
+        assert s3.iloc[0].OBS_STATUS.value_for == "OBS_STATUS"  # consistency!
 
     def test_write2pandas(self, msg):
-        df = sdmx.to_pandas(msg, attributes='')
+        df = sdmx.to_pandas(msg, attributes="")
 
         assert isinstance(df, pd.Series)
 
         assert df.shape == (12,)
 
         # with metadata
-        df = sdmx.to_pandas(msg, attributes='osgd')
+        df = sdmx.to_pandas(msg, attributes="osgd")
         df, mdf = df.iloc[:, 0], df.iloc[:, 1:]
         assert mdf.shape == (12, 7)
-        assert mdf.iloc[1].OBS_STATUS == 'A'
+        assert mdf.iloc[1].OBS_STATUS == "A"
 
 
 class TestGenericSeriesDataSet2(DataMessageTest):
-    filename = 'ng-ts.xml'
+    filename = "ng-ts.xml"
 
     def test_header_attributes(self, msg):
-        assert msg.dataflow.id == 'STR1'
-        assert msg.structure.id == 'ECB_EXR_NG'
+        assert msg.dataflow.id == "STR1"
+        assert msg.structure.id == "ECB_EXR_NG"
 
         # Observation dimension is 1 or more Dimensions
-        assert msg.observation_dimension == 'TIME_PERIOD'
+        assert msg.observation_dimension == "TIME_PERIOD"
 
     def test_generic_obs(self, msg):
         data = msg.data[0]
@@ -181,16 +182,16 @@ class TestGenericSeriesDataSet2(DataMessageTest):
         assert isinstance(s3[0].series_key, model.Key)
 
         assert len(s3[0].series_key) == 5
-        assert s3[0].key.CURRENCY == 'USD'
-        assert s3[0].attrib.DECIMALS == '4'
+        assert s3[0].key.CURRENCY == "USD"
+        assert s3[0].attrib.DECIMALS == "4"
         obs_list = list(reversed(s3))
         assert len(obs_list) == 3
         o0 = obs_list[2]
 
-        assert o0.dim == '2010-08'
-        assert o0.value == '1.2894'
+        assert o0.dim == "2010-08"
+        assert o0.value == "1.2894"
 
-        assert o0.attrib.OBS_STATUS == 'A'
+        assert o0.attrib.OBS_STATUS == "A"
 
     def test_dataframe(self, msg):
         df = sdmx.to_pandas(msg.data[0]).iloc[::-1]
@@ -201,7 +202,7 @@ class TestGenericSeriesDataSet2(DataMessageTest):
 
 
 class TestGenericSeriesData_SiblingGroup_TS(DataMessageTest):
-    filename = 'sg-ts.xml'
+    filename = "sg-ts.xml"
 
     def test_groups(self, msg):
         data = msg.data[0]
@@ -212,9 +213,10 @@ class TestGenericSeriesData_SiblingGroup_TS(DataMessageTest):
 
         # GroupKeys can be retrieved from keys of DataSet.group
         g2_key, g2 = list(data.group.items())[2]
-        assert g2_key.CURRENCY == 'JPY'
-        assert g2[0].attrib.TITLE == ('ECB reference exchange rate, Japanese '
-                                      'yen/Euro')
+        assert g2_key.CURRENCY == "JPY"
+        assert g2[0].attrib.TITLE == (
+            "ECB reference exchange rate, Japanese " "yen/Euro"
+        )
 
         # Check group attributes of a series
         s = list(data.series)[0]
@@ -223,7 +225,7 @@ class TestGenericSeriesData_SiblingGroup_TS(DataMessageTest):
 
 
 class TestGenericSeriesData_RateGroup_TS(DataMessageTest):
-    filename = 'rg-ts.xml'
+    filename = "rg-ts.xml"
 
     def test_groups(self, msg):
         data = msg.data[0]
@@ -233,17 +235,18 @@ class TestGenericSeriesData_RateGroup_TS(DataMessageTest):
 
         # .group is DictLike; retrieve the key and obs separately
         g2_key, g2 = list(data.group.items())[2]
-        assert g2_key.CURRENCY == 'GBP'
-        assert g2_key.attrib.TITLE == ('ECB reference exchange rate, U.K. '
-                                       'Pound sterling /Euro')
+        assert g2_key.CURRENCY == "GBP"
+        assert g2_key.attrib.TITLE == (
+            "ECB reference exchange rate, U.K. " "Pound sterling /Euro"
+        )
         # Check group attributes of a series
         s = list(data.series)[0]
         g_attrib = s.group_attrib
         assert len(g_attrib) == 5
 
     def test_footer(self):
-        with specimen('footer.xml') as f:
+        with specimen("footer.xml") as f:
             f = sdmx.read_sdmx(f).footer
         assert f.code == 413
-        assert f.severity == 'Infomation'
-        assert str(f.text[1]).startswith('http')
+        assert f.severity == "Infomation"
+        assert str(f.text[1]).startswith("http")

--- a/sdmx/tests/test_dataset.py
+++ b/sdmx/tests/test_dataset.py
@@ -19,8 +19,11 @@ class TestGenericFlatDataSet(DataMessageTest):
         assert isinstance(msg, message.DataMessage)
 
     def test_header_attributes(self, msg):
-        # Internal reference of the StructureUsage is available
-        assert msg.dataflow.id == "STR1"
+        # NB removed 2020-05-15. This is the <mes:Structure structureID="…"> attrib.
+        #    SDMXCommon.xsd states: "The structureID attribute uniquely identifies the
+        #    structure for the purpose of referencing it from the payload. This is only
+        #    used in structure specific formats." It is not related to any DFD.
+        # assert msg.dataflow.id == "STR1"
 
         # Maintained ID of the DataStructureDefinition is available
         assert msg.structure.id == "ECB_EXR_NG"
@@ -61,7 +64,8 @@ class TestGenericSeriesDataSet(DataMessageTest):
     filename = "ng-ts-gf.xml"
 
     def test_header_attributes(self, msg):
-        assert msg.dataflow.id == "STR1"
+        # NB remove 2020-05-15; see above.
+        # assert msg.dataflow.id == "STR1"
         assert msg.structure.id == "ECB_EXR_NG"
         assert msg.observation_dimension == "TIME_PERIOD"
 
@@ -161,7 +165,8 @@ class TestGenericSeriesDataSet2(DataMessageTest):
     filename = "ng-ts.xml"
 
     def test_header_attributes(self, msg):
-        assert msg.dataflow.id == "STR1"
+        # NB removed 2020-05-15; see above.
+        # assert msg.dataflow.id == "STR1"
         assert msg.structure.id == "ECB_EXR_NG"
 
         # Observation dimension is 1 or more Dimensions

--- a/sdmx/tests/test_dataset_bare.py
+++ b/sdmx/tests/test_dataset_bare.py
@@ -1,4 +1,5 @@
 import sdmx
+from sdmx import model
 from sdmx.message import DataMessage, Header
 from sdmx.model import AttributeValue, DataAttribute, DataSet, Key, Observation
 
@@ -14,7 +15,7 @@ def test_flat():
     header = Header(
         id="62b5f19d-f1c9-495d-8446-a3661ed24753",
         prepared="2012-11-29T08:40:26Z",
-        sender="ECB",
+        sender=model.Agency(id="ECB"),
     )
     msg.header = header
 

--- a/sdmx/tests/test_dataset_bare.py
+++ b/sdmx/tests/test_dataset_bare.py
@@ -1,15 +1,6 @@
 import sdmx
-from sdmx.message import (
-    Header,
-    DataMessage,
-    )
-from sdmx.model import (
-    AttributeValue,
-    DataAttribute,
-    DataSet,
-    Key,
-    Observation,
-    )
+from sdmx.message import DataMessage, Header
+from sdmx.model import AttributeValue, DataAttribute, DataSet, Key, Observation
 
 from . import assert_pd_equal
 from .data import specimen
@@ -21,41 +12,43 @@ def test_flat():
 
     # Recreate the content from exr-flat.json
     header = Header(
-        id='62b5f19d-f1c9-495d-8446-a3661ed24753',
-        prepared='2012-11-29T08:40:26Z',
-        sender='ECB',
-        )
+        id="62b5f19d-f1c9-495d-8446-a3661ed24753",
+        prepared="2012-11-29T08:40:26Z",
+        sender="ECB",
+    )
     msg.header = header
 
     ds = DataSet()
 
     # Create a Key and attributes
-    key = Key(FREQ='D', CURRENCY='NZD', CURRENCY_DENOM='EUR', EXR_TYPE='SP00',
-              EXR_SUFFIX='A', TIME_PERIOD='2013-01-18')
-    obs_status = DataAttribute(id='OBS_STATUS')
-    attr = {'OBS_STATUS': AttributeValue(value_for=obs_status, value='A')}
+    key = Key(
+        FREQ="D",
+        CURRENCY="NZD",
+        CURRENCY_DENOM="EUR",
+        EXR_TYPE="SP00",
+        EXR_SUFFIX="A",
+        TIME_PERIOD="2013-01-18",
+    )
+    obs_status = DataAttribute(id="OBS_STATUS")
+    attr = {"OBS_STATUS": AttributeValue(value_for=obs_status, value="A")}
 
-    ds.obs.append(Observation(dimension=key, value=1.5931,
-                  attached_attribute=attr))
+    ds.obs.append(Observation(dimension=key, value=1.5931, attached_attribute=attr))
 
-    key = key.copy(TIME_PERIOD='2013-01-21')
-    ds.obs.append(Observation(dimension=key, value=1.5925,
-                  attached_attribute=attr))
+    key = key.copy(TIME_PERIOD="2013-01-21")
+    ds.obs.append(Observation(dimension=key, value=1.5925, attached_attribute=attr))
 
-    key = key.copy(CURRENCY='RUB', TIME_PERIOD='2013-01-18')
-    ds.obs.append(Observation(dimension=key, value=40.3426,
-                  attached_attribute=attr))
+    key = key.copy(CURRENCY="RUB", TIME_PERIOD="2013-01-18")
+    ds.obs.append(Observation(dimension=key, value=40.3426, attached_attribute=attr))
 
-    key = key.copy(TIME_PERIOD='2013-01-21')
-    ds.obs.append(Observation(dimension=key, value=40.3000,
-                  attached_attribute=attr))
+    key = key.copy(TIME_PERIOD="2013-01-21")
+    ds.obs.append(Observation(dimension=key, value=40.3000, attached_attribute=attr))
 
     msg.data.append(ds)
 
     # Write to pd.Dataframe
     df1 = sdmx.to_pandas(msg)
 
-    with specimen('flat.json') as f:
+    with specimen("flat.json") as f:
         ref = sdmx.read_sdmx(f)
     df2 = sdmx.to_pandas(ref)
 
@@ -63,7 +56,7 @@ def test_flat():
 
 
 def test_bare_series():
-    with specimen('ng-ts.xml') as f:
+    with specimen("ng-ts.xml") as f:
         sdmx.read_sdmx(f)
 
     # TODO generate the series and observations

--- a/sdmx/tests/test_dataset_ss.py
+++ b/sdmx/tests/test_dataset_ss.py
@@ -12,15 +12,16 @@ from . import MessageTest
 
 class StructuredMessageTest(MessageTest):
     """Variant of MessageTest for structure-specific messages."""
-    path = MessageTest.path / 'ECB_EXR'
+
+    path = MessageTest.path / "ECB_EXR"
     dsd_filename: str
 
     # Fixtures
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def dsd(self):
         yield sdmx.read_sdmx(self.path / self.dsd_filename).structure[0]
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def msg(self, dsd):
         yield sdmx.read_sdmx(self.path / self.filename, dsd=dsd)
 
@@ -35,8 +36,8 @@ class StructuredMessageTest(MessageTest):
 
 
 class TestStructSpecFlatDataSet(StructuredMessageTest):
-    filename = 'ng-flat-ss.xml'
-    dsd_filename = 'ng-structure-full.xml'
+    filename = "ng-flat-ss.xml"
+    dsd_filename = "ng-structure-full.xml"
 
     def test_msg_type(self, msg):
         assert isinstance(msg, message.DataMessage)
@@ -55,23 +56,23 @@ class TestStructSpecFlatDataSet(StructuredMessageTest):
 
         # Flat data set → all six dimensions are at the observation level
         assert len(o0) == 6
-        assert o0.key.FREQ == 'M'
-        assert o0.key.CURRENCY == 'CHF'
-        assert o0.value == '1.3413'
+        assert o0.key.FREQ == "M"
+        assert o0.key.CURRENCY == "CHF"
+        assert o0.value == "1.3413"
 
         # All attributes are at the observation level
         assert len(o0.attrib) == 7
-        assert o0.attrib.OBS_STATUS == 'A'
-        assert o0.attrib.DECIMALS == '4'
+        assert o0.attrib.OBS_STATUS == "A"
+        assert o0.attrib.DECIMALS == "4"
 
     def test_write2pandas(self, msg):
-        data_series = sdmx.to_pandas(msg, attributes='')
+        data_series = sdmx.to_pandas(msg, attributes="")
         assert isinstance(data_series, pd.Series)
 
 
 class TestStructSpecSeriesDataSet(StructuredMessageTest):
-    filename = 'ng-ts-gf-ss.xml'
-    dsd_filename = 'ng-structure-full.xml'
+    filename = "ng-ts-gf-ss.xml"
+    dsd_filename = "ng-structure-full.xml"
 
     def test_msg_type(self, dsd, msg):
         # assert msg.data[0].dim_at_obs == 'TIME_PERIOD'
@@ -90,11 +91,11 @@ class TestStructSpecSeriesDataSet(StructuredMessageTest):
 
         # Time series data set → five dimensions are at the SeriesKey level
         assert len(s3) == 5
-        assert s3.CURRENCY == 'USD'
+        assert s3.CURRENCY == "USD"
 
         # 5 of 7 attributes are at the Observation level
         assert len(s3.attrib) == 5
-        assert s3.attrib.DECIMALS == '4'
+        assert s3.attrib.DECIMALS == "4"
 
         obs_list = data.series[s3]
         assert len(obs_list) == 3
@@ -102,12 +103,12 @@ class TestStructSpecSeriesDataSet(StructuredMessageTest):
 
         # One remaining dimension is at the Observation Level
         assert len(o0.dimension) == 1
-        assert o0.dim == Key(TIME_PERIOD='2010-08')
-        assert o0.value == '1.3898'
+        assert o0.dim == Key(TIME_PERIOD="2010-08")
+        assert o0.value == "1.3898"
 
         # Two remaining attributes are at the Observation level
         assert len(o0.attached_attribute)
-        assert o0.attrib.OBS_STATUS == 'A'
+        assert o0.attrib.OBS_STATUS == "A"
 
     def test_pandas(self, msg):
         data = msg.data[0]
@@ -117,13 +118,13 @@ class TestStructSpecSeriesDataSet(StructuredMessageTest):
         assert len(data.series) == 4
 
         # Single series can be converted to pandas
-        s3 = sdmx.to_pandas(data.series[3], attributes='')
+        s3 = sdmx.to_pandas(data.series[3], attributes="")
         assert isinstance(s3, pd.Series)
         # With expected values
         assert s3[0] == 1.2894
 
         # Single series can be converted with attributes
-        s3_attr = sdmx.to_pandas(data.series[3], attributes='osgd')
+        s3_attr = sdmx.to_pandas(data.series[3], attributes="osgd")
 
         # yields a DataFrame
         assert isinstance(s3_attr, pd.DataFrame)
@@ -132,21 +133,21 @@ class TestStructSpecSeriesDataSet(StructuredMessageTest):
         assert s3_attr.iloc[0].value == 1.2894
 
         # Attributes of observations can be accessed
-        assert s3_attr.iloc[0].OBS_STATUS == 'A'
+        assert s3_attr.iloc[0].OBS_STATUS == "A"
 
     def test_write2pandas(self, msg):
-        df = sdmx.to_pandas(msg, attributes='')
+        df = sdmx.to_pandas(msg, attributes="")
         assert isinstance(df, pd.Series)
         assert df.shape == (12,)
         # with metadata
-        df = sdmx.to_pandas(msg, attributes='osgd')
+        df = sdmx.to_pandas(msg, attributes="osgd")
         assert df.shape == (12, 8)
-        assert df.iloc[1].OBS_STATUS == 'A'
+        assert df.iloc[1].OBS_STATUS == "A"
 
 
 class TestStructSpecSeriesDataSet2(StructuredMessageTest):
-    filename = 'ng-ts-ss.xml'
-    dsd_filename = 'ng-structure-full.xml'
+    filename = "ng-ts-ss.xml"
+    dsd_filename = "ng-structure-full.xml"
 
     def test_msg_type(self, dsd, msg):
         # assert msg.data[0].dim_at_obs == 'TIME_PERIOD'
@@ -168,41 +169,40 @@ class TestStructSpecSeriesDataSet2(StructuredMessageTest):
 
         # SeriesKey has expected number of dimensions and values
         assert len(s3) == 5
-        assert s3.CURRENCY == 'USD'
+        assert s3.CURRENCY == "USD"
 
         # SeriesKey has expected number of attributes and values
         assert len(s3.attrib) == 5
-        assert s3.attrib.DECIMALS == '4'
+        assert s3.attrib.DECIMALS == "4"
 
         # Series observations can be accessed
         obs_list = data.series[s3]
         assert len(obs_list) == 3
         o0 = obs_list[2]
         assert len(o0.dimension) == 1
-        assert o0.dim == Key(TIME_PERIOD='2010-08')
-        assert o0.value == '1.3898'
-        assert o0.attrib.OBS_STATUS == 'A'
+        assert o0.dim == Key(TIME_PERIOD="2010-08")
+        assert o0.value == "1.3898"
+        assert o0.attrib.OBS_STATUS == "A"
 
     def test_dataframe(self, msg):
         data = msg.data[0]
-        s = sdmx.to_pandas(data, attributes='')
+        s = sdmx.to_pandas(data, attributes="")
         assert isinstance(s, pd.Series)
         assert len(s) == 12
 
 
 class TestStructSpecSeriesData_SiblingGroup_TS(StructuredMessageTest):
-    filename = 'sg-ts-ss.xml'
-    dsd_filename = 'sg-structure.xml'
+    filename = "sg-ts-ss.xml"
+    dsd_filename = "sg-structure.xml"
 
     def test_groups(self, msg):
         data = msg.data[0]
         assert len(data.group) == 4
         assert len(data.series) == 4
         g2 = list(data.group.keys())[2]
-        assert g2.CURRENCY == 'JPY'
-        print(list(data.group.keys()), g2, g2.attrib, sep='\n')
-        assert g2.attrib.TITLE == \
-            'ECB reference exchange rate, Japanese yen/Euro'
+        assert g2.CURRENCY == "JPY"
+        print(list(data.group.keys()), g2, g2.attrib, sep="\n")
+        assert g2.attrib.TITLE == "ECB reference exchange rate, Japanese yen/Euro"
         # Check group attributes of a series
         s = list(data.series)[0]
         g_attrib = s.group_attrib
@@ -211,17 +211,18 @@ class TestStructSpecSeriesData_SiblingGroup_TS(StructuredMessageTest):
 
 
 class TestStructSpecSeriesData_RateGroup_TS(StructuredMessageTest):
-    filename = 'rg-ts-ss.xml'
-    dsd_filename = 'rg-structure.xml'
+    filename = "rg-ts-ss.xml"
+    dsd_filename = "rg-structure.xml"
 
     def test_groups(self, msg):
         data = msg.data[0]
         assert len(data.group) == 5
         assert len(data.series) == 4
         g2 = list(data.group.keys())[2]
-        assert g2.CURRENCY == 'GBP'
-        assert g2.attrib.TITLE == \
-            'ECB reference exchange rate, U.K. Pound sterling /Euro'
+        assert g2.CURRENCY == "GBP"
+        assert (
+            g2.attrib.TITLE == "ECB reference exchange rate, U.K. Pound sterling /Euro"
+        )
         # Check group attributes of a series
         s = list(data.series)[0]
         g_attrib = s.group_attrib

--- a/sdmx/tests/test_dataset_ss.py
+++ b/sdmx/tests/test_dataset_ss.py
@@ -13,7 +13,7 @@ from . import MessageTest
 class StructuredMessageTest(MessageTest):
     """Variant of MessageTest for structure-specific messages."""
     path = MessageTest.path / 'ECB_EXR'
-    dsd = None
+    dsd_filename: str
 
     # Fixtures
     @pytest.fixture(scope='class')

--- a/sdmx/tests/test_dataset_ss.py
+++ b/sdmx/tests/test_dataset_ss.py
@@ -35,7 +35,7 @@ class StructuredMessageTest(MessageTest):
         assert msg.data[0].structured_by is dsd
 
 
-class TestStructSpecFlatDataSet(StructuredMessageTest):
+class TestFlatDataSet(StructuredMessageTest):
     filename = "ng-flat-ss.xml"
     dsd_filename = "ng-structure-full.xml"
 
@@ -70,7 +70,7 @@ class TestStructSpecFlatDataSet(StructuredMessageTest):
         assert isinstance(data_series, pd.Series)
 
 
-class TestStructSpecSeriesDataSet(StructuredMessageTest):
+class TestSeriesDataSet(StructuredMessageTest):
     filename = "ng-ts-gf-ss.xml"
     dsd_filename = "ng-structure-full.xml"
 
@@ -145,7 +145,7 @@ class TestStructSpecSeriesDataSet(StructuredMessageTest):
         assert df.iloc[1].OBS_STATUS == "A"
 
 
-class TestStructSpecSeriesDataSet2(StructuredMessageTest):
+class TestSeriesDataSet2(StructuredMessageTest):
     filename = "ng-ts-ss.xml"
     dsd_filename = "ng-structure-full.xml"
 
@@ -191,7 +191,7 @@ class TestStructSpecSeriesDataSet2(StructuredMessageTest):
         assert len(s) == 12
 
 
-class TestStructSpecSeriesData_SiblingGroup_TS(StructuredMessageTest):
+class TestSeriesData_SiblingGroup_TS(StructuredMessageTest):
     filename = "sg-ts-ss.xml"
     dsd_filename = "sg-structure.xml"
 
@@ -210,7 +210,7 @@ class TestStructSpecSeriesData_SiblingGroup_TS(StructuredMessageTest):
         assert len(g_attrib) == 1
 
 
-class TestStructSpecSeriesData_RateGroup_TS(StructuredMessageTest):
+class TestSeriesData_RateGroup_TS(StructuredMessageTest):
     filename = "rg-ts-ss.xml"
     dsd_filename = "rg-structure.xml"
 

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -24,23 +24,21 @@ from .data import specimen
 def test_doc_example():
     """Code from example.rst."""
     import sdmx
-    estat = sdmx.Request('ESTAT')
 
-    metadata = estat.datastructure('DSD_une_rt_a')
+    estat = sdmx.Request("ESTAT")
 
-    for cl in 'CL_AGE', 'CL_UNIT':
+    metadata = estat.datastructure("DSD_une_rt_a")
+
+    for cl in "CL_AGE", "CL_UNIT":
         print(sdmx.to_pandas(metadata.codelist[cl]))
 
     resp = estat.data(
-        'une_rt_a',
-        key={'GEO': 'EL+ES+IE'},
-        params={'startPeriod': '2007'},
-        )
+        "une_rt_a", key={"GEO": "EL+ES+IE"}, params={"startPeriod": "2007"}
+    )
 
-    data = sdmx.to_pandas(resp) \
-               .xs('Y15-74', level='AGE', drop_level=False)
+    data = sdmx.to_pandas(resp).xs("Y15-74", level="AGE", drop_level=False)
 
-    data.loc[('A', 'Y15-74', 'PC_ACT', 'T')]
+    data.loc[("A", "Y15-74", "PC_ACT", "T")]
 
     # Further checks per https://github.com/dr-leo/pandaSDMX/issues/157
 
@@ -63,63 +61,72 @@ def test_doc_example():
 @pytest.mark.remote_data
 def test_doc_index1():
     """First code example in index.rst."""
-    estat = Request('ESTAT')
-    flow_response = estat.dataflow('une_rt_a')
+    estat = Request("ESTAT")
+    flow_response = estat.dataflow("une_rt_a")
 
     with pytest.raises(TypeError):
         # This presumes the DataStructureDefinition instance can conduct a
         # network request for its own content
         structure_response = flow_response.dataflow.une_rt_a.structure(
-            request=True, target_only=False)
+            request=True, target_only=False
+        )
 
     # Same effect
     structure_response = estat.get(
-        'datastructure', flow_response.dataflow.une_rt_a.structure.id)
+        "datastructure", flow_response.dataflow.une_rt_a.structure.id
+    )
 
     # Even better: Request.get(…) should examine the class and ID of the object
     # structure = estat.get(flow_response.dataflow.une_rt_a.structure)
 
     # Show some codelists
     s = sdmx.to_pandas(structure_response)
-    expected = pd.Series({
-        'AT': 'Austria',
-        'BE': 'Belgium',
-        'BG': 'Bulgaria',
-        'CH': 'Switzerland',
-        'CY': 'Cyprus',
-        }, name='GEO') \
-        .rename_axis('CL_GEO')
+    expected = pd.Series(
+        {
+            "AT": "Austria",
+            "BE": "Belgium",
+            "BG": "Bulgaria",
+            "CH": "Switzerland",
+            "CY": "Cyprus",
+        },
+        name="GEO",
+    ).rename_axis("CL_GEO")
 
     # Codelists are converted to a DictLike
     assert isinstance(s.codelist, DictLike)
 
     # Same effect
-    assert_pd_equal(s.codelist['CL_GEO'].sort_index().head(), expected)
+    assert_pd_equal(s.codelist["CL_GEO"].sort_index().head(), expected)
 
 
 @pytest.mark.remote_data
 def test_doc_usage_structure():
     """Code examples in walkthrough.rst."""
-    ecb = Request('ECB')
+    ecb = Request("ECB")
 
-    ecb_via_proxy = Request('ECB', proxies={'http': 'http://1.2.3.4:5678'})
-    assert all(getattr(ecb_via_proxy.session, k) == v for k, v in (
-        ('proxies', {'http': 'http://1.2.3.4:5678'}),
-        ('stream', False),
-        ('timeout', 30.1),
-        ))
+    ecb_via_proxy = Request("ECB", proxies={"http": "http://1.2.3.4:5678"})
+    assert all(
+        getattr(ecb_via_proxy.session, k) == v
+        for k, v in (
+            ("proxies", {"http": "http://1.2.3.4:5678"}),
+            ("stream", False),
+            ("timeout", 30.1),
+        )
+    )
 
     msg1 = ecb.categoryscheme()
 
     assert msg1.response.url == (
-        'http://sdw-wsrest.ecb.int/service/categoryscheme/ECB/latest'
-        '?references=parentsandsiblings')
+        "http://sdw-wsrest.ecb.int/service/categoryscheme/ECB/latest"
+        "?references=parentsandsiblings"
+    )
 
     # Check specific headers
     headers = msg1.response.headers
-    assert headers['Content-Type'] == ('application/vnd.sdmx.structure+xml; '
-                                       'version=2.1')
-    assert all(k in headers for k in ['Connection', 'Date', 'Server'])
+    assert headers["Content-Type"] == (
+        "application/vnd.sdmx.structure+xml; " "version=2.1"
+    )
+    assert all(k in headers for k in ["Connection", "Date", "Server"])
 
     # Removed: in pandaSDMX 0.x this was a convenience method that (for this
     # structure message) returned two DataStructureDefinitions. Contra the
@@ -131,48 +138,61 @@ def test_doc_usage_structure():
     # list(cat_response.category_scheme['MOBILE_NAVI']['07'])
 
     dfs = sdmx.to_pandas(msg1.dataflow).head()
-    expected = pd.Series({
-        'AME': 'AMECO',
-        'BKN': 'Banknotes statistics',
-        'BLS': 'Bank Lending Survey Statistics',
-        'BOP': ('Euro Area Balance of Payments and International Investment '
-                'Position Statistics'),
-        'BSI': 'Balance Sheet Items',
-        })
+    expected = pd.Series(
+        {
+            "AME": "AMECO",
+            "BKN": "Banknotes statistics",
+            "BLS": "Bank Lending Survey Statistics",
+            "BOP": (
+                "Euro Area Balance of Payments and International Investment "
+                "Position Statistics"
+            ),
+            "BSI": "Balance Sheet Items",
+        }
+    )
     assert_pd_equal(dfs, expected)
 
     flows = ecb.dataflow()  # noqa: F841
     dsd_id = msg1.dataflow.EXR.structure.id
-    assert dsd_id == 'ECB_EXR1'
+    assert dsd_id == "ECB_EXR1"
 
-    refs = dict(references='all')
+    refs = dict(references="all")
     msg2 = ecb.datastructure(resource_id=dsd_id, params=refs)
     dsd = msg2.structure[dsd_id]
 
     assert sdmx.to_pandas(dsd.dimensions) == [
-        'FREQ', 'CURRENCY', 'CURRENCY_DENOM', 'EXR_TYPE', 'EXR_SUFFIX',
-        'TIME_PERIOD']
+        "FREQ",
+        "CURRENCY",
+        "CURRENCY_DENOM",
+        "EXR_TYPE",
+        "EXR_SUFFIX",
+        "TIME_PERIOD",
+    ]
 
-    cl = sdmx.to_pandas(msg2.codelist['CL_CURRENCY']).sort_index()
-    expected = pd.Series({
-        'ADF': 'Andorran Franc (1-1 peg to the French franc)',
-        'ADP': 'Andorran Peseta (1-1 peg to the Spanish peseta)',
-        'AED': 'United Arab Emirates dirham',
-        'AFA': 'Afghanistan afghani (old)',
-        'AFN': 'Afghanistan, Afghanis',
-        }, name='Currency code list') \
-        .rename_axis('CL_CURRENCY')
+    cl = sdmx.to_pandas(msg2.codelist["CL_CURRENCY"]).sort_index()
+    expected = pd.Series(
+        {
+            "ADF": "Andorran Franc (1-1 peg to the French franc)",
+            "ADP": "Andorran Peseta (1-1 peg to the Spanish peseta)",
+            "AED": "United Arab Emirates dirham",
+            "AFA": "Afghanistan afghani (old)",
+            "AFN": "Afghanistan, Afghanis",
+        },
+        name="Currency code list",
+    ).rename_axis("CL_CURRENCY")
     assert_pd_equal(cl.head(), expected)
 
 
 @pytest.mark.remote_data
 def test_doc_usage_data():
     """Code examples in usage.rst."""
-    ecb = Request('ECB')
+    ecb = Request("ECB")
 
-    data_response = ecb.data(resource_id='EXR', key={'CURRENCY': 'USD+JPY'},
-                             params={'startPeriod': '2016',
-                                     'endPeriod': '2016-12-31'})
+    data_response = ecb.data(
+        resource_id="EXR",
+        key={"CURRENCY": "USD+JPY"},
+        params={"startPeriod": "2016", "endPeriod": "2016-12-31"},
+    )
     # # Commented: do the same without triggering requests for validation
     # data_response = ecb.data(resource_id='EXR', key='.JPY+USD...',
     #                          params={'startPeriod': '2016',
@@ -193,38 +213,38 @@ def test_doc_usage_data():
 
     series_keys[5]
 
-    assert (sorted(set(sk.FREQ.value for sk in data.series))
-            == 'A D H M Q'.split())
+    assert sorted(set(sk.FREQ.value for sk in data.series)) == "A D H M Q".split()
 
-    daily = sdmx.to_pandas(data).xs('D', level='FREQ')
+    daily = sdmx.to_pandas(data).xs("D", level="FREQ")
     assert len(daily) == 514
 
-    assert_pd_equal(daily.tail().values,
-                    np.array([1.0446, 1.0445, 1.0401, 1.0453, 1.0541]))
+    assert_pd_equal(
+        daily.tail().values, np.array([1.0446, 1.0445, 1.0401, 1.0453, 1.0541])
+    )
 
 
 def test_doc_howto_timeseries():
-    with specimen('sg-ts.xml') as f:
+    with specimen("sg-ts.xml") as f:
         ds = sdmx.read_sdmx(f).data[0]
 
     # Convert to pd.Series and unstack the time dimension to columns
     base = sdmx.to_pandas(ds)
-    s1 = base.unstack('TIME_PERIOD')
+    s1 = base.unstack("TIME_PERIOD")
 
     # DatetimeIndex on columns
     s1.columns = pd.to_datetime(s1.columns)
     assert isinstance(s1.columns, pd.DatetimeIndex)
 
     # DatetimeIndex on index
-    s2 = base.unstack('TIME_PERIOD').transpose()
+    s2 = base.unstack("TIME_PERIOD").transpose()
     s2.index = pd.to_datetime(s2.index)
     assert isinstance(s2.index, pd.DatetimeIndex)
 
     # Same with pd.PeriodIndex
     s3 = s1.to_period(axis=1)
     assert isinstance(s3.columns, pd.PeriodIndex)
-    assert s3.columns.freqstr == 'M'
+    assert s3.columns.freqstr == "M"
 
     s4 = s2.to_period(axis=0)
     assert isinstance(s4.index, pd.PeriodIndex)
-    assert s4.index.freqstr == 'M'
+    assert s4.index.freqstr == "M"

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -131,7 +131,7 @@ def test_doc_usage_structure():
     # spec, that assumes:
     # - There is 1 Categorization using the CategoryScheme; there could be
     #   many.
-    # - The Categorization maps DataStructureDefintions to Categories, when
+    # - The Categorization maps DataStructureDefinitions to Categories, when
     #   there could be many.
     # list(cat_response.category_scheme['MOBILE_NAVI']['07'])
 

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -1,11 +1,9 @@
 """Test code appearing in the documentation.
 
-The 'remote_data' mark, from the pytest plugin 'pytest-remotedata', is used to
-mark tests that will access the Internet. In order to run these tests, a
-command-line argument must be given:
+The 'network' mark is used to mark tests that will access the Internet. In order to run
+these tests, a command-line argument must be given:
 
-$ py.test --remote-data [...]
-
+$ pytest -m network [...]
 """
 import numpy as np
 import pandas as pd
@@ -20,7 +18,7 @@ from . import assert_pd_equal
 from .data import specimen
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_doc_example():
     """Code from example.rst."""
     import sdmx
@@ -58,7 +56,7 @@ def test_doc_example():
     assert dd1.order_key(sk) == sk
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_doc_index1():
     """First code example in index.rst."""
     estat = Request("ESTAT")
@@ -99,7 +97,7 @@ def test_doc_index1():
     assert_pd_equal(s.codelist["CL_GEO"].sort_index().head(), expected)
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_doc_usage_structure():
     """Code examples in walkthrough.rst."""
     ecb = Request("ECB")
@@ -183,7 +181,7 @@ def test_doc_usage_structure():
     assert_pd_equal(cl.head(), expected)
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_doc_usage_data():
     """Code examples in usage.rst."""
     ecb = Request("ECB")

--- a/sdmx/tests/test_dsd.py
+++ b/sdmx/tests/test_dsd.py
@@ -1,23 +1,23 @@
+import pytest
+
 import sdmx
 from sdmx import model
 
 from . import MessageTest
 from .data import specimen
 
-import pytest
-
 
 class Test_ESTAT_dsd_apro_mk_cola(MessageTest):
-    path = MessageTest.path / 'ESTAT'
-    filename = 'apro_mk_cola-structure.xml'
+    path = MessageTest.path / "ESTAT"
+    filename = "apro_mk_cola-structure.xml"
 
     def test_codelists_keys(self, msg):
         assert len(msg.codelist) == 6
         assert isinstance(msg.codelist.CL_GEO, model.Codelist)
 
     def test_codelist_name(self, msg):
-        assert msg.codelist.CL_GEO.UK.name.en == 'United Kingdom'
-        assert msg.codelist.CL_FREQ.name.en == 'FREQ'
+        assert msg.codelist.CL_GEO.UK.name.en == "United Kingdom"
+        assert msg.codelist.CL_FREQ.name.en == "FREQ"
 
     def test_code_cls(self, msg):
         assert isinstance(msg.codelist.CL_FREQ.D, model.Code)
@@ -27,35 +27,37 @@ class Test_ESTAT_dsd_apro_mk_cola(MessageTest):
 
         # Number of codes expected in each Codelist
         count = {
-            'CL_FREQ': 6,
-            'CL_GEO': 41,
-            'CL_OBS_FLAG': 10,
-            'CL_OBS_STATUS': 3,
-            'CL_PRODMILK': 12,
-            'CL_UNIT': 1,
-            }
+            "CL_FREQ": 6,
+            "CL_GEO": 41,
+            "CL_OBS_FLAG": 10,
+            "CL_OBS_STATUS": 3,
+            "CL_PRODMILK": 12,
+            "CL_UNIT": 1,
+        }
 
         assert all(len(df) == count[id] for id, df in cls_as_dfs.items())
 
     def test_urn(self, msg):
         """https://github.com/dr-leo/pandaSDMX/issue/154."""
-        expected = ('urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure='
-                    'ESTAT:DSD_apro_mk_cola(1.0)')
+        expected = (
+            "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure="
+            "ESTAT:DSD_apro_mk_cola(1.0)"
+        )
 
         # URN is parsed
         assert msg.structure.DSD_apro_mk_cola.urn == expected
 
 
 class TestDSDCommon(MessageTest):
-    path = MessageTest.path / 'SGR'
-    filename = 'common-structure.xml'
+    path = MessageTest.path / "SGR"
+    filename = "common-structure.xml"
 
     def test_codelists_keys(self, msg):
         assert len(msg.codelist) == 5
         assert isinstance(msg.codelist.CL_FREQ, model.Codelist)
 
     def test_codelist_name(self, msg):
-        assert msg.codelist.CL_FREQ.D.name.en == 'Daily'
+        assert msg.codelist.CL_FREQ.D.name.en == "Daily"
 
     def test_code_cls(self, msg):
         assert isinstance(msg.codelist.CL_FREQ.D, model.Code)
@@ -66,50 +68,50 @@ class TestDSDCommon(MessageTest):
         assert len(anno_list) == 1
         a = anno_list[0]
         assert isinstance(a, model.Annotation)
-        assert a.text.en.startswith('It is')
-        assert a.type == 'NOTE'
+        assert a.text.en.startswith("It is")
+        assert a.type == "NOTE"
 
 
 class TestECB_EXR1(MessageTest):
-    path = MessageTest.path / 'ECB_EXR' / '1'
-    filename = 'structure.xml'
+    path = MessageTest.path / "ECB_EXR" / "1"
+    filename = "structure.xml"
 
     def test_uri(self, msg):
         """https://github.com/dr-leo/pandaSDMX/issue/154."""
-        expected = 'https://www.ecb.europa.eu/vocabulary/stats/exr/1'
+        expected = "https://www.ecb.europa.eu/vocabulary/stats/exr/1"
         # URI is parsed
-        assert msg.structure['ECB_EXR1'].uri == expected
+        assert msg.structure["ECB_EXR1"].uri == expected
 
 
 def test_exr_constraints():
-    with specimen('1/structure-full.xml') as f:
+    with specimen("1/structure-full.xml") as f:
         m = sdmx.read_sdmx(f)
-    ECB_EXR1 = m.structure['ECB_EXR1']
+    ECB_EXR1 = m.structure["ECB_EXR1"]
 
     # Test DimensionDescriptor
     dd = ECB_EXR1.dimensions
 
     # Correct order
-    assert dd[0].id == 'FREQ'
+    assert dd[0].id == "FREQ"
 
     # Correct number of dimensions
     assert len(dd.components) == 6
 
     # Dimensions can be retrieved by name; membership can be tested
-    assert 'W' in dd.get('FREQ')
+    assert "W" in dd.get("FREQ")
 
     # Similar tests for AttributeDescriptor
     ad = ECB_EXR1.attributes
     assert len(ad.components) == 24
-    assert ad[-1].id == 'UNIT_MULT'
-    assert '5' in ad.get('UNIT_MULT')
+    assert ad[-1].id == "UNIT_MULT"
+    assert "5" in ad.get("UNIT_MULT")
 
-    pytest.xfail('constrained codes not implemented')  # TODO
+    pytest.xfail("constrained codes not implemented")  # TODO
     assert len(m._constrained_codes), 14
 
-    assert 'W' not in m._constrained_codes.FREQ
+    assert "W" not in m._constrained_codes.FREQ
 
-    key = {'FREQ': ['W']}
+    key = {"FREQ": ["W"]}
 
     assert m.in_codes(key)
 
@@ -118,11 +120,11 @@ def test_exr_constraints():
     with pytest.raises(ValueError):
         m.in_constraints(key)
 
-    assert m.in_constraints({'CURRENCY': ['CHF']})
+    assert m.in_constraints({"CURRENCY": ["CHF"]})
 
     # test with invalid key
     with pytest.raises(TypeError):
-        m._in_constraints({'FREQ': 'A'})
+        m._in_constraints({"FREQ": "A"})
 
     # structure writer with constraints
     out = sdmx.to_pandas(m)

--- a/sdmx/tests/test_dsd.py
+++ b/sdmx/tests/test_dsd.py
@@ -106,7 +106,7 @@ def test_exr_constraints():
     assert ad[-1].id == "UNIT_MULT"
     assert "5" in ad.get("UNIT_MULT")
 
-    pytest.xfail("constrained codes not implemented")  # TODO
+    pytest.xfail("constrained codes not implemented")
     assert len(m._constrained_codes), 14
 
     assert "W" not in m._constrained_codes.FREQ

--- a/sdmx/tests/test_experimental.py
+++ b/sdmx/tests/test_experimental.py
@@ -2,35 +2,28 @@
 
 See sdmx.experimental for more information.
 """
-from sdmx.experimental import DataSet as PandasDataSet
-from sdmx.model import (
-    AttributeValue,
-    DataAttribute,
-    DataSet,
-    Key,
-    Observation,
-    )
 import pytest
+
+from sdmx.experimental import DataSet as PandasDataSet
+from sdmx.model import AttributeValue, DataAttribute, DataSet, Key, Observation
 
 
 # Run the tests on both the standard DataSet class, and the experimental,
 # PandasDataSet version
-@pytest.mark.parametrize('DataSetType', [
-    DataSet,
-    pytest.param(PandasDataSet, marks=pytest.mark.experimental),
-])
+@pytest.mark.parametrize(
+    "DataSetType",
+    [DataSet, pytest.param(PandasDataSet, marks=pytest.mark.experimental)],
+)
 def test_add_obs(DataSetType):
     # Create a Key and Attributes
-    key = Key(CURRENCY='NZD', CURRENCY_DENOM='EUR',
-              TIME_PERIOD='2018-01-01')
-    obs_status = DataAttribute(id='OBS_STATUS')
-    attr = {'OBS_STATUS': AttributeValue(value_for=obs_status, value='A')}
+    key = Key(CURRENCY="NZD", CURRENCY_DENOM="EUR", TIME_PERIOD="2018-01-01")
+    obs_status = DataAttribute(id="OBS_STATUS")
+    attr = {"OBS_STATUS": AttributeValue(value_for=obs_status, value="A")}
 
     obs = []
     for day, value in enumerate([5, 6, 7]):
-        key = key.copy(TIME_PERIOD='2018-01-{:02d}'.format(day))
-        obs.append(Observation(dimension=key, value=value,
-                               attached_attribute=attr))
+        key = key.copy(TIME_PERIOD="2018-01-{:02d}".format(day))
+        obs.append(Observation(dimension=key, value=value, attached_attribute=attr))
 
     ds = DataSetType()
     ds.add_obs(obs)

--- a/sdmx/tests/test_insee.py
+++ b/sdmx/tests/test_insee.py
@@ -1,45 +1,42 @@
 # TODO tidy these tests to use fixtures/methods from sdmx.tests
 from collections import OrderedDict
 
+import pytest
+
 import sdmx
 from sdmx import Request
-import pytest
 
 from .data import BASE_PATH as test_data_path
 
+test_data_path = test_data_path / "INSEE"
 
-test_data_path = test_data_path / 'INSEE'
-
-DATAFLOW_FP = test_data_path / 'dataflow.xml'
+DATAFLOW_FP = test_data_path / "dataflow.xml"
 
 DATASETS = {
-    'IPI-2010-A21': {
-        'data-fp': test_data_path / 'IPI-2010-A21.xml',
-        'datastructure-fp': test_data_path / 'IPI-2010-A21-structure.xml',
-        'series_count': 20,
+    "IPI-2010-A21": {
+        "data-fp": test_data_path / "IPI-2010-A21.xml",
+        "datastructure-fp": test_data_path / "IPI-2010-A21-structure.xml",
+        "series_count": 20,
     },
-    'CNA-2010-CONSO-SI-A17': {
-        'data-fp': test_data_path / 'CNA-2010-CONSO-SI-A17.xml',
-        'datastructure-fp': (test_data_path /
-                             'CNA-2010-CONSO-SI-A17-structure.xml'),
-        'series_count': 1,
+    "CNA-2010-CONSO-SI-A17": {
+        "data-fp": test_data_path / "CNA-2010-CONSO-SI-A17.xml",
+        "datastructure-fp": (test_data_path / "CNA-2010-CONSO-SI-A17-structure.xml"),
+        "series_count": 1,
     },
 }
 
 SERIES = {
-    'UNEMPLOYMENT_CAT_A_B_C': {
-        'data-fp': test_data_path / 'bug-series-freq-data.xml',
-    }
+    "UNEMPLOYMENT_CAT_A_B_C": {"data-fp": test_data_path / "bug-series-freq-data.xml"}
 }
 
 
 class TestINSEE:
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def req(self):
-        return Request('INSEE')
+        return Request("INSEE")
 
     def test_load_dataset(self, req):
-        dataset_code = 'IPI-2010-A21'
+        dataset_code = "IPI-2010-A21"
 
         # Load all dataflows
         dataflows_response = sdmx.read_sdmx(DATAFLOW_FP)
@@ -49,26 +46,28 @@ class TestINSEE:
         assert dataset_code in dataflows
 
         # Load datastructure for current dataset_code
-        fp_datastructure = DATASETS[dataset_code]['datastructure-fp']
+        fp_datastructure = DATASETS[dataset_code]["datastructure-fp"]
         datastructure_response = sdmx.read_sdmx(fp_datastructure)
         assert dataset_code in datastructure_response.dataflow
         dsd = datastructure_response.dataflow[dataset_code].structure
 
         # Verify dimensions list
-        dimensions = OrderedDict([dim.id, dim] for dim in
-                                 dsd.dimensions if dim.id not in
-                                 ['TIME', 'TIME_PERIOD'])
+        dimensions = OrderedDict(
+            [dim.id, dim]
+            for dim in dsd.dimensions
+            if dim.id not in ["TIME", "TIME_PERIOD"]
+        )
         dim_keys = list(dimensions.keys())
-        assert dim_keys == ['FREQ', 'PRODUIT', 'NATURE']
+        assert dim_keys == ["FREQ", "PRODUIT", "NATURE"]
 
         # Load datas for the current dataset
-        fp_data = DATASETS[dataset_code]['data-fp']
+        fp_data = DATASETS[dataset_code]["data-fp"]
         data = sdmx.read_sdmx(fp_data)
 
         # Verify series count and values
         series = data.data[0].series
         series_count = len(series)
-        assert series_count == DATASETS[dataset_code]['series_count']
+        assert series_count == DATASETS[dataset_code]["series_count"]
 
         first_series = series[0]
         observations = first_series
@@ -76,45 +75,58 @@ class TestINSEE:
         first_obs = observations[0]
         last_obs = observations[-1]
 
-        assert first_obs.dim == '2015-10'
-        assert first_obs.value == '105.61'
+        assert first_obs.dim == "2015-10"
+        assert first_obs.value == "105.61"
 
-        assert last_obs.dim == '1990-01'
-        assert last_obs.value == '139.22'
+        assert last_obs.dim == "1990-01"
+        assert last_obs.value == "139.22"
 
     def test_fixe_key_names(self, req):
         """Verify key or attribute contains '-' in name."""
-        dataset_code = 'CNA-2010-CONSO-SI-A17'
+        dataset_code = "CNA-2010-CONSO-SI-A17"
 
-        fp_datastructure = DATASETS[dataset_code]['datastructure-fp']
+        fp_datastructure = DATASETS[dataset_code]["datastructure-fp"]
         datastructure_response = sdmx.read_sdmx(fp_datastructure)
         assert dataset_code in datastructure_response.dataflow
         dsd = datastructure_response.dataflow[dataset_code].structure
 
-        dimensions = OrderedDict([dim.id, dim] for dim in
-                                 dsd.dimensions if dim.id not in
-                                 ['TIME', 'TIME_PERIOD'])
+        dimensions = OrderedDict(
+            [dim.id, dim]
+            for dim in dsd.dimensions
+            if dim.id not in ["TIME", "TIME_PERIOD"]
+        )
         dim_keys = list(dimensions.keys())
-        assert dim_keys == ['SECT-INST', 'OPERATION', 'PRODUIT', 'PRIX']
+        assert dim_keys == ["SECT-INST", "OPERATION", "PRODUIT", "PRIX"]
 
-        fp_data = DATASETS[dataset_code]['data-fp']
+        fp_data = DATASETS[dataset_code]["data-fp"]
         data = sdmx.read_sdmx(fp_data)
         series = data.data[0].series
         series_key = list(series.keys())[0]
 
-        assert (list(series_key.values.keys()) ==
-                ['SECT-INST', 'OPERATION', 'PRODUIT', 'PRIX'])
+        assert list(series_key.values.keys()) == [
+            "SECT-INST",
+            "OPERATION",
+            "PRODUIT",
+            "PRIX",
+        ]
 
-        assert (list(series_key.attrib.keys()) ==
-                ['FREQ', 'IDBANK', 'TITLE', 'LAST_UPDATE', 'UNIT_MEASURE',
-                 'UNIT_MULT', 'REF_AREA', 'DECIMALS', 'BASE_PER',
-                 'TIME_PER_COLLECT'])
+        assert list(series_key.attrib.keys()) == [
+            "FREQ",
+            "IDBANK",
+            "TITLE",
+            "LAST_UPDATE",
+            "UNIT_MEASURE",
+            "UNIT_MULT",
+            "REF_AREA",
+            "DECIMALS",
+            "BASE_PER",
+            "TIME_PER_COLLECT",
+        ]
 
     def test_freq_in_series_attribute(self, req):
         # Test that we don't have regression on Issues #39 and #41
         # INSEE time series provide the FREQ value as attribute on the series
         # instead of a dimension. This caused a runtime error when writing as
         # pandas dataframe.
-        data_response = sdmx.read_sdmx(
-            SERIES['UNEMPLOYMENT_CAT_A_B_C']['data-fp'])
+        data_response = sdmx.read_sdmx(SERIES["UNEMPLOYMENT_CAT_A_B_C"]["data-fp"])
         sdmx.to_pandas(data_response)

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -1,16 +1,20 @@
 import re
 
+import pytest
+
 import sdmx
 
 from .data import specimen
 
-EXPECTED = {
+EXPECTED = [
     # Structure messages
-    "IPI-2010-A21-structure.xml": """<sdmx.StructureMessage>
+    (
+        "IPI-2010-A21-structure.xml",
+        """<sdmx.StructureMessage>
   <Header>
     id: 'categorisation_1450864290565'
     prepared: '2015-12-23T09:51:30.565Z'
-    receiver: <Agency unknown:>
+    receiver: <Agency unknown>
     sender: <Agency FR1: Institut national de la statistique et des études économiques>
     source: fr: Banque de données macro-économiques
     test: False
@@ -19,49 +23,59 @@ EXPECTED = {
   ConceptScheme (1): CONCEPTS_INSEE
   DataflowDefinition (1): IPI-2010-A21
   DataStructureDefinition (1): IPI-2010-A21""",
-    # This message shows the summarization feature: the DFD list is truncated
-    "dataflow.xml": """<sdmx.StructureMessage>
+    ),
+    (
+        # This message shows the summarization feature: the DFD list is truncated
+        "dataflow.xml",
+        """<sdmx.StructureMessage>
   <Header>
     id: 'dataflow_ENQ-CONJ-TRES-IND-PERSP_1450865196042'
     prepared: '2015-12-23T10:06:36.042Z'
-    receiver: <Agency unknown:>
+    receiver: <Agency unknown>
     sender: <Agency FR1: Institut national de la statistique et des études économiques>
     source: fr: Banque de données macro-économiques
     test: False
   DataflowDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINANCIER ...
   DataStructureDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINAN...""",
-    # Data message
-    "sg-xs.xml": """<sdmx.DataMessage>
+    ),
+    # Data messages
+    (
+        "sg-xs.xml",
+        """<sdmx.DataMessage>
   <Header>
     id: 'Generic'
     prepared: '2010-01-04T16:21:49+01:00'
-    sender: <Agency ECB:>
+    sender: <Agency ECB>
     source: """
-    """
+        """
     test: False
   DataSet (1)
-  dataflow: <DataflowDefinition (missing id):>
+  dataflow: <DataflowDefinition (missing id)>
   observation_dimension: <Dimension CURRENCY>""",
-    # This message has two DataSets:
-    "action-delete.json": """<sdmx.DataMessage>
+    ),
+    (
+        # This message has two DataSets:
+        "action-delete.json",
+        """<sdmx.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
     prepared: '2012-11-29T08:40:26Z'
     sender: <Agency ECB: European Central Bank>
     source: """
-    """
+        """
     test: False
   DataSet (2)
-  dataflow: <DataflowDefinition (missing id):>
+  dataflow: <DataflowDefinition (missing id)>
   observation_dimension: [<Dimension CURRENCY>]""",
-}
+    ),
+]
 
 
-def test_message_repr():
-    for pattern, expected in EXPECTED.items():
-        with specimen(pattern) as f:
-            msg = sdmx.read_sdmx(f)
-        if isinstance(expected, re.Pattern):
-            assert expected.fullmatch(repr(msg))
-        else:
-            assert expected == repr(msg)
+@pytest.mark.parametrize("pattern, expected", EXPECTED, ids=range(len(EXPECTED)))
+def test_message_repr(pattern, expected):
+    with specimen(pattern) as f:
+        msg = sdmx.read_sdmx(f)
+    if isinstance(expected, re.Pattern):
+        assert expected.fullmatch(repr(msg))
+    else:
+        assert expected == repr(msg)

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -35,16 +35,14 @@ EXPECTED = {
   dataflow: <DataflowDefinition: 'STR1'=''>
   observation_dimension: <Dimension: CURRENCY>""",
     # This message has two DataSets:
-    "action-delete.json": re.compile(
-        r"""<sdmx\.DataMessage>
+    "action-delete.json": """<sdmx.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
     prepared: '2012-11-29T08:40:26Z'
     sender: <Item: 'ECB'='European Central Bank'>
-  DataSet \(2\)
-  dataflow: <DataflowDefinition: '\(\d+\)'=''>
-  observation_dimension: \[<Dimension: CURRENCY>\]"""
-    ),
+  DataSet (2)
+  dataflow: <DataflowDefinition: '<missing id>'=''>
+  observation_dimension: [<Dimension: CURRENCY>]""",
 }
 
 

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -10,10 +10,12 @@ EXPECTED = {
   <Header>
     id: 'categorisation_1450864290565'
     prepared: '2015-12-23T09:51:30.565Z'
-    receiver: 'unknown'
-    sender: 'FR1'
+    receiver: <Agency unknown:>
+    sender: <Agency FR1: Institut national de la statistique et des études économiques>
+    source: fr: Banque de données macro-économiques
+    test: False
   CategoryScheme (1): CLASSEMENT_DATAFLOWS
-  Codelist (3): CL_FREQ CL_NAF2_A21 CL_NATURE
+  Codelist (7): CL_FREQ CL_NAF2_A21 CL_NATURE CL_UNIT CL_AREA CL_TIME_C...
   ConceptScheme (1): CONCEPTS_INSEE
   DataflowDefinition (1): IPI-2010-A21
   DataStructureDefinition (1): IPI-2010-A21""",
@@ -22,27 +24,36 @@ EXPECTED = {
   <Header>
     id: 'dataflow_ENQ-CONJ-TRES-IND-PERSP_1450865196042'
     prepared: '2015-12-23T10:06:36.042Z'
-    receiver: 'unknown'
-    sender: 'FR1'
-  DataflowDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINANCIER ...""",
+    receiver: <Agency unknown:>
+    sender: <Agency FR1: Institut national de la statistique et des études économiques>
+    source: fr: Banque de données macro-économiques
+    test: False
+  DataflowDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINANCIER ...
+  DataStructureDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINAN...""",
     # Data message
     "sg-xs.xml": """<sdmx.DataMessage>
   <Header>
     id: 'Generic'
     prepared: '2010-01-04T16:21:49+01:00'
-    sender: 'ECB'
+    sender: <Agency ECB:>
+    source: """
+    """
+    test: False
   DataSet (1)
-  dataflow: <DataflowDefinition: 'STR1'=''>
-  observation_dimension: <Dimension: CURRENCY>""",
+  dataflow: <DataflowDefinition (missing id):>
+  observation_dimension: <Dimension CURRENCY>""",
     # This message has two DataSets:
     "action-delete.json": """<sdmx.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
     prepared: '2012-11-29T08:40:26Z'
-    sender: <Item: 'ECB'='European Central Bank'>
+    sender: <Agency ECB: European Central Bank>
+    source: """
+    """
+    test: False
   DataSet (2)
-  dataflow: <DataflowDefinition: '<missing id>'=''>
-  observation_dimension: [<Dimension: CURRENCY>]""",
+  dataflow: <DataflowDefinition (missing id):>
+  observation_dimension: [<Dimension CURRENCY>]""",
 }
 
 

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -1,5 +1,5 @@
-from operator import itemgetter
 import re
+from operator import itemgetter
 
 import pytest
 

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 import re
 
 import pytest
@@ -71,7 +72,9 @@ EXPECTED = [
 ]
 
 
-@pytest.mark.parametrize("pattern, expected", EXPECTED, ids=range(len(EXPECTED)))
+@pytest.mark.parametrize(
+    "pattern, expected", EXPECTED, ids=list(map(itemgetter(0), EXPECTED))
+)
 def test_message_repr(pattern, expected):
     with specimen(pattern) as f:
         msg = sdmx.read_sdmx(f)

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -4,10 +4,9 @@ import sdmx
 
 from .data import specimen
 
-
 EXPECTED = {
     # Structure messages
-    'IPI-2010-A21-structure.xml': """<sdmx.StructureMessage>
+    "IPI-2010-A21-structure.xml": """<sdmx.StructureMessage>
   <Header>
     id: 'categorisation_1450864290565'
     prepared: '2015-12-23T09:51:30.565Z'
@@ -18,18 +17,16 @@ EXPECTED = {
   ConceptScheme (1): CONCEPTS_INSEE
   DataflowDefinition (1): IPI-2010-A21
   DataStructureDefinition (1): IPI-2010-A21""",
-
     # This message shows the summarization feature: the DFD list is truncated
-    'dataflow.xml': """<sdmx.StructureMessage>
+    "dataflow.xml": """<sdmx.StructureMessage>
   <Header>
     id: 'dataflow_ENQ-CONJ-TRES-IND-PERSP_1450865196042'
     prepared: '2015-12-23T10:06:36.042Z'
     receiver: 'unknown'
     sender: 'FR1'
   DataflowDefinition (663): ACT-TRIM-ANC BPM6-CCAPITAL BPM6-CFINANCIER ...""",
-
     # Data message
-    'sg-xs.xml': """<sdmx.DataMessage>
+    "sg-xs.xml": """<sdmx.DataMessage>
   <Header>
     id: 'Generic'
     prepared: '2010-01-04T16:21:49+01:00'
@@ -37,16 +34,17 @@ EXPECTED = {
   DataSet (1)
   dataflow: <DataflowDefinition: 'STR1'=''>
   observation_dimension: <Dimension: CURRENCY>""",
-
     # This message has two DataSets:
-    'action-delete.json': re.compile(r"""<sdmx\.DataMessage>
+    "action-delete.json": re.compile(
+        r"""<sdmx\.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
     prepared: '2012-11-29T08:40:26Z'
     sender: <Item: 'ECB'='European Central Bank'>
   DataSet \(2\)
   dataflow: <DataflowDefinition: '\(\d+\)'=''>
-  observation_dimension: \[<Dimension: CURRENCY>\]"""),
+  observation_dimension: \[<Dimension: CURRENCY>\]"""
+    ),
 }
 
 

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -1,3 +1,5 @@
+import re
+
 import sdmx
 
 from .data import specimen
@@ -37,14 +39,14 @@ EXPECTED = {
   observation_dimension: <Dimension: CURRENCY>""",
 
     # This message has two DataSets:
-    'action-delete.json': """<sdmx.DataMessage>
+    'action-delete.json': re.compile(r"""<sdmx\.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
     prepared: '2012-11-29T08:40:26Z'
     sender: <Item: 'ECB'='European Central Bank'>
-  DataSet (2)
-  dataflow: <DataflowDefinition: 'None'=''>
-  observation_dimension: [<Dimension: CURRENCY>]""",
+  DataSet \(2\)
+  dataflow: <DataflowDefinition: '\(\d+\)'=''>
+  observation_dimension: \[<Dimension: CURRENCY>\]"""),
 }
 
 
@@ -52,4 +54,7 @@ def test_message_repr():
     for pattern, expected in EXPECTED.items():
         with specimen(pattern) as f:
             msg = sdmx.read_sdmx(f)
-        assert expected == repr(msg)
+        if isinstance(expected, re.Pattern):
+            assert expected.fullmatch(repr(msg))
+        else:
+            assert expected == repr(msg)

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -216,6 +216,9 @@ def test_item():
     with raises(ValueError):
         items[0].get_child("Foo 2")
 
+    # Hierarchical IDs constructed automatically
+    assert items[0].child[0].hierarchical_id == "Bar 2.Foo 0.Foo 1"
+
 
 def test_itemscheme():
     is0 = ItemScheme(id="is0")
@@ -273,7 +276,10 @@ def test_itemscheme():
         is0.setdefault(foo0, id="bar")
 
     is0.setdefault(id="bar1", parent="foo0")
-    is0.setdefault(id="bar1", parent=foo0)
+    bar1 = is0.setdefault(id="bar1", parent=foo0)
+
+    # get_hierarchical()
+    assert is0.get_hierarchical("foo0.bar1") == bar1
 
 
 def test_key():

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -1,29 +1,30 @@
 # TODO test str() and repr() implementations
 
+import pydantic
+from pytest import raises
+
 from sdmx.model import (
     DEFAULT_LOCALE,
     AttributeValue,
-    ContentConstraint,
     ConstraintRole,
     ConstraintRoleType,
+    ContentConstraint,
     CubeRegion,
     DataAttribute,
+    DataflowDefinition,
     DataSet,
     DataStructureDefinition,
-    DataflowDefinition,
     Dimension,
     DimensionDescriptor,
     Item,
     ItemScheme,
     Key,
     Observation,
-    )
-import pydantic
-from pytest import raises
+)
 
 
 def test_contentconstraint():
-    crole = ConstraintRole(role=ConstraintRoleType['allowable'])
+    crole = ConstraintRole(role=ConstraintRoleType["allowable"])
     cr = ContentConstraint(role=crole)
     cr.content = {DataflowDefinition()}
     cr.data_content_region = CubeRegion(included=True, member={})
@@ -32,18 +33,19 @@ def test_contentconstraint():
 def test_dataset():
     # Enumeration values can be used to initialize
     from sdmx.model import ActionType
+
     print(ActionType)
-    DataSet(action=ActionType['information'])
+    DataSet(action=ActionType["information"])
 
 
 def test_datastructuredefinition():
     dsd = DataStructureDefinition()
 
     # Convenience methods
-    da = dsd.attributes.getdefault(id='foo')
+    da = dsd.attributes.getdefault(id="foo")
     assert isinstance(da, DataAttribute)
 
-    d = dsd.dimensions.getdefault(id='baz', order=-1)
+    d = dsd.dimensions.getdefault(id="baz", order=-1)
     assert isinstance(d, Dimension)
 
     # from_keys()
@@ -54,7 +56,7 @@ def test_datastructuredefinition():
 
 def test_dimension():
     # Constructor
-    Dimension(id='CURRENCY', order=0)
+    Dimension(id="CURRENCY", order=0)
 
 
 def test_dimensiondescriptor():
@@ -71,34 +73,33 @@ def test_dimensiondescriptor():
 
 def test_internationalstring():
     # Constructor; the .name attribute is an InternationalString
-    i = Item(id='ECB')
+    i = Item(id="ECB")
 
     # Set and get using the attribute directly
-    i.name.localizations['DE'] = 'Europäische Zentralbank'
-    assert i.name.localizations['DE'] == 'Europäische Zentralbank'
+    i.name.localizations["DE"] = "Europäische Zentralbank"
+    assert i.name.localizations["DE"] == "Europäische Zentralbank"
 
     # Set and get using item convenience
-    i.name['FR'] = 'Banque centrale européenne'
+    i.name["FR"] = "Banque centrale européenne"
     assert len(i.name.localizations) == 2
-    assert i.name['FR'] == 'Banque centrale européenne'
+    assert i.name["FR"] == "Banque centrale européenne"
 
     # repr() gives all localizations
-    assert repr(i.name) == '\n'.join(sorted([
-        'DE: Europäische Zentralbank',
-        'FR: Banque centrale européenne',
-        ]))
+    assert repr(i.name) == "\n".join(
+        sorted(["DE: Europäische Zentralbank", "FR: Banque centrale européenne"])
+    )
 
     # Setting with a string directly sets the value in the default locale
-    i.name = 'European Central Bank'
+    i.name = "European Central Bank"
     assert len(i.name.localizations) == 1
-    assert i.name.localizations[DEFAULT_LOCALE] == 'European Central Bank'
+    assert i.name.localizations[DEFAULT_LOCALE] == "European Central Bank"
 
     # Setting with a (locale, text) tuple
-    i.name = ('FI', 'Euroopan keskuspankki')
+    i.name = ("FI", "Euroopan keskuspankki")
     assert len(i.name.localizations) == 1
 
     # Setting with a dict()
-    i.name = {'IT': 'Banca centrale europea'}
+    i.name = {"IT": "Banca centrale europea"}
     assert len(i.name.localizations) == 1
 
     # Using some other type is an error
@@ -106,59 +107,58 @@ def test_internationalstring():
         i.name = 123
 
     # Same, but in the constructor
-    i2 = Item(id='ECB', name='European Central Bank')
+    i2 = Item(id="ECB", name="European Central Bank")
 
     # str() uses the default locale
-    assert str(i2.name) == 'European Central Bank'
+    assert str(i2.name) == "European Central Bank"
 
     # Creating with name=None raises an exception…
-    with raises(pydantic.ValidationError,
-                match='none is not an allowed value'):
-        Item(id='ECB', name=None)
+    with raises(pydantic.ValidationError, match="none is not an allowed value"):
+        Item(id="ECB", name=None)
 
     # …giving empty dict is equivalent to giving nothing
-    i3 = Item(id='ECB', name={})
-    assert i3.name.localizations == Item(id='ECB').name.localizations
+    i3 = Item(id="ECB", name={})
+    assert i3.name.localizations == Item(id="ECB").name.localizations
 
     # Create with iterable of 2-tuples
-    i4 = Item(id='ECB', name=[
-        ('DE', 'Europäische Zentralbank'),
-        ('FR', 'Banque centrale européenne'),
-    ])
-    assert i4.name['FR'] == 'Banque centrale européenne'
+    i4 = Item(
+        id="ECB",
+        name=[("DE", "Europäische Zentralbank"), ("FR", "Banque centrale européenne")],
+    )
+    assert i4.name["FR"] == "Banque centrale européenne"
 
 
 def test_item():
     # Add a tree of 10 items
     items = []
     for i in range(10):
-        items.append(Item(id='Foo {}'.format(i)))
+        items.append(Item(id="Foo {}".format(i)))
 
         if i > 0:
             items[-1].parent = items[-2]
             items[-2].child.append(items[-1])
 
     # __init__(parent=...)
-    Item(id='Bar 1', parent=items[0])
+    Item(id="Bar 1", parent=items[0])
     assert len(items[0].child) == 2
 
     # __init__(child=)
-    bar2 = Item(id='Bar 2', child=[items[0]])
+    bar2 = Item(id="Bar 2", child=[items[0]])
 
     # __contains__()
     assert items[0] in bar2
     assert items[-1] in items[0]
 
     # get_child()
-    assert items[0].get_child('Foo 1') == items[1]
+    assert items[0].get_child("Foo 1") == items[1]
 
     with raises(ValueError):
-        items[0].get_child('Foo 2')
+        items[0].get_child("Foo 2")
 
 
 def test_itemscheme():
-    is0 = ItemScheme(id='is0')
-    foo0 = Item(id='foo0')
+    is0 = ItemScheme(id="is0")
+    foo0 = Item(id="foo0")
 
     # With a single Item
 
@@ -169,10 +169,10 @@ def test_itemscheme():
     assert is0.foo0 is foo0
 
     # __getitem__
-    assert is0['foo0'] is foo0
+    assert is0["foo0"] is foo0
 
     # __contains__
-    assert 'foo0' in is0
+    assert "foo0" in is0
     assert foo0 in is0
 
     # __len__
@@ -186,10 +186,10 @@ def test_itemscheme():
 
     # With multiple Items
 
-    foo1 = Item(id='foo1')
-    foo2 = Item(id='foo2')
+    foo1 = Item(id="foo1")
+    foo2 = Item(id="foo2")
     items_list = [foo0, foo1, foo2]
-    items_dict = {'foo0': foo0, 'foo1': foo1, 'foo2': foo2}
+    items_dict = {"foo0": foo0, "foo1": foo1, "foo2": foo2}
 
     # set with a non-dict
     is0.items = items_list
@@ -205,19 +205,19 @@ def test_itemscheme():
     assert is0.items == items_dict
 
     # setdefault()
-    bar0 = is0.setdefault(id='bar')
-    assert bar0.id == 'bar'
+    bar0 = is0.setdefault(id="bar")
+    assert bar0.id == "bar"
 
     with raises(ValueError):
-        is0.setdefault(foo0, id='bar')
+        is0.setdefault(foo0, id="bar")
 
-    is0.setdefault(id='bar1', parent='foo0')
-    is0.setdefault(id='bar1', parent=foo0)
+    is0.setdefault(id="bar1", parent="foo0")
+    is0.setdefault(id="bar1", parent=foo0)
 
 
 def test_key():
     # Construct with a dict
-    k1 = Key({'foo': 1, 'bar': 2})
+    k1 = Key({"foo": 1, "bar": 2})
 
     # Construct with kwargs
     k2 = Key(foo=1, bar=2)
@@ -227,7 +227,7 @@ def test_key():
 
     # Doing both is an error
     with raises(ValueError):
-        Key({'foo': 1}, bar=2)
+        Key({"foo": 1}, bar=2)
 
     # __len__
     assert len(k1) == 2
@@ -239,11 +239,11 @@ def test_key():
     assert k1 not in Key(foo=1)
 
     # Set and get using item convenience
-    k1['baz'] = 3  # bare value is converted to a KeyValue
-    assert k1['foo'] == 1
+    k1["baz"] = 3  # bare value is converted to a KeyValue
+    assert k1["foo"] == 1
 
     # __str__
-    assert str(k1) == '(foo=1, bar=2, baz=3)'
+    assert str(k1) == "(foo=1, bar=2, baz=3)"
 
     # copying: returns a new object equal to the old one
     k2 = k1.copy()
@@ -273,26 +273,26 @@ def test_observation():
     obs = Observation()
 
     # Set by item name
-    obs.attached_attribute['TIME_PERIOD'] = 3
+    obs.attached_attribute["TIME_PERIOD"] = 3
     # NB the following does not work; see Observation.attrib()
     # obs.attrib['TIME_PERIOD'] = 3
 
-    obs.attached_attribute['CURRENCY'] = 'USD'
+    obs.attached_attribute["CURRENCY"] = "USD"
 
     # Access by attribute name
     assert obs.attrib.TIME_PERIOD == 3
-    assert obs.attrib.CURRENCY == 'USD'
+    assert obs.attrib.CURRENCY == "USD"
 
     # Access by item index
-    assert obs.attrib[1] == 'USD'
+    assert obs.attrib[1] == "USD"
 
     # Add attributes
-    obs.attached_attribute['FOO'] = '1'
-    obs.attached_attribute['BAR'] = '2'
-    assert obs.attrib.FOO == '1' and obs.attrib['BAR'] == '2'
+    obs.attached_attribute["FOO"] = "1"
+    obs.attached_attribute["BAR"] = "2"
+    assert obs.attrib.FOO == "1" and obs.attrib["BAR"] == "2"
 
     # Using classes
-    da = DataAttribute(id='FOO')
-    av = AttributeValue(value_for=da, value='baz')
+    da = DataAttribute(id="FOO")
+    av = AttributeValue(value_for=da, value="baz")
     obs.attached_attribute[da.id] = av
-    assert obs.attrib[da.id] == 'baz'
+    assert obs.attrib[da.id] == "baz"

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -213,7 +213,7 @@ def test_itemscheme():
     assert len(is0) == 1
 
     # __repr__
-    assert repr(is0) == "<ItemScheme: 'is0', 1 items>"
+    assert repr(is0) == "<ItemScheme is0 (1 items)>"
 
     # __iter__
     assert all(i is foo0 for i in is0)

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -97,8 +97,8 @@ def test_identifiable():
     ia = IdentifiableArtefact()
     assert hash(ia) == id(ia)
 
-    ia = IdentifiableArtefact(id='foo')
-    assert hash(ia) == hash('foo')
+    ia = IdentifiableArtefact(id="foo")
+    assert hash(ia) == hash("foo")
 
     # Subclass is hashable
     ad = AttributeDescriptor()

--- a/sdmx/tests/test_performance.py
+++ b/sdmx/tests/test_performance.py
@@ -1,15 +1,11 @@
 """Speed and memory usage tests."""
-from sdmx.model import (
-    AttributeValue,
-    DataAttribute,
-    DataStructureDefinition,
-    )
+from sdmx.model import AttributeValue, DataAttribute, DataStructureDefinition
 
 
 def test_refcount():
     # Component (subclasses) created outside of a DataStructureDefintion
-    da1 = DataAttribute(id='foo')
-    da2 = DataAttribute(id='foo')
+    da1 = DataAttribute(id="foo")
+    da2 = DataAttribute(id="foo")
 
     assert id(da1) != id(da2)
     assert da1 is not da2
@@ -18,17 +14,17 @@ def test_refcount():
     # to the same object
     dsd = DataStructureDefinition()
 
-    da3 = dsd.attributes.getdefault('foo')
-    da4 = dsd.attributes.getdefault('foo')
+    da3 = dsd.attributes.getdefault("foo")
+    da4 = dsd.attributes.getdefault("foo")
 
     assert id(da3) == id(da4)
     assert da3 is da4
     assert len(dsd.attributes) == 1
 
     # Creating an AttributeValue referencing a DataAttribute outside a DSD
-    av1 = AttributeValue(value='baz', value_for=DataAttribute(id='foo'))
+    av1 = AttributeValue(value="baz", value_for=DataAttribute(id="foo"))
     assert not any([av1.value_for is da for da in (da1, da2, da3)])
 
     # Same, using a DSD
-    av2 = AttributeValue(value='baz', value_for='foo', dsd=dsd)
+    av2 = AttributeValue(value="baz", value_for="foo", dsd=dsd)
     assert av2.value_for is da3

--- a/sdmx/tests/test_performance.py
+++ b/sdmx/tests/test_performance.py
@@ -3,14 +3,14 @@ from sdmx.model import AttributeValue, DataAttribute, DataStructureDefinition
 
 
 def test_refcount():
-    # Component (subclasses) created outside of a DataStructureDefintion
+    # Component (subclasses) created outside of a DataStructureDefinition
     da1 = DataAttribute(id="foo")
     da2 = DataAttribute(id="foo")
 
     assert id(da1) != id(da2)
     assert da1 is not da2
 
-    # Retrieving attributes from a DataStructureDefintion results in references
+    # Retrieving attributes from a DataStructureDefinition results in references
     # to the same object
     dsd = DataStructureDefinition()
 

--- a/sdmx/tests/test_remote.py
+++ b/sdmx/tests/test_remote.py
@@ -13,7 +13,7 @@ def test_session_without_requests_cache():  # pragma: no cover
         Session(cache_name="test")
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_session_init_cache(tmp_path):
     # Instantiate a REST object with cache
     cache_name = tmp_path / "pandasdmx_cache"

--- a/sdmx/tests/test_remote.py
+++ b/sdmx/tests/test_remote.py
@@ -5,22 +5,22 @@ from sdmx.remote import Session
 from . import has_requests_cache
 
 
-@pytest.mark.skipif(has_requests_cache, reason='test without requests_cache')
+@pytest.mark.skipif(has_requests_cache, reason="test without requests_cache")
 def test_session_without_requests_cache():  # pragma: no cover
     # Passing cache= arguments when requests_cache is not installed triggers a
     # warning
     with pytest.warns(RuntimeWarning):
-        Session(cache_name='test')
+        Session(cache_name="test")
 
 
 @pytest.mark.remote_data
 def test_session_init_cache(tmp_path):
     # Instantiate a REST object with cache
-    cache_name = tmp_path / 'pandasdmx_cache'
-    s = Session(cache_name=str(cache_name), backend='sqlite')
+    cache_name = tmp_path / "pandasdmx_cache"
+    s = Session(cache_name=str(cache_name), backend="sqlite")
 
     # Get a resource
-    s.get('https://registry.sdmx.org/ws/rest/dataflow')
+    s.get("https://registry.sdmx.org/ws/rest/dataflow")
 
     # Test for existence of cache file
-    assert cache_name.with_suffix('.sqlite').exists()
+    assert cache_name.with_suffix(".sqlite").exists()

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -6,19 +6,19 @@ def test_list_sources():
     assert len(source_ids) == 14
 
     # Listed alphabetically
-    assert source_ids[0] == 'ABS'
-    assert source_ids[-1] == 'WB'
+    assert source_ids[0] == "ABS"
+    assert source_ids[-1] == "WB"
 
 
 def test_source_support():
     # Implicitly supported endpoint
-    assert sources['ILO'].supports['categoryscheme']
+    assert sources["ILO"].supports["categoryscheme"]
 
     # Specifically unsupported endpoint
-    assert not sources['ESTAT'].supports['categoryscheme']
+    assert not sources["ESTAT"].supports["categoryscheme"]
 
     # Explicitly supported structure-specific data
-    assert sources['INEGI'].supports['structure-specific data']
+    assert sources["INEGI"].supports["structure-specific data"]
 
 
 def test_add_source():
@@ -37,4 +37,4 @@ def test_add_source():
         "url": "https://example.org/sdmx"
         }"""
     add_source(profile2)
-    assert not sources['BAR'].supports['datastructure']
+    assert not sources["BAR"].supports["datastructure"]

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -190,6 +190,7 @@ class TestESTAT(DataSourceTest):
 
         return fixture
 
+    @pytest.mark.network
     def test_xml_footer(self, mock):
         req = Request(self.source_id)
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -127,7 +127,7 @@ class DataSourceTest:
     @pytest.mark.network
     def test_endpoints(self, req, endpoint, args):
         # See pytest_generate_tests() for values of 'endpoint'
-        cache = self._cache_path.with_suffix("." + endpoint)
+        cache = self._cache_path.with_suffix(f".{endpoint}.xml")
         result = req.get(endpoint, tofile=cache, **args)
 
         # For debugging

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -6,6 +6,7 @@ To force the data to be retrieved over the Internet, delete this directory.
 # TODO add a pytest argument for clearing this cache in conftest.py
 import logging
 import os
+from typing import Any, Dict, Type
 
 import sdmx
 from sdmx import Resource
@@ -100,17 +101,17 @@ class DataSourceTest:
     # TODO also test structure-specific data
 
     # Must be one of the IDs in sources.json
-    source_id = None
+    source_id: str
 
     # Mapping of endpoint → Exception subclass.
     # Tests of these endpoints are expected to fail.
-    xfail = {}
+    xfail: Dict[str, Type[Exception]] = {}
 
     # True to xfail if a 503 Error is returned
     tolerate_503 = False
 
     # Keyword arguments for particular endpoints
-    endpoint_args = {}
+    endpoint_args: Dict[str, Dict[str, Any]] = {}
 
     @pytest.fixture
     def req(self):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -18,6 +18,7 @@ from sdmx.exceptions import HTTPError
 from sdmx.source import DataContentType, sources
 
 from .data import BASE_PATH as TEST_DATA_PATH
+from .data import specimen
 
 log = logging.getLogger(__name__)
 
@@ -297,8 +298,11 @@ class TestISTAT(DataSourceTest):
 
         df_id = "47_850"
 
-        # Reported Dataflow query works
-        df = req.dataflow(df_id).dataflow[df_id]
+        # # Reported Dataflow query works
+        # df = req.dataflow(df_id).dataflow[df_id]
+
+        with specimen("47_850-structure") as f:
+            df = sdmx.read_sdmx(f).dataflow[df_id]
 
         # dict() key for the query
         data_key = dict(

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -124,7 +124,7 @@ class DataSourceTest:
             self.source_id, cache_name=str(self._cache_path), backend="sqlite"
         )
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_endpoints(self, req, endpoint, args):
         # See pytest_generate_tests() for values of 'endpoint'
         cache = self._cache_path.with_suffix("." + endpoint)
@@ -198,7 +198,7 @@ class TestESTAT(DataSourceTest):
 
         assert len(msg.data[0].obs) == 43
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_ss_data(self, req):
         """Test a request for structure-specific data.
 
@@ -244,7 +244,7 @@ class TestILO(DataSourceTest):
         "codelist": HTTPError
     }
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_codelist(self, req):
         req.get(
             "codelist",
@@ -259,7 +259,7 @@ class TestILO(DataSourceTest):
 class TestINEGI(DataSourceTest):
     source_id = "INEGI"
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_endpoints(self, req, endpoint, args):
         # SSL certificate verification sometimes fails for this server; works
         # in Google Chrome
@@ -274,7 +274,7 @@ class TestINSEE(DataSourceTest):
 
     tolerate_503 = True
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_endpoints(self, req, endpoint, args):
         # Using the default 'INSEE' agency in the URL gives a response "La
         # syntaxe de la requête est invalide."
@@ -290,7 +290,7 @@ class TestINSEE(DataSourceTest):
 class TestISTAT(DataSourceTest):
     source_id = "ISTAT"
 
-    @pytest.mark.remote_data
+    @pytest.mark.network
     def test_gh_75(self, req):
         """Test of https://github.com/dr-leo/pandaSDMX/pull/75."""
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -8,31 +8,32 @@ import logging
 import os
 from typing import Any, Dict, Type
 
+import pytest
+import requests_mock
+
 import sdmx
 from sdmx import Resource
 from sdmx.api import Request
 from sdmx.exceptions import HTTPError
 from sdmx.source import DataContentType, sources
-import pytest
-import requests_mock
 
 from .data import BASE_PATH as TEST_DATA_PATH
-
 
 log = logging.getLogger(__name__)
 
 
 pytestmark = pytest.mark.skipif(
     # Default value in get() ensures that when *not* on Travis, the tests run
-    condition=os.environ.get('TRAVIS_EVENT_TYPE', 'cron') != 'cron',
+    condition=os.environ.get("TRAVIS_EVENT_TYPE", "cron") != "cron",
     # For development/debugging, uncomment the following to *always* run
     # condition=False,
-    reason="Fragile source tests only run on Travis for 'cron' events.")
+    reason="Fragile source tests only run on Travis for 'cron' events.",
+)
 
 
 def pytest_generate_tests(metafunc):
     """pytest hook for parametrizing tests with 'endpoint' arguments."""
-    if 'endpoint' not in metafunc.fixturenames:
+    if "endpoint" not in metafunc.fixturenames:
         return  # Don't need to parametrize this metafunc
 
     # Arguments to parametrize()
@@ -47,9 +48,8 @@ def pytest_generate_tests(metafunc):
     #      XPASS will reveal when data sources change their support for
     #      endpoints
     mark_unsupported = pytest.mark.xfail(
-        strict=True,
-        reason='Known non-supported endpoint.',
-        raises=NotImplementedError)
+        strict=True, reason="Known non-supported endpoint.", raises=NotImplementedError
+    )
 
     for ep in Resource:
         # Accumulate multiple marks; first takes precedence
@@ -57,8 +57,7 @@ def pytest_generate_tests(metafunc):
 
         # Check if the associated source supports the endpoint
         supported = source.supports[ep]
-        if (source.data_content_type == DataContentType.JSON and
-                ep is not Resource.data):
+        if source.data_content_type == DataContentType.JSON and ep is not Resource.data:
             # SDMX-JSON sources only support data queries
             continue
         elif not supported:
@@ -72,16 +71,18 @@ def pytest_generate_tests(metafunc):
             marks.append(pytest.mark.xfail(strict=True, raises=exc_class))
 
             if not supported:
-                log.info(f'tests for {metafunc.cls.source_id!r} mention '
-                         f'unsupported endpoint {ep.name!r}')
+                log.info(
+                    f"tests for {metafunc.cls.source_id!r} mention "
+                    f"unsupported endpoint {ep.name!r}"
+                )
 
         # Tolerate 503 errors
         if metafunc.cls.tolerate_503:
             marks.append(
                 pytest.mark.xfail(
-                    raises=HTTPError,
-                    reason='503 Server Error: Service Unavailable')
+                    raises=HTTPError, reason="503 Server Error: Service Unavailable"
                 )
+            )
 
         # Get keyword arguments for this endpoint
         args = metafunc.cls.endpoint_args.get(ep.name, dict())
@@ -93,11 +94,12 @@ def pytest_generate_tests(metafunc):
         ids.append(ep.name)
 
     # Run the test function once for each endpoint
-    metafunc.parametrize('endpoint, args', ep_data, ids=ids)
+    metafunc.parametrize("endpoint, args", ep_data, ids=ids)
 
 
 class DataSourceTest:
     """Base class for data source tests."""
+
     # TODO also test structure-specific data
 
     # Must be one of the IDs in sources.json
@@ -116,15 +118,16 @@ class DataSourceTest:
     @pytest.fixture
     def req(self):
         # Use a common cache file for all agency tests
-        (TEST_DATA_PATH / '.cache').mkdir(exist_ok=True)
-        self._cache_path = TEST_DATA_PATH / '.cache' / self.source_id
-        return Request(self.source_id, cache_name=str(self._cache_path),
-                       backend='sqlite')
+        (TEST_DATA_PATH / ".cache").mkdir(exist_ok=True)
+        self._cache_path = TEST_DATA_PATH / ".cache" / self.source_id
+        return Request(
+            self.source_id, cache_name=str(self._cache_path), backend="sqlite"
+        )
 
     @pytest.mark.remote_data
     def test_endpoints(self, req, endpoint, args):
         # See pytest_generate_tests() for values of 'endpoint'
-        cache = self._cache_path.with_suffix('.' + endpoint)
+        cache = self._cache_path.with_suffix("." + endpoint)
         result = req.get(endpoint, tofile=cache, **args)
 
         # For debugging
@@ -137,46 +140,44 @@ class DataSourceTest:
 
 
 class TestABS(DataSourceTest):
-    source_id = 'ABS'
+    source_id = "ABS"
 
 
 class TestECB(DataSourceTest):
-    source_id = 'ECB'
+    source_id = "ECB"
     xfail = {
         # 404 Client Error: Not Found
-        'provisionagreement': HTTPError,
-        }
+        "provisionagreement": HTTPError
+    }
 
 
 # Data for requests_mock; see TestESTAT.mock()
 estat_mock = {
-    ('http://ec.europa.eu/eurostat/SDMX/diss-web/rest/data/nama_10_gdp/'
-     '..B1GQ+P3.'): {
-        'body': TEST_DATA_PATH / 'ESTAT' / 'footer2.xml',
-        'headers': {
-            'Content-Type':
-                'application/vnd.sdmx.genericdata+xml; version=2.1',
-            },
+    (
+        "http://ec.europa.eu/eurostat/SDMX/diss-web/rest/data/nama_10_gdp/" "..B1GQ+P3."
+    ): {
+        "body": TEST_DATA_PATH / "ESTAT" / "footer2.xml",
+        "headers": {
+            "Content-Type": "application/vnd.sdmx.genericdata+xml; version=2.1"
         },
-    'http://ec.europa.eu/eurostat/SDMX/diss-web/file/7JUdWyAy4fmjBSWT': {
+    },
+    "http://ec.europa.eu/eurostat/SDMX/diss-web/file/7JUdWyAy4fmjBSWT": {
         # This file is a trimmed version of the actual response for the above
         # query
-        'body': TEST_DATA_PATH / 'ESTAT' / 'footer2.zip',
-        'headers': {
-            'Content-Type': 'application/octet-stream',
-            },
-        },
-    }
+        "body": TEST_DATA_PATH / "ESTAT" / "footer2.zip",
+        "headers": {"Content-Type": "application/octet-stream"},
+    },
+}
 
 
 class TestESTAT(DataSourceTest):
-    source_id = 'ESTAT'
+    source_id = "ESTAT"
     xfail = {
         # 404 Client Error: Not Found
         # NOTE the ESTAT service does not give a general response that contains
         #      all datastructures; this is really more of a 501.
-        'datastructure': HTTPError,
-        }
+        "datastructure": HTTPError
+    }
 
     @pytest.fixture
     def mock(self):
@@ -184,7 +185,7 @@ class TestESTAT(DataSourceTest):
         fixture = requests_mock.Mocker()
         for url, args in estat_mock.items():
             # str() here is for Python 3.5 compatibility
-            args['body'] = open(str(args['body']), 'rb')
+            args["body"] = open(str(args["body"]), "rb")
             fixture.get(url, **args)
 
         return fixture
@@ -193,8 +194,7 @@ class TestESTAT(DataSourceTest):
         req = Request(self.source_id)
 
         with mock:
-            msg = req.get(url=list(estat_mock.keys())[0],
-                          get_footer_url=(1, 1))
+            msg = req.get(url=list(estat_mock.keys())[0], get_footer_url=(1, 1))
 
         assert len(msg.data[0].obs) == 43
 
@@ -205,7 +205,7 @@ class TestESTAT(DataSourceTest):
         Examples from:
         https://ec.europa.eu/eurostat/web/sdmx-web-services/example-queries
         """
-        df_id = 'nama_10_gdp'
+        df_id = "nama_10_gdp"
         args = dict(resource_id=df_id)
 
         # Query for the DSD
@@ -220,38 +220,44 @@ class TestESTAT(DataSourceTest):
         assert not dsd.is_external_reference
 
         # Example query, using the DSD already retrieved
-        args.update(dict(
-            key=dict(UNIT=['CP_MEUR'], NA_ITEM=['B1GQ'], GEO=['LU']),
-            params={'startPeriod': '2012', 'endPeriod': '2015'},
-            dsd=dsd,
-            # commented: for debugging
-            # tofile='temp.xml',
-        ))
+        args.update(
+            dict(
+                key=dict(UNIT=["CP_MEUR"], NA_ITEM=["B1GQ"], GEO=["LU"]),
+                params={"startPeriod": "2012", "endPeriod": "2015"},
+                dsd=dsd,
+                # commented: for debugging
+                # tofile='temp.xml',
+            )
+        )
         req.data(**args)
 
 
 class TestIMF(DataSourceTest):
-    source_id = 'IMF'
+    source_id = "IMF"
 
 
 class TestILO(DataSourceTest):
-    source_id = 'ILO'
+    source_id = "ILO"
 
     xfail = {
         # 413 Client Error: Request Entity Too Large
-        'codelist': HTTPError,
-        }
+        "codelist": HTTPError
+    }
 
     @pytest.mark.remote_data
     def test_codelist(self, req):
-        req.get('codelist', 'CL_ECO',
-                tofile=self._cache_path.with_suffix('.' + 'codelist-CL_ECO'))
+        req.get(
+            "codelist",
+            "CL_ECO",
+            tofile=self._cache_path.with_suffix("." + "codelist-CL_ECO"),
+        )
 
 
-@pytest.mark.xfail(reason='500 Server Error returned for all requests.',
-                   raises=HTTPError)
+@pytest.mark.xfail(
+    reason="500 Server Error returned for all requests.", raises=HTTPError
+)
 class TestINEGI(DataSourceTest):
-    source_id = 'INEGI'
+    source_id = "INEGI"
 
     @pytest.mark.remote_data
     def test_endpoints(self, req, endpoint, args):
@@ -264,7 +270,7 @@ class TestINEGI(DataSourceTest):
 
 
 class TestINSEE(DataSourceTest):
-    source_id = 'INSEE'
+    source_id = "INSEE"
 
     tolerate_503 = True
 
@@ -272,85 +278,87 @@ class TestINSEE(DataSourceTest):
     def test_endpoints(self, req, endpoint, args):
         # Using the default 'INSEE' agency in the URL gives a response "La
         # syntaxe de la requête est invalide."
-        req.get(endpoint, provider='all', **args,
-                tofile=self._cache_path.with_suffix('.' + endpoint))
+        req.get(
+            endpoint,
+            provider="all",
+            **args,
+            tofile=self._cache_path.with_suffix("." + endpoint),
+        )
 
 
-@pytest.mark.xfail(reason='Service is currently unavailable.',
-                   raises=HTTPError)
+@pytest.mark.xfail(reason="Service is currently unavailable.", raises=HTTPError)
 class TestISTAT(DataSourceTest):
-    source_id = 'ISTAT'
+    source_id = "ISTAT"
 
     @pytest.mark.remote_data
     def test_gh_75(self, req):
         """Test of https://github.com/dr-leo/pandaSDMX/pull/75."""
 
-        df_id = '47_850'
+        df_id = "47_850"
 
         # Reported Dataflow query works
         df = req.dataflow(df_id).dataflow[df_id]
 
         # dict() key for the query
         data_key = dict(
-            FREQ=['A'],
-            ITTER107=['001001'],
-            SETTITOLARE=['1'],
-            TIPO_DATO=['AUTP'],
-            TIPO_GESTIONE=['ALL'],
-            TIPSERVSOC=['ALL'],
+            FREQ=["A"],
+            ITTER107=["001001"],
+            SETTITOLARE=["1"],
+            TIPO_DATO=["AUTP"],
+            TIPO_GESTIONE=["ALL"],
+            TIPSERVSOC=["ALL"],
         )
 
         # Dimension components are in the correct order
-        assert [dim.id for dim in df.structure.dimensions.components] == \
-            list(data_key.keys()) + ['TIME_PERIOD']
+        assert [dim.id for dim in df.structure.dimensions.components] == list(
+            data_key.keys()
+        ) + ["TIME_PERIOD"]
 
         # Reported data query works
-        req.data(df_id, key='A.001001+001002.1.AUTP.ALL.ALL')
+        req.data(df_id, key="A.001001+001002.1.AUTP.ALL.ALL")
 
         # Use a dict() key to force Request to make a sub-query for the DSD
         req.data(df_id, key=data_key)
 
 
 class TestNB(DataSourceTest):
-    source_id = 'NB'
+    source_id = "NB"
     # This source returns a valid SDMX Error message (100 No Results Found)
     # for the 'categoryscheme' endpoint.
 
 
 class TestOECD(DataSourceTest):
-    source_id = 'OECD'
+    source_id = "OECD"
 
     endpoint_args = {
-        'data': dict(
-            resource_id='ITF_GOODS_TRANSPORT',
-            key='.T-CONT-RL-TEU+T-CONT-RL-TON',
-        ),
+        "data": dict(
+            resource_id="ITF_GOODS_TRANSPORT", key=".T-CONT-RL-TEU+T-CONT-RL-TON"
+        )
     }
 
 
 class TestSGR(DataSourceTest):
-    source_id = 'SGR'
+    source_id = "SGR"
 
 
 class TestUNESCO(DataSourceTest):
-    source_id = 'UNESCO'
+    source_id = "UNESCO"
     xfail = {
         # Requires registration
-        'categoryscheme': HTTPError,
-        'codelist': HTTPError,
-        'conceptscheme': HTTPError,
-        'dataflow': HTTPError,
-        'provisionagreement': HTTPError,
-
+        "categoryscheme": HTTPError,
+        "codelist": HTTPError,
+        "conceptscheme": HTTPError,
+        "dataflow": HTTPError,
+        "provisionagreement": HTTPError,
         # Because 'supports_series_keys_only' was set
         # TODO check
         # 'datastructure': NotImplementedError,
-        }
+    }
 
 
 class TestUNSD(DataSourceTest):
-    source_id = 'UNSD'
+    source_id = "UNSD"
 
 
 class TestWB(DataSourceTest):
-    source_id = 'WB'
+    source_id = "WB"

--- a/sdmx/tests/test_util.py
+++ b/sdmx/tests/test_util.py
@@ -1,25 +1,26 @@
-from sdmx.util import BaseModel, DictLike, validate_dictlike
 import pydantic
-from pydantic import StrictStr
 import pytest
+from pydantic import StrictStr
+
+from sdmx.util import BaseModel, DictLike, validate_dictlike
 
 
 def test_dictlike():
     dl = DictLike()
 
     # Set by item name
-    dl['TIME_PERIOD'] = 3
-    dl['CURRENCY'] = 'USD'
+    dl["TIME_PERIOD"] = 3
+    dl["CURRENCY"] = "USD"
 
     # Access by attribute name
     assert dl.TIME_PERIOD == 3
 
     # Access by item index
-    assert dl[1] == 'USD'
+    assert dl[1] == "USD"
 
     # Access beyond index
     with pytest.raises(KeyError):
-        dl['FOO']
+        dl["FOO"]
 
     with pytest.raises(IndexError):
         dl[2]
@@ -29,7 +30,7 @@ def test_dictlike():
 
 
 def test_dictlike_anno():
-    @validate_dictlike('items')
+    @validate_dictlike("items")
     class Foo(BaseModel):
         items: DictLike[StrictStr, int] = DictLike()
 
@@ -41,20 +42,20 @@ def test_dictlike_anno():
     assert type(f.items) == DictLike
 
     # Can be set with dict()
-    f.items = {'a': 1, 'b': 2}
+    f.items = {"a": 1, "b": 2}
     assert type(f.items) == DictLike
 
     # Type checking on creation
     with pytest.raises(pydantic.ValidationError):
-        f = Foo(items={1: 'a'})
+        f = Foo(items={1: "a"})
 
     # Type checking on assignment
     f = Foo()
     with pytest.raises(pydantic.ValidationError):
-        f.items = {1: 'a'}
+        f.items = {1: "a"}
 
     # Type checking on setting elements
-    f = Foo(items={'a': 1})
+    f = Foo(items={"a": 1})
     with pytest.raises(pydantic.ValidationError):
         f.items[123] = 456
 
@@ -65,6 +66,6 @@ def test_dictlike_anno():
     #     f.items[123] = 456
 
     # Use validate_dictlike() twice
-    @validate_dictlike('elems')
+    @validate_dictlike("elems")
     class Bar(BaseModel):
         elems: DictLike[StrictStr, float] = DictLike()

--- a/sdmx/tests/writer/conftest.py
+++ b/sdmx/tests/writer/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sdmx.message import StructureMessage
 from sdmx.model import Agency, Annotation, Code, Codelist
 
@@ -6,36 +7,25 @@ from sdmx.model import Agency, Annotation, Code, Codelist
 @pytest.fixture
 def codelist():
     """A Codelist for writer testing."""
-    ECB = Agency(id='ECB')
+    ECB = Agency(id="ECB")
 
     cl = Codelist(
-        id='CL_COLLECTION',
-        version='1.0',
+        id="CL_COLLECTION",
+        version="1.0",
         is_final=False,
         is_external_reference=False,
         maintainer=ECB,
-        name={'en': 'Collection indicator code list'},
+        name={"en": "Collection indicator code list"},
     )
 
-    cl.items['A'] = Code(
-        id='A',
-        name={'en': "Average of observations through period"},
-    )
-    cl.items['B'] = Code(
-        id='B',
-        name={'en': 'Beginning of period'},
-    )
-    cl.items['B1'] = Code(
-        id='B1',
-        name={'en': 'Child code of B'},
-    )
-    cl.items['B'].append_child(cl.items['B1'])
+    cl.items["A"] = Code(id="A", name={"en": "Average of observations through period"})
+    cl.items["B"] = Code(id="B", name={"en": "Beginning of period"})
+    cl.items["B1"] = Code(id="B1", name={"en": "Child code of B"})
+    cl.items["B"].append_child(cl.items["B1"])
 
-    cl.items['A'].annotations.append(Annotation(
-        id='A1',
-        type='NOTE',
-        text={'en': 'Text annotation on Code A.'},
-    ))
+    cl.items["A"].annotations.append(
+        Annotation(id="A1", type="NOTE", text={"en": "Text annotation on Code A."})
+    )
 
     return cl
 

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -5,51 +5,48 @@ from pytest import raises
 
 import sdmx
 from sdmx.model import TimeDimension
-
 from sdmx.tests import assert_pd_equal
 from sdmx.tests.data import expected_data, specimen, test_files
 
-
 # file name → (exception raised, exception message, comment/reason)
-ssds = ('Reading StructureSpecificDataSet does not distinguish between attrs '
-        'and dimension values.')
+ssds = (
+    "Reading StructureSpecificDataSet does not distinguish between attrs "
+    "and dimension values."
+)
 
 file_marks = {
-    'exr-action-delete.json': (
+    "exr-action-delete.json": (
         AssertionError,
         "Expected type <class 'pandas.core.frame.DataFrame'>, found <class "
         " 'list'> instead",
-        'Message contains two DataSets; test infrastructure currently handles '
-        'only messages with a single DataSet.'),
-    'ECB/EXR/ng-ts-ss.xml':
-        (AssertionError, 'Series.index are different', ssds),
-    'ECB/EXR/ng-flat-ss.xml':
-        (AssertionError, 'Series.index are different', ssds),
-    'ECB/EXR/ng-xs-ss.xml':
-        (AssertionError, 'Series.index are different', ssds),
-    'ECB/EXR/ng-ts-gf-ss.xml':
-        (AssertionError, 'Series.index are different', ssds),
-    }
+        "Message contains two DataSets; test infrastructure currently handles "
+        "only messages with a single DataSet.",
+    ),
+    "ECB/EXR/ng-ts-ss.xml": (AssertionError, "Series.index are different", ssds),
+    "ECB/EXR/ng-flat-ss.xml": (AssertionError, "Series.index are different", ssds),
+    "ECB/EXR/ng-xs-ss.xml": (AssertionError, "Series.index are different", ssds),
+    "ECB/EXR/ng-ts-gf-ss.xml": (AssertionError, "Series.index are different", ssds),
+}
 
 
 def pytest_generate_tests(metafunc):
-    if 'data_path' in metafunc.fixturenames:
+    if "data_path" in metafunc.fixturenames:
         params = []
-        tf = test_files(kind='data')
-        for value, id in zip(tf['argvalues'], tf['ids']):
+        tf = test_files(kind="data")
+        for value, id in zip(tf["argvalues"], tf["ids"]):
             kwargs = dict(id=id)
             for cond, info in file_marks.items():
                 if cond in str(value):
-                    kwargs['marks'] = pytest.mark.skip(reason=info[2])
+                    kwargs["marks"] = pytest.mark.skip(reason=info[2])
                     break
 
             params.append(pytest.param(value, **kwargs))
 
-        metafunc.parametrize('data_path', params)
+        metafunc.parametrize("data_path", params)
 
 
 def test_write_data_arguments():
-    msg = sdmx.read_sdmx(test_files(kind='data')['argvalues'][0])
+    msg = sdmx.read_sdmx(test_files(kind="data")["argvalues"][0])
 
     # Attributes must be a string
     with raises(TypeError):
@@ -57,7 +54,7 @@ def test_write_data_arguments():
 
     # Attributes must contain only 'dgso'
     with raises(ValueError):
-        sdmx.to_pandas(msg, attributes='foobarbaz')
+        sdmx.to_pandas(msg, attributes="foobarbaz")
 
 
 def test_write_data(data_path):
@@ -67,36 +64,36 @@ def test_write_data(data_path):
 
     expected = expected_data(data_path)
     if expected is not None:
-        print(expected, result, sep='\n')
+        print(expected, result, sep="\n")
     assert_pd_equal(expected, result)
 
     # TODO incomplete
     assert isinstance(result, (pd.Series, pd.DataFrame, list)), type(result)
 
 
-@pytest.mark.parametrize('path', **test_files(kind='data'))
+@pytest.mark.parametrize("path", **test_files(kind="data"))
 def test_write_data_attributes(path):
     msg = sdmx.read_sdmx(path)
 
-    result = sdmx.to_pandas(msg, attributes='osgd')
+    result = sdmx.to_pandas(msg, attributes="osgd")
     # TODO incomplete
     assert isinstance(result, (pd.Series, pd.DataFrame, list)), type(result)
 
 
 def test_write_agencyscheme():
     # Convert an agency scheme
-    with specimen('ECB/orgscheme.xml') as f:
+    with specimen("ECB/orgscheme.xml") as f:
         msg = sdmx.read_sdmx(f)
         data = sdmx.to_pandas(msg)
 
-    assert data['organisation_scheme']['AGENCIES']['ESTAT'] == 'Eurostat'
+    assert data["organisation_scheme"]["AGENCIES"]["ESTAT"] == "Eurostat"
 
     # to_pandas only returns keys for non-empty attributes of StructureMessage
     # https://github.com/dr-leo/pandaSDMX/issues/90
-    assert set(data.keys()) == {'organisation_scheme'}
+    assert set(data.keys()) == {"organisation_scheme"}
 
     # Attribute access works
-    assert data.organisation_scheme.AGENCIES.ESTAT == 'Eurostat'
+    assert data.organisation_scheme.AGENCIES.ESTAT == "Eurostat"
 
     with pytest.raises(AttributeError):
         data.codelist
@@ -107,115 +104,122 @@ def test_write_agencyscheme():
 
 
 def test_write_categoryscheme():
-    with specimen('IPI-2010-A21-structure.xml') as f:
+    with specimen("IPI-2010-A21-structure.xml") as f:
         msg = sdmx.read_sdmx(f)
         print(msg.category_scheme)
         data = sdmx.to_pandas(msg)
 
-    cs = data['category_scheme']['CLASSEMENT_DATAFLOWS']
+    cs = data["category_scheme"]["CLASSEMENT_DATAFLOWS"]
 
-    assert (cs.loc['COMPTA-NAT', 'name']
-            == 'National accounts (GDP, consumption...)')
+    assert cs.loc["COMPTA-NAT", "name"] == "National accounts (GDP, consumption...)"
 
     # Children appear
-    assert cs.loc['CNA-PIB-2005', 'parent'] == 'CNA-PIB'
+    assert cs.loc["CNA-PIB-2005", "parent"] == "CNA-PIB"
 
 
 def test_write_codelist():
     # Retrieve codelists from a test specimen and convert to pandas
-    with specimen('common-structure.xml') as f:
+    with specimen("common-structure.xml") as f:
         dsd_common = sdmx.read_sdmx(f)
-    codelists = sdmx.to_pandas(dsd_common)['codelist']
+    codelists = sdmx.to_pandas(dsd_common)["codelist"]
 
     # File contains 5 code lists
     assert len(codelists) == 5
 
     # Code lists have expected number of items
-    assert len(codelists['CL_FREQ']) == 8
+    assert len(codelists["CL_FREQ"]) == 8
 
     # Items names can be retrieved by ID
-    freq = codelists['CL_FREQ']
-    assert freq['A'] == 'Annual'
+    freq = codelists["CL_FREQ"]
+    assert freq["A"] == "Annual"
 
     # Non-hierarchical code list has a string name
-    assert freq.name == 'Code list for Frequency (FREQ)'
+    assert freq.name == "Code list for Frequency (FREQ)"
 
     # Hierarchical code list
-    with specimen('codelist_partial.xml') as f:
+    with specimen("codelist_partial.xml") as f:
         msg = sdmx.read_sdmx(f)
 
     # Convert single codelist
-    CL_AREA = sdmx.to_pandas(msg.codelist['CL_AREA'])
+    CL_AREA = sdmx.to_pandas(msg.codelist["CL_AREA"])
 
     # Hierichical list has a 'parent' column; parent of Africa is the World
-    assert CL_AREA.loc['002', 'parent'] == '001'
+    assert CL_AREA.loc["002", "parent"] == "001"
 
     # Pandas features can be used to merge parent names
-    area_hierarchy = pd.merge(CL_AREA, CL_AREA,
-                              how='left', left_on='parent', right_index=True,
-                              suffixes=('', '_parent'))
-    assert area_hierarchy.loc['002', 'name_parent'] == 'World'
+    area_hierarchy = pd.merge(
+        CL_AREA,
+        CL_AREA,
+        how="left",
+        left_on="parent",
+        right_index=True,
+        suffixes=("", "_parent"),
+    )
+    assert area_hierarchy.loc["002", "name_parent"] == "World"
 
 
 def test_write_conceptscheme():
-    with specimen('common-structure.xml') as f:
+    with specimen("common-structure.xml") as f:
         msg = sdmx.read_sdmx(f)
         data = sdmx.to_pandas(msg)
 
-    cdc = data['concept_scheme']['CROSS_DOMAIN_CONCEPTS']
-    assert cdc.loc['UNIT_MEASURE', 'name'] == 'Unit of Measure'
+    cdc = data["concept_scheme"]["CROSS_DOMAIN_CONCEPTS"]
+    assert cdc.loc["UNIT_MEASURE", "name"] == "Unit of Measure"
 
 
 def test_write_dataflow():
     # Read the INSEE dataflow definition
-    with specimen('INSEE/dataflow') as f:
+    with specimen("INSEE/dataflow") as f:
         msg = sdmx.read_sdmx(f)
 
     # Convert to pandas
-    result = sdmx.to_pandas(msg, include='dataflow')
+    result = sdmx.to_pandas(msg, include="dataflow")
 
     # Number of Dataflows described in the file
-    assert len(result['dataflow']) == 663
+    assert len(result["dataflow"]) == 663
 
     # ID and names of first Dataflows
-    mbop = 'Monthly Balance of Payments - '
-    expected = pd.Series({
-        'ACT-TRIM-ANC': 'Activity by sex and age - Quarterly series',
-        'BPM6-CCAPITAL': '{}Capital account'.format(mbop),
-        'BPM6-CFINANCIER': '{}Financial account'.format(mbop),
-        'BPM6-CTRANSACTION': '{}Current transactions account'.format(mbop),
-        'BPM6-TOTAL': '{}Overall total and main headings'.format(mbop),
-        })
-    assert_pd_equal(result['dataflow'].head(), expected)
+    mbop = "Monthly Balance of Payments - "
+    expected = pd.Series(
+        {
+            "ACT-TRIM-ANC": "Activity by sex and age - Quarterly series",
+            "BPM6-CCAPITAL": "{}Capital account".format(mbop),
+            "BPM6-CFINANCIER": "{}Financial account".format(mbop),
+            "BPM6-CTRANSACTION": "{}Current transactions account".format(mbop),
+            "BPM6-TOTAL": "{}Overall total and main headings".format(mbop),
+        }
+    )
+    assert_pd_equal(result["dataflow"].head(), expected)
 
 
 def test_write_dataset_datetime():
     """Test datetime arguments to write_dataset()."""
     # Load structure
-    with specimen('IPI-2010-A21-structure.xml') as f:
-        dsd = sdmx.read_sdmx(f).structure['IPI-2010-A21']
-        TIME_PERIOD = dsd.dimensions.get('TIME_PERIOD')
-        FREQ = dsd.dimensions.get('FREQ')
+    with specimen("IPI-2010-A21-structure.xml") as f:
+        dsd = sdmx.read_sdmx(f).structure["IPI-2010-A21"]
+        TIME_PERIOD = dsd.dimensions.get("TIME_PERIOD")
+        FREQ = dsd.dimensions.get("FREQ")
 
     assert isinstance(TIME_PERIOD, TimeDimension)
 
     # Load data, two ways
-    with specimen('IPI-2010-A21.xml') as f:
+    with specimen("IPI-2010-A21.xml") as f:
         msg = sdmx.read_sdmx(f, dsd=dsd)
         ds = msg.data[0]
-    with specimen('IPI-2010-A21.xml') as f:
+    with specimen("IPI-2010-A21.xml") as f:
         msg_no_structure = sdmx.read_sdmx(f)
 
-    other_dims = list(filter(lambda n: n != 'TIME_PERIOD',
-                             [d.id for d in dsd.dimensions.components]))
+    other_dims = list(
+        filter(lambda n: n != "TIME_PERIOD", [d.id for d in dsd.dimensions.components])
+    )
 
     def expected(df, axis=0, cls=pd.DatetimeIndex):
-        axes = ['index', 'columns'] if axis else ['columns', 'index']
+        axes = ["index", "columns"] if axis else ["columns", "index"]
         assert getattr(df, axes[0]).names == other_dims
         assert isinstance(getattr(df, axes[1]), cls)
 
     # Write with datetime=str
-    df = sdmx.to_pandas(ds, datetime='TIME_PERIOD')
+    df = sdmx.to_pandas(ds, datetime="TIME_PERIOD")
     expected(df)
 
     # Write with datetime=Dimension instance
@@ -224,9 +228,9 @@ def test_write_dataset_datetime():
 
     # Write with datetime=True fails because the data message contains no
     # actual structure information
-    with pytest.raises(ValueError, match=r'no TimeDimension in \[.*\]'):
+    with pytest.raises(ValueError, match=r"no TimeDimension in \[.*\]"):
         sdmx.to_pandas(msg_no_structure, datetime=True)
-    with pytest.raises(ValueError, match=r'no TimeDimension in \[.*\]'):
+    with pytest.raises(ValueError, match=r"no TimeDimension in \[.*\]"):
         sdmx.to_pandas(msg_no_structure.data[0], datetime=True)
 
     # DataMessage parsed with a DSD allows write_dataset to infer the
@@ -238,7 +242,7 @@ def test_write_dataset_datetime():
     expected(df)
 
     # As above, with axis=1
-    df = sdmx.to_pandas(ds, datetime=dict(dim='TIME_PERIOD', axis=1))
+    df = sdmx.to_pandas(ds, datetime=dict(dim="TIME_PERIOD", axis=1))
     expected(df, axis=1)
     df = sdmx.to_pandas(ds, datetime=dict(dim=TIME_PERIOD, axis=1))
     expected(df, axis=1)
@@ -249,29 +253,31 @@ def test_write_dataset_datetime():
     expected(df, axis=1)
 
     # Write with freq='M' works
-    df = sdmx.to_pandas(ds, datetime=dict(dim='TIME_PERIOD', freq='M'))
+    df = sdmx.to_pandas(ds, datetime=dict(dim="TIME_PERIOD", freq="M"))
     expected(df, cls=pd.PeriodIndex)
 
     # Write with freq='A' works
-    df = sdmx.to_pandas(ds, datetime=dict(dim='TIME_PERIOD', freq='A'))
+    df = sdmx.to_pandas(ds, datetime=dict(dim="TIME_PERIOD", freq="A"))
     expected(df, cls=pd.PeriodIndex)
     # …but the index is not unique, because month information was discarded
     assert not df.index.is_unique
 
     # Write specifying the FREQ dimension by name fails
-    with pytest.raises(ValueError, match='cannot convert to PeriodIndex with '
-                       r"non-unique freq=\['A', 'M'\]"):
-        sdmx.to_pandas(ds, datetime=dict(dim='TIME_PERIOD', freq='FREQ'))
+    with pytest.raises(
+        ValueError,
+        match="cannot convert to PeriodIndex with " r"non-unique freq=\['A', 'M'\]",
+    ):
+        sdmx.to_pandas(ds, datetime=dict(dim="TIME_PERIOD", freq="FREQ"))
 
     # Remove non-monthly obs
     # TODO use a constraint, when this is supported
-    ds.obs = list(filter(lambda o: o.key.FREQ != 'A', ds.obs))
+    ds.obs = list(filter(lambda o: o.key.FREQ != "A", ds.obs))
 
     # Now specifying the dimension by name works
-    df = sdmx.to_pandas(ds, datetime=dict(dim='TIME_PERIOD', freq='FREQ'))
+    df = sdmx.to_pandas(ds, datetime=dict(dim="TIME_PERIOD", freq="FREQ"))
 
     # and FREQ is no longer in the columns index
-    other_dims.pop(other_dims.index('FREQ'))
+    other_dims.pop(other_dims.index("FREQ"))
     expected(df, cls=pd.PeriodIndex)
 
     # Specifying a Dimension works
@@ -279,19 +285,19 @@ def test_write_dataset_datetime():
     expected(df, cls=pd.PeriodIndex)
 
     # As above, using DSD attached to the DataMessage
-    df = sdmx.to_pandas(msg, datetime=dict(dim=TIME_PERIOD, freq='FREQ'))
+    df = sdmx.to_pandas(msg, datetime=dict(dim=TIME_PERIOD, freq="FREQ"))
     expected(df, cls=pd.PeriodIndex)
 
     # Invalid arguments
-    with pytest.raises(ValueError, match='X'):
-        sdmx.to_pandas(msg, datetime=dict(dim=TIME_PERIOD, freq='X'))
-    with pytest.raises(ValueError, match='foo'):
-        sdmx.to_pandas(ds, datetime=dict(foo='bar'))
-    with pytest.raises(ValueError, match='43'):
+    with pytest.raises(ValueError, match="X"):
+        sdmx.to_pandas(msg, datetime=dict(dim=TIME_PERIOD, freq="X"))
+    with pytest.raises(ValueError, match="foo"):
+        sdmx.to_pandas(ds, datetime=dict(foo="bar"))
+    with pytest.raises(ValueError, match="43"):
         sdmx.to_pandas(ds, datetime=43)
 
 
-@pytest.mark.parametrize('path', **test_files(kind='structure'))
+@pytest.mark.parametrize("path", **test_files(kind="structure"))
 def test_writer_structure(path):
     msg = sdmx.read_sdmx(path)
 
@@ -303,7 +309,7 @@ def test_writer_structure(path):
 @pytest.mark.remote_data
 def test_write_constraint():
     """'constraint' argument to writer.write_dataset."""
-    with specimen('ng-ts.xml') as f:
+    with specimen("ng-ts.xml") as f:
         msg = sdmx.read_sdmx(f)
 
     # Fetch the message's DSD
@@ -311,21 +317,21 @@ def test_write_constraint():
     # NB the speciment included in tests/data has 'ECB_EXR_NG' as the
     #    data structure ID; but a query against the web service gives
     #    'ECB_EXR1' for the same data structure.
-    id = 'ECB_EXR1'
-    dsd = sdmx.Request(msg.structure.maintainer.id) \
-              .get('datastructure', id) \
-              .structure[id]
+    id = "ECB_EXR1"
+    dsd = (
+        sdmx.Request(msg.structure.maintainer.id).get("datastructure", id).structure[id]
+    )
 
     # Create a ContentConstraint
-    cc = dsd.make_constraint({'CURRENCY': 'JPY+USD'})
+    cc = dsd.make_constraint({"CURRENCY": "JPY+USD"})
 
     # Write the message without constraint
     s1 = sdmx.to_pandas(msg)
     assert len(s1) == 12
-    assert set(s1.index.to_frame()['CURRENCY']) == {'CHF', 'GBP', 'JPY', 'USD'}
+    assert set(s1.index.to_frame()["CURRENCY"]) == {"CHF", "GBP", "JPY", "USD"}
 
     # Writing using constraint produces a fewer items; only those matching the
     # constraint
     s2 = sdmx.to_pandas(msg, constraint=cc)
     assert len(s2) == 6
-    assert set(s2.index.to_frame()['CURRENCY']) == {'JPY', 'USD'}
+    assert set(s2.index.to_frame()["CURRENCY"]) == {"JPY", "USD"}

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -306,7 +306,7 @@ def test_writer_structure(path):
     # TODO test contents
 
 
-@pytest.mark.remote_data
+@pytest.mark.network
 def test_write_constraint():
     """'constraint' argument to writer.write_dataset."""
     with specimen("ng-ts.xml") as f:

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -106,7 +106,6 @@ def test_write_agencyscheme():
 def test_write_categoryscheme():
     with specimen("IPI-2010-A21-structure.xml") as f:
         msg = sdmx.read_sdmx(f)
-        print(msg.category_scheme)
         data = sdmx.to_pandas(msg)
 
     cs = data["category_scheme"]["CLASSEMENT_DATAFLOWS"]

--- a/sdmx/tests/writer/test_protobuf.py
+++ b/sdmx/tests/writer/test_protobuf.py
@@ -1,12 +1,12 @@
 import logging
 
 import pytest
+
 from sdmx.message import StructureMessage
 from sdmx.writer.protobuf import write as to_protobuf
 
 
-@pytest.mark.xfail(raises=RuntimeError,
-                   match='sdmx.format.protobuf_pb2 missing')
+@pytest.mark.xfail(raises=RuntimeError, match="sdmx.format.protobuf_pb2 missing")
 def test_codelist(caplog, codelist):
     msg = StructureMessage()
     msg.codelist[codelist.id] = codelist

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -1,4 +1,5 @@
 import pytest
+
 import sdmx
 from sdmx.message import DataMessage
 
@@ -13,20 +14,19 @@ def test_structuremessage(tmp_path, structuremessage):
     print(result.decode())
 
     # Message can be round-tripped to/from file
-    path = tmp_path / 'output.xml'
+    path = tmp_path / "output.xml"
     path.write_bytes(result)
     msg = sdmx.read_sdmx(path)
 
     # Contents match the original object
     assert (
-        msg.codelist['CL_COLLECTION']['A'].name['en']
-        == structuremessage.codelist['CL_COLLECTION']['A'].name['en']
+        msg.codelist["CL_COLLECTION"]["A"].name["en"]
+        == structuremessage.codelist["CL_COLLECTION"]["A"].name["en"]
     )
 
 
 def test_not_implemented():
     msg = DataMessage()
 
-    with pytest.raises(NotImplementedError,
-                       match='write DataMessage to XML'):
+    with pytest.raises(NotImplementedError, match="write DataMessage to XML"):
         sdmx.to_xml(msg)

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -2,17 +2,18 @@ import re
 
 from sdmx.model import PACKAGE, MaintainableArtefact
 
-
 # Regular expression for URNs
-URN = re.compile(r'urn:sdmx:org\.sdmx\.infomodel'
-                 r'\.(?P<package>[^\.]*)'
-                 r'\.(?P<class>[^=]*)=((?P<agency>[^:]*):)?'
-                 r'(?P<id>[^\(\.]*)(\((?P<version>[\d\.]*)\))?'
-                 r'(\.(?P<item_id>.*))?')
+URN = re.compile(
+    r"urn:sdmx:org\.sdmx\.infomodel"
+    r"\.(?P<package>[^\.]*)"
+    r"\.(?P<class>[^=]*)=((?P<agency>[^:]*):)?"
+    r"(?P<id>[^\(\.]*)(\((?P<version>[\d\.]*)\))?"
+    r"(\.(?P<item_id>.*))?"
+)
 
 _BASE = (
-    'urn:sdmx:org.sdmx.infomodel.{package}.{obj.__class__.__name__}='
-    '{ma.maintainer.id}:{ma.id}({ma.version}){extra_id}'
+    "urn:sdmx:org.sdmx.infomodel.{package}.{obj.__class__.__name__}="
+    "{ma.maintainer.id}:{ma.id}({ma.version}){extra_id}"
 )
 
 
@@ -24,18 +25,15 @@ def make(obj, maintainable_parent=None):
     """
     if maintainable_parent:
         ma = maintainable_parent
-        extra_id = f'.{obj.id}'
+        extra_id = f".{obj.id}"
     else:
         ma = obj
-        extra_id = ''
+        extra_id = ""
 
     assert isinstance(ma, MaintainableArtefact)
 
     return _BASE.format(
-        package=PACKAGE[obj.__class__],
-        obj=obj,
-        ma=ma,
-        extra_id=extra_id,
+        package=PACKAGE[obj.__class__], obj=obj, ma=ma, extra_id=extra_id
     )
 
 

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -1,31 +1,24 @@
 import collections
-from enum import Enum
 import typing
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    List,
-    Union,
-    Type,
-    TypeVar,
-    no_type_check,
-    )
+from enum import Enum
+from typing import TYPE_CHECKING, Any, List, Type, TypeVar, Union, no_type_check
+
+import pydantic
+from pydantic import DictError, Extra, ValidationError
+from pydantic.class_validators import make_generic_validator
+
 try:
     from typing import OrderedDict
 except ImportError:
     # Python < 3.7.2 compatibility; see
     # https://github.com/python/cpython/commit/68b56d0
     from typing import _alias  # type: ignore
+
     OrderedDict = _alias(collections.OrderedDict, (typing._KT, typing._VT))
 
 
-import pydantic
-from pydantic import DictError, Extra, ValidationError
-from pydantic.class_validators import make_generic_validator
-
-
-KT = TypeVar('KT')
-VT = TypeVar('VT')
+KT = TypeVar("KT")
+VT = TypeVar("VT")
 
 
 class Resource(str, Enum):
@@ -47,15 +40,15 @@ class Resource(str, Enum):
     # agencyscheme = 'agencyscheme'
     # attachementconstraint = 'attachementconstraint'
     # categorisation = 'categorisation'
-    categoryscheme = 'categoryscheme'
-    codelist = 'codelist'
-    conceptscheme = 'conceptscheme'
+    categoryscheme = "categoryscheme"
+    codelist = "codelist"
+    conceptscheme = "conceptscheme"
     # contentconstraint = 'contentconstraint'
-    data = 'data'
+    data = "data"
     # dataconsumerscheme = 'dataconsumerscheme'
-    dataflow = 'dataflow'
+    dataflow = "dataflow"
     # dataproviderscheme = 'dataproviderscheme'
-    datastructure = 'datastructure'
+    datastructure = "datastructure"
     # hierarchicalcodelist = 'hierarchicalcodelist'
     # metadata = 'metadata'
     # metadataflow = 'metadataflow'
@@ -63,7 +56,7 @@ class Resource(str, Enum):
     # organisationscheme = 'organisationscheme'
     # organisationunitscheme = 'organisationunitscheme'
     # process = 'process'
-    provisionagreement = 'provisionagreement'
+    provisionagreement = "provisionagreement"
     # reportingtaxonomy = 'reportingtaxonomy'
     # schema = 'schema'
     # structure = 'structure'
@@ -72,18 +65,18 @@ class Resource(str, Enum):
     @classmethod
     def from_obj(cls, obj):
         """Return an enumeration value based on the class of *obj*."""
-        clsname = {
-            'DataStructureDefinition': 'datastructure',
-            }.get(obj.__class__.__name__, obj.__class__.__name__)
+        clsname = {"DataStructureDefinition": "datastructure"}.get(
+            obj.__class__.__name__, obj.__class__.__name__
+        )
         return cls[clsname.lower()]
 
     @classmethod
     def describe(cls):
-        return '{' + ' '.join(v.name for v in cls._member_map_.values()) + '}'
+        return "{" + " ".join(v.name for v in cls._member_map_.values()) + "}"
 
 
 if TYPE_CHECKING:
-    Model = TypeVar('Model', bound='BaseModel')
+    Model = TypeVar("Model", bound="BaseModel")
 
 
 class BaseModel(pydantic.BaseModel):
@@ -111,13 +104,14 @@ class BaseModel(pydantic.BaseModel):
          a.attr is b.attr is always False, even when set to the same reference.
        - Fix: override BaseModel.validate() without copy().
     """
+
     class Config:
-        validate_assignment = 'limited'
+        validate_assignment = "limited"
         validate_assignment_exclude: List[str] = []
 
     # Workaround for https://github.com/samuelcolvin/pydantic/issues/521
     @classmethod
-    def validate(cls: Type['Model'], value: Any) -> 'Model':
+    def validate(cls: Type["Model"], value: Any) -> "Model":
         if isinstance(value, dict):
             return cls(**value)
         elif isinstance(value, cls):
@@ -134,23 +128,26 @@ class BaseModel(pydantic.BaseModel):
     # Workaround for https://github.com/samuelcolvin/pydantic/issues/524
     @no_type_check
     def __setattr__(self, name, value):
-        if (self.__config__.extra is not Extra.allow and name not in
-                self.__fields__):
-            raise ValueError(f'"{self.__class__.__name__}" object has no field'
-                             f' "{name}"')
+        if self.__config__.extra is not Extra.allow and name not in self.__fields__:
+            raise ValueError(
+                f'"{self.__class__.__name__}" object has no field' f' "{name}"'
+            )
         elif not self.__config__.allow_mutation:
-            raise TypeError(f'"{self.__class__.__name__}" is immutable and '
-                            'does not support item assignment')
-        elif (self.__config__.validate_assignment and name not in
-              self.__config__.validate_assignment_exclude):
-            if self.__config__.validate_assignment == 'limited':
-                kw = {'include': {}}
+            raise TypeError(
+                f'"{self.__class__.__name__}" is immutable and '
+                "does not support item assignment"
+            )
+        elif (
+            self.__config__.validate_assignment
+            and name not in self.__config__.validate_assignment_exclude
+        ):
+            if self.__config__.validate_assignment == "limited":
+                kw = {"include": {}}
             else:
-                kw = {'exclude': {name}}
+                kw = {"exclude": {name}}
             known_field = self.__fields__.get(name, None)
             if known_field:
-                value, error_ = known_field.validate(value, self.dict(**kw),
-                                                     loc=name)
+                value, error_ = known_field.validate(value, self.dict(**kw), loc=name)
                 if error_:
                     raise ValidationError([error_], type(self))
         self.__dict__[name] = value
@@ -159,20 +156,21 @@ class BaseModel(pydantic.BaseModel):
 
 class DictLike(collections.OrderedDict, typing.MutableMapping[KT, VT]):
     """Container with features of a dict & list, plus attribute access."""
+
     def __getitem__(self, key: Union[KT, int]) -> VT:
         try:
             return super().__getitem__(key)
         except KeyError:
             if isinstance(key, int):
                 return list(self.values())[key]
-            elif isinstance(key, str) and key.startswith('__'):
+            elif isinstance(key, str) and key.startswith("__"):
                 raise AttributeError
             else:
                 raise
 
     def __setitem__(self, key: KT, value: VT) -> None:
-        key = self._apply_validators('key', key)
-        value = self._apply_validators('value', value)
+        key = self._apply_validators("key", key)
+        value = self._apply_validators("value", value)
         super().__setitem__(key, value)
 
     # Access items as attributes
@@ -187,7 +185,7 @@ class DictLike(collections.OrderedDict, typing.MutableMapping[KT, VT]):
             raise ValueError(value)
 
         result = DictLike()
-        result.__fields = {'key': field.key_field, 'value': field}
+        result.__fields = {"key": field.key_field, "value": field}
         result.update(value)
         return result
 
@@ -197,7 +195,8 @@ class DictLike(collections.OrderedDict, typing.MutableMapping[KT, VT]):
         except AttributeError:
             return value
         result, error = field._apply_validators(
-            value, validators=field.validators, values={}, loc=(), cls=None)
+            value, validators=field.validators, values={}, loc=(), cls=None
+        )
         if error:
             raise ValidationError([error], self.__class__)
         else:
@@ -208,12 +207,12 @@ def summarize_dictlike(dl, maxwidth=72):
     """Return a string summary of the DictLike contents."""
     value_cls = dl[0].__class__.__name__
     count = len(dl)
-    keys = ' '.join(dl.keys())
-    result = f'{value_cls} ({count}): {keys}'
+    keys = " ".join(dl.keys())
+    result = f"{value_cls} ({count}): {keys}"
 
     if len(result) > maxwidth:
         # Truncate the list of keys
-        result = result[:maxwidth - 3] + '...'
+        result = result[: maxwidth - 3] + "..."
 
     return result
 

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Type, TypeVar, Union, no_type_check
 
 import pydantic
-from pydantic import DictError, Extra, ValidationError
+from pydantic import DictError, Extra, ValidationError, validator  # noqa: F401
 from pydantic.class_validators import make_generic_validator
 
 KT = TypeVar("KT")

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -7,6 +7,9 @@ import pydantic
 from pydantic import DictError, Extra, ValidationError
 from pydantic.class_validators import make_generic_validator
 
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
 try:
     from typing import OrderedDict
 except ImportError:
@@ -14,11 +17,7 @@ except ImportError:
     # https://github.com/python/cpython/commit/68b56d0
     from typing import _alias  # type: ignore
 
-    OrderedDict = _alias(collections.OrderedDict, (typing._KT, typing._VT))
-
-
-KT = TypeVar("KT")
-VT = TypeVar("VT")
+    OrderedDict = _alias(collections.OrderedDict, (KT, VT))
 
 
 class Resource(str, Enum):

--- a/sdmx/writer/__init__.py
+++ b/sdmx/writer/__init__.py
@@ -1,4 +1,7 @@
-from .pandas import write as to_pandas
-from .xml import write as to_xml
+from .pandas import to_pandas
+from .xml import to_xml
 
-__all__ = ["to_pandas", "to_xml"]
+__all__ = [
+    "to_pandas",
+    "to_xml",
+]

--- a/sdmx/writer/__init__.py
+++ b/sdmx/writer/__init__.py
@@ -1,7 +1,4 @@
 from .pandas import write as to_pandas
 from .xml import write as to_xml
 
-__all__ = [
-    'to_pandas',
-    'to_xml',
-]
+__all__ = ["to_pandas", "to_xml"]

--- a/sdmx/writer/base.py
+++ b/sdmx/writer/base.py
@@ -27,12 +27,14 @@ class BaseWriter:
         ... code to write a Codelist ...
         return result
     """
+
     def __init__(self, format_name):
         # Create the single-dispatch function
         @singledispatch
         def func(obj, *args, **kwargs):
-            raise NotImplementedError(f'write {obj.__class__.__name__} to '
-                                      f'{format_name}')
+            raise NotImplementedError(
+                f"write {obj.__class__.__name__} to " f"{format_name}"
+            )
 
         self._dispatcher = func
 
@@ -45,7 +47,7 @@ class BaseWriter:
         # TODO use a cache to speed up the MRO does not need to be traversed
         #      for every object instance
 
-        dispatcher = getattr(self, '_dispatcher')
+        dispatcher = getattr(self, "_dispatcher")
         try:
             # Let the single dispatch function choose the overload
             return dispatcher(obj, *args, **kwargs)
@@ -61,6 +63,6 @@ class BaseWriter:
 
     def register(self, func):
         """Register *func* as a writer for a particular object type."""
-        dispatcher = getattr(self, '_dispatcher')
+        dispatcher = getattr(self, "_dispatcher")
         dispatcher.register(func)
         return func

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -17,16 +17,15 @@ from sdmx.model import (
     SeriesKey,
     TimeDimension,
 )
-from sdmx.writer.base import BaseWriter
 from sdmx.util import DictLike
-
+from sdmx.writer.base import BaseWriter
 
 #: Default return type for :func:`write_dataset` and similar methods. Either
 #: 'compat' or 'rows'. See the ref:`HOWTO <howto-rtype>`.
-DEFAULT_RTYPE = 'rows'
+DEFAULT_RTYPE = "rows"
 
 
-Writer = BaseWriter('pandas')
+Writer = BaseWriter("pandas")
 
 
 def write(obj, *args, **kwargs):
@@ -60,8 +59,10 @@ def _dict(obj: dict, *args, **kwargs):
     result_type = set(type(v) for v in result.values())
 
     if result_type <= {pd.Series, pd.DataFrame}:
-        if (len(set(map(lambda s: s.index.name, result.values()))) == 1 and
-                len(result) > 1):
+        if (
+            len(set(map(lambda s: s.index.name, result.values()))) == 1
+            and len(result) > 1
+        ):
             # Can safely concatenate these to a pd.MultiIndex'd Series.
             return pd.concat(result)
         else:
@@ -107,13 +108,13 @@ def write_datamessage(obj: message.DataMessage, *args, rtype=None, **kwargs):
         if `obj` has more than one data set.
     """
     # Pass the message's DSD to assist datetime handling
-    kwargs.setdefault('dsd', obj.dataflow.structure)
+    kwargs.setdefault("dsd", obj.dataflow.structure)
 
     # Pass the return type and associated information
-    kwargs['_rtype'] = rtype or DEFAULT_RTYPE
-    if kwargs['_rtype'] == 'compat':
-        kwargs['_message_class'] = obj.__class__
-        kwargs['_observation_dimension'] = obj.observation_dimension
+    kwargs["_rtype"] = rtype or DEFAULT_RTYPE
+    if kwargs["_rtype"] == "compat":
+        kwargs["_message_class"] = obj.__class__
+        kwargs["_observation_dimension"] = obj.observation_dimension
 
     if len(obj.data) == 1:
         return write(obj.data[0], *args, **kwargs)
@@ -122,8 +123,7 @@ def write_datamessage(obj: message.DataMessage, *args, rtype=None, **kwargs):
 
 
 @Writer.register
-def write_structuremessage(obj: message.StructureMessage, include=None,
-                           **kwargs):
+def write_structuremessage(obj: message.StructureMessage, include=None, **kwargs):
     """Convert :class:`.StructureMessage`.
 
     Parameters
@@ -141,13 +141,13 @@ def write_structuremessage(obj: message.StructureMessage, include=None,
         Keys are StructureMessage attributes; values are pandas objects.
     """
     all_contents = {
-        'category_scheme',
-        'codelist',
-        'concept_scheme',
-        'constraint',
-        'dataflow',
-        'structure',
-        'organisation_scheme',
+        "category_scheme",
+        "codelist",
+        "concept_scheme",
+        "constraint",
+        "dataflow",
+        "structure",
+        "organisation_scheme",
     }
 
     # Handle arguments
@@ -171,11 +171,12 @@ def write_structuremessage(obj: message.StructureMessage, include=None,
 
 # Functions for model classes
 
+
 @Writer.register
 def _c(obj: model.Component):
     """Convert :class:`.Component`."""
     # Raises AttributeError if the concept_identity is missing
-    return str(obj.concept_identity.id)   # type: ignore
+    return str(obj.concept_identity.id)  # type: ignore
 
 
 @Writer.register
@@ -192,14 +193,21 @@ def _cr(obj: model.CubeRegion, **kwargs):
     """Convert :class:`.CubeRegion`."""
     result: DictLike[str, pd.Series] = DictLike()
     for dim, memberselection in obj.member.items():
-        result[dim.id] = pd.Series([mv.value for mv in memberselection.values],
-                                   name=dim.id)
+        result[dim.id] = pd.Series(
+            [mv.value for mv in memberselection.values], name=dim.id
+        )
     return result
 
 
 @Writer.register
-def write_dataset(obj: model.DataSet, attributes='', dtype=np.float64,
-                  constraint=None, datetime=False, **kwargs):
+def write_dataset(
+    obj: model.DataSet,
+    attributes="",
+    dtype=np.float64,
+    constraint=None,
+    datetime=False,
+    **kwargs,
+):
     """Convert :class:`~.DataSet`.
 
     See the :ref:`walkthrough <datetime>` for examples of using the `datetime`
@@ -263,25 +271,24 @@ def write_dataset(obj: model.DataSet, attributes='', dtype=np.float64,
     """
     # If called directly on a DataSet (rather than a parent DataMessage),
     # cannot determine the "dimension at observation level"
-    rtype = kwargs.setdefault('_rtype', 'rows')
+    rtype = kwargs.setdefault("_rtype", "rows")
 
     # Validate attributes argument
-    attributes = attributes or ''
+    attributes = attributes or ""
     try:
         attributes = attributes.lower()
     except AttributeError:
         raise TypeError("'attributes' argument must be str")
 
-    if rtype == 'compat' and \
-            kwargs['_observation_dimension'] is not AllDimensions:
+    if rtype == "compat" and kwargs["_observation_dimension"] is not AllDimensions:
         # Cannot return attributes in this case
-        attributes = ''
-    elif set(attributes) - {'o', 's', 'g', 'd'}:
+        attributes = ""
+    elif set(attributes) - {"o", "s", "g", "d"}:
         raise ValueError(f"attributes must be in 'osgd'; got {attributes}")
 
     # Iterate on observations
     data = {}
-    for observation in getattr(obj, 'obs', obj):
+    for observation in getattr(obj, "obs", obj):
         # Check that the Observation is within the constraint, if any
         key = observation.key.order()
         if constraint and key not in constraint:
@@ -290,21 +297,22 @@ def write_dataset(obj: model.DataSet, attributes='', dtype=np.float64,
         # Add value and attributes
         row = {}
         if dtype:
-            row['value'] = observation.value
+            row["value"] = observation.value
         if attributes:
             row.update(observation.attrib)
 
         data[tuple(map(str, key.get_values()))] = row
 
-    result: Union[pd.Series, pd.DataFrame] = \
-        pd.DataFrame.from_dict(data, orient='index')
+    result: Union[pd.Series, pd.DataFrame] = pd.DataFrame.from_dict(
+        data, orient="index"
+    )
 
     if len(result):
         result.index.names = observation.key.order().values.keys()
         if dtype:
-            result['value'] = result['value'].astype(dtype)
+            result["value"] = result["value"].astype(dtype)
             if not attributes:
-                result = result['value']
+                result = result["value"]
 
     # Reshape for compatibility with v0.9
     result, datetime, kwargs = _dataset_compat(result, datetime, kwargs)
@@ -314,13 +322,13 @@ def write_dataset(obj: model.DataSet, attributes='', dtype=np.float64,
 
 def _dataset_compat(df, datetime, kwargs):
     """Helper for :meth:`.write_dataset` 0.9 compatibility."""
-    rtype = kwargs.pop('_rtype')
-    if rtype != 'compat':
+    rtype = kwargs.pop("_rtype")
+    if rtype != "compat":
         return df, datetime, kwargs  # Do nothing
 
     # Remove compatibility arguments from kwargs
-    kwargs.pop('_message_class')
-    obs_dim = kwargs.pop('_observation_dimension')
+    kwargs.pop("_message_class")
+    obs_dim = kwargs.pop("_observation_dimension")
 
     if isinstance(obs_dim, list) and len(obs_dim) == 1:
         # Unwrap a length-1 list
@@ -337,9 +345,11 @@ def _dataset_compat(df, datetime, kwargs):
             datetime = obs_dim
         elif isinstance(datetime, dict):
             # Dict argument; ensure the 'dim' key is the same as obs_dim
-            if datetime.setdefault('dim', obs_dim) != obs_dim:
-                msg = (f"datetime={datetime} conflicts with rtype='compat' and"
-                       f" {obs_dim} at observation level")
+            if datetime.setdefault("dim", obs_dim) != obs_dim:
+                msg = (
+                    f"datetime={datetime} conflicts with rtype='compat' and"
+                    f" {obs_dim} at observation level"
+                )
                 raise ValueError(msg)
         else:
             assert datetime == obs_dim, (datetime, obs_dim)
@@ -373,9 +383,9 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
     # Check argument values
     param = dict(dim=None, axis=0, freq=False)
     if isinstance(arg, str):
-        param['dim'] = arg
+        param["dim"] = arg
     elif isinstance(arg, DimensionComponent):
-        param['dim'] = arg.id
+        param["dim"] = arg.id
     elif isinstance(arg, dict):
         extra_keys = set(arg.keys()) - set(param.keys())
         if extra_keys:
@@ -404,24 +414,24 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
         else:
             return []
 
-    if not param['dim']:
+    if not param["dim"]:
         # Determine time dimension
         dims = _get_dims()
         for dim in dims:
             if isinstance(dim, TimeDimension):
-                param['dim'] = dim
+                param["dim"] = dim
                 break
-        if not param['dim']:
-            raise ValueError(f'no TimeDimension in {dims}')
+        if not param["dim"]:
+            raise ValueError(f"no TimeDimension in {dims}")
 
     # Unstack all but the time dimension and convert
-    other_dims = list(filter(lambda d: d != param['dim'], df.index.names))
+    other_dims = list(filter(lambda d: d != param["dim"], df.index.names))
     df = df.unstack(other_dims)
     df.index = pd.to_datetime(df.index)
 
-    if param['freq']:
+    if param["freq"]:
         # Determine frequency string, Dimension, or Attribute
-        freq = param['freq']
+        freq = param["freq"]
         if isinstance(freq, str) and freq not in pd.offsets.prefix_mapping:
             # ID of a Dimension or Attribute
             for component in chain(_get_dims(), _get_attrs()):
@@ -444,8 +454,9 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
 
             if len(values) > 1:
                 values = sorted(values)
-                raise ValueError('cannot convert to PeriodIndex with '
-                                 f'non-unique freq={values}')
+                raise ValueError(
+                    "cannot convert to PeriodIndex with " f"non-unique freq={values}"
+                )
 
             # Store the unique value
             freq = values.pop()
@@ -457,7 +468,7 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
 
         df.index = df.index.to_period(freq=freq)
 
-    if param['axis'] in {1, 'columns'}:
+    if param["axis"] in {1, "columns"}:
         # Change axis
         df = df.transpose()
 
@@ -495,12 +506,12 @@ def write_itemscheme(obj: model.ItemScheme, locale=DEFAULT_LOCALE):
             seen.add(item)
 
         # Localized name
-        row = {'name': item.name.localized_default(locale)}
+        row = {"name": item.name.localized_default(locale)}
         try:
             # Parent ID
-            row['parent'] = item.parent.id
+            row["parent"] = item.parent.id
         except AttributeError:
-            row['parent'] = ''
+            row["parent"] = ""
 
         items[item.id] = row
 
@@ -512,12 +523,13 @@ def write_itemscheme(obj: model.ItemScheme, locale=DEFAULT_LOCALE):
         add_item(item)
 
     # Convert to DataFrame
-    result = pd.DataFrame.from_dict(items, orient='index', dtype=object) \
-               .rename_axis(obj.id, axis='index')
+    result = pd.DataFrame.from_dict(items, orient="index", dtype=object).rename_axis(
+        obj.id, axis="index"
+    )
 
-    if len(result) and not result['parent'].str.len().any():
+    if len(result) and not result["parent"].str.len().any():
         # 'parent' column is empty; convert to pd.Series and rename
-        result = result['name'].rename(obj.name.localized_default(locale))
+        result = result["name"].rename(obj.name.localized_default(locale))
 
     return result
 

--- a/sdmx/writer/protobuf.py
+++ b/sdmx/writer/protobuf.py
@@ -1,9 +1,6 @@
 import logging
 
-try:
-    import sdmx.format.protobuf_pb2 as pb
-except ImportError:
-    pb = None
+import sdmx.format.protobuf_pb2 as pb
 
 
 log = logging.getLogger(__name__)
@@ -11,9 +8,6 @@ log = logging.getLogger(__name__)
 
 def write(obj, *args, **kwargs):
     """Convert an SDMX *obj* to protobuf string."""
-    if not pb:
-        raise RuntimeError('sdmx.format.protobuf_pb2 missing')
-
     return _write(obj, *args, **kwargs).SerializeToString()
 
 

--- a/sdmx/writer/protobuf.py
+++ b/sdmx/writer/protobuf.py
@@ -2,7 +2,6 @@ import logging
 
 import sdmx.format.protobuf_pb2 as pb
 
-
 log = logging.getLogger(__name__)
 
 
@@ -14,11 +13,11 @@ def write(obj, *args, **kwargs):
 def _write(obj, *args, **kwargs):
     """Helper for :meth:`write`; returns :mod:`protobuf` object(s)."""
     cls_name = obj.__class__.__name__
-    func_name = f'write_{cls_name.lower()}'
+    func_name = f"write_{cls_name.lower()}"
     try:
         func = globals()[func_name]
     except KeyError:
-        raise NotImplementedError(f'write {cls_name} to protobuf')
+        raise NotImplementedError(f"write {cls_name} to protobuf")
     else:
         return func(obj, *args, **kwargs)
 
@@ -33,12 +32,12 @@ def _copy(obj, pb_obj):
 
         try:
             setattr(pb_obj, attr, value)
-            log.info(f'Set {attr}')
+            log.info(f"Set {attr}")
         except Exception as exc:
-            log.error(f'Failed to set {attr}: {exc}')
+            log.error(f"Failed to set {attr}: {exc}")
 
             if not dir_logged:
-                fields = filter(lambda n: not n.startswith('_'), dir(pb_obj))
+                fields = filter(lambda n: not n.startswith("_"), dir(pb_obj))
                 log.info(sorted(fields))
                 dir_logged = True
 

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -84,7 +84,7 @@ def maintainable(obj, parent=None):
 
 
 @Writer.register
-def _(obj: message.StructureMessage):
+def _sm(obj: message.StructureMessage):
     msg = Element('mes:Structure')
 
     # Empty header element
@@ -101,14 +101,14 @@ def _(obj: message.StructureMessage):
 
 
 @Writer.register
-def _(obj: model.ItemScheme):
+def _is(obj: model.ItemScheme):
     elem = maintainable(obj)
     elem.extend(Writer.recurse(i, parent=obj) for i in obj.items.values())
     return elem
 
 
 @Writer.register
-def _(obj: model.Item, parent):
+def _i(obj: model.Item, parent):
     elem = maintainable(obj, parent=parent)
 
     if obj.parent:
@@ -121,7 +121,7 @@ def _(obj: model.Item, parent):
 
 
 @Writer.register
-def _(obj: model.Annotation):
+def _a(obj: model.Annotation):
     elem = Element('com:Annotation')
     if obj.id:
         elem.attrib['id'] = obj.id

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -6,13 +6,11 @@ from sdmx import message, model
 from sdmx.format.xml import NS, qname
 from sdmx.writer.base import BaseWriter
 
-_element_maker = ElementMaker(nsmap=NS)
+_element_maker = ElementMaker(nsmap={k: v for k, v in NS.items() if v is not None})
 
 
 def Element(name, *args, **kwargs):
-    name = name.split(":")
-    name = qname(*name) if len(name) == 2 else name[0]
-    return _element_maker(name, *args, **kwargs)
+    return _element_maker(qname(name), *args, **kwargs)
 
 
 Writer = BaseWriter("XML")
@@ -91,7 +89,7 @@ def _sm(obj: message.StructureMessage):
     structures = Element("mes:Structures")
     msg.append(structures)
 
-    codelists = Element("mes:Codelists")
+    codelists = Element("str:Codelists")
     structures.append(codelists)
     codelists.extend(Writer.recurse(cl) for cl in obj.codelist.values())
 
@@ -112,7 +110,7 @@ def _i(obj: model.Item, parent):
     if obj.parent:
         # Reference to parent code
         e_parent = Element("str:Parent")
-        e_parent.append(Element("Ref", id=obj.parent.id))
+        e_parent.append(Element(":Ref", id=obj.parent.id))
         elem.append(e_parent)
 
     return elem

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -16,7 +16,7 @@ def Element(name, *args, **kwargs):
 Writer = BaseWriter("XML")
 
 
-def write(obj, **kwargs):
+def to_xml(obj, **kwargs):
     """Convert an SDMX *obj* to SDMX-ML.
 
     Parameters

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -1,22 +1,21 @@
 from lxml import etree
 from lxml.builder import ElementMaker
 
+import sdmx.urn
 from sdmx import message, model
 from sdmx.format.xml import NS, qname
-import sdmx.urn
 from sdmx.writer.base import BaseWriter
-
 
 _element_maker = ElementMaker(nsmap=NS)
 
 
 def Element(name, *args, **kwargs):
-    name = name.split(':')
+    name = name.split(":")
     name = qname(*name) if len(name) == 2 else name[0]
     return _element_maker(name, *args, **kwargs)
 
 
-Writer = BaseWriter('XML')
+Writer = BaseWriter("XML")
 
 
 def write(obj, **kwargs):
@@ -39,6 +38,7 @@ def write(obj, **kwargs):
 
 # Utility functions
 
+
 def i11lstring(obj, name):
     """InternationalString.
 
@@ -48,7 +48,7 @@ def i11lstring(obj, name):
 
     for locale, label in obj.localizations.items():
         child = Element(name, label)
-        child.set(qname('xml', 'lang'), locale)
+        child.set(qname("xml", "lang"), locale)
         elems.append(child)
 
     return elems
@@ -58,7 +58,7 @@ def annotable(obj, name, *args, **kwargs):
     elem = Element(name, *args, **kwargs)
 
     if len(obj.annotations):
-        e_anno = Element('com:Annotations')
+        e_anno = Element("com:Annotations")
         e_anno.extend(Writer.recurse(a) for a in obj.annotations)
         elem.append(e_anno)
 
@@ -71,29 +71,27 @@ def identifiable(obj, name, *args, **kwargs):
 
 def nameable(obj, name, *args, **kwargs):
     elem = identifiable(obj, name, *args, **kwargs)
-    elem.extend(i11lstring(obj.name, 'com:Name'))
+    elem.extend(i11lstring(obj.name, "com:Name"))
     return elem
 
 
 def maintainable(obj, parent=None):
     return nameable(
-        obj,
-        f'str:{obj.__class__.__name__}',
-        urn=sdmx.urn.make(obj, parent),
+        obj, f"str:{obj.__class__.__name__}", urn=sdmx.urn.make(obj, parent)
     )
 
 
 @Writer.register
 def _sm(obj: message.StructureMessage):
-    msg = Element('mes:Structure')
+    msg = Element("mes:Structure")
 
     # Empty header element
-    msg.append(Element('mes:Header'))
+    msg.append(Element("mes:Header"))
 
-    structures = Element('mes:Structures')
+    structures = Element("mes:Structures")
     msg.append(structures)
 
-    codelists = Element('mes:Codelists')
+    codelists = Element("mes:Codelists")
     structures.append(codelists)
     codelists.extend(Writer.recurse(cl) for cl in obj.codelist.values())
 
@@ -113,8 +111,8 @@ def _i(obj: model.Item, parent):
 
     if obj.parent:
         # Reference to parent code
-        e_parent = Element('str:Parent')
-        e_parent.append(Element('Ref', id=obj.parent.id))
+        e_parent = Element("str:Parent")
+        e_parent.append(Element("Ref", id=obj.parent.id))
         elem.append(e_parent)
 
     return elem
@@ -122,8 +120,8 @@ def _i(obj: model.Item, parent):
 
 @Writer.register
 def _a(obj: model.Annotation):
-    elem = Element('com:Annotation')
+    elem = Element("com:Annotation")
     if obj.id:
-        elem.attrib['id'] = obj.id
-    elem.extend(i11lstring(obj.text, 'com:AnnotationText'))
+        elem.attrib["id"] = obj.id
+    elem.extend(i11lstring(obj.text, "com:AnnotationText"))
     return elem

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,3 +67,33 @@ omit =
     sdmx/experimental.py
     sdmx/tests/writer/test_protobuf.py
     sdmx/writer/protobuf.py
+
+[isort]
+default_section = THIRDPARTY
+known_first_party = sdmx
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[flake8]
+max-line-length = 88
+ignore =
+    # line break before binary operator
+    W503
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+[mypy-numpy.*]
+ignore_missing_imports = True
+[mypy-pandas.*]
+ignore_missing_imports = True
+[mypy-pytest.*]
+ignore_missing_imports = True
+[mypy-requests_cache.*]
+ignore_missing_imports = True
+[mypy-requests_mock.*]
+ignore_missing_imports = True
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ setup_requires =
 [options.extras_require]
 cache = requests_cache
 docs = sphinx >= 2.3; IPython
-tests = pytest >= 5; pytest-remotedata >= 0.3.1; requests-mock >= 1.4
+tests = pytest >= 5; requests-mock >= 1.4
 
 [options.package_data]
 sdmx =
@@ -58,9 +58,10 @@ universal=1
 [tool:pytest]
 addopts = sdmx
     --cov sdmx --cov-report=
-    -m "not experimental"
+    -m "not experimental and not network"
 markers =
     experimental: experimental features
+    network: tests requiring a network connection
 
 [coverage:run]
 omit =

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(use_scm_version=dict(local_scheme='no-local-version'))
+setup(use_scm_version=dict(local_scheme="no-local-version"))


### PR DESCRIPTION
`sdmx.reader.sdmxml` is switched from a recursive [tree iteration](https://lxml.de/tutorial.html#tree-iteration) pattern to an [event-driven](https://lxml.de/tutorial.html#event-driven-parsing) pattern. The call stack is replaced with stacks of generated objects that are frequently collected, resulting in better speed and memory performance.

Other changes:
- Code style is standardized by applying:
  - `isort -rc .` (including settings in setup.cfg)
  - `black .`
  - `mypy .`
  - `flake8` (including settings in setup.cfg)
- Code is adjusted to satisfy mypy.
- Improvements and extensions to `model`, `reader`, and other modules; see whatsnew.rst.