### PR TITLE
 Add World Bank WDI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ jobs:
   # Non-linux jobs; Python configured below
   - os: osx
     language: objective-c  # Only language provided
-    # Homebrew installs Python to this location
-    env: PATH=/usr/local/opt/python@3.8/bin:$PATH
+    # Homebrew's Python is installed at this location
+    env: PATH=/usr/local/opt/python@3.7/bin:$PATH
   - os: windows
     language: shell
     # Chocolatey installs Python to this location
@@ -28,9 +28,6 @@ install:
 # Install Python & pip on macOS and Windows
 - |-
   case $TRAVIS_OS_NAME in
-    osx)
-      brew update --quiet
-      brew install python@3.8 ;;
     windows)
       choco install --no-progress python3
       python -m pip install --upgrade pip ;;

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -10,15 +10,12 @@ SDMX makes a distinction between data providers and sources:
 - a **data source** is a specific web service that provides access to
   statistical information.
 
-Each data *source* might aggregate and provide data or metadata from multiple
-data *providers*. Or, an agency might operate a data source that only contains
-information they provide themselves; in this case, the source and provider are
-identical.
+Each data *source* might aggregate and provide data or metadata from multiple data *providers*.
+Or, an agency might operate a data source that only contains information they provide themselves; in this case, the source and provider are identical.
 
-:mod:`sdmx` identifies each data source using a string such as ``'ABS'``, and has
-built-in support for a number of data sources. Use :meth:`list_sources` to list
-these. Read the following sections, or the file ``sources.json`` in the
-package source code, for more details.
+:mod:`sdmx` identifies each data source using a string such as ``'ABS'``, and has built-in support for a number of data sources.
+Use :meth:`list_sources` to list these.
+Read the following sections, or the file ``sources.json`` in the package source code, for more details.
 
 :mod:`sdmx` also supports adding other data sources; see :meth:`add_source` and :class:`~.source.Source`.
 
@@ -30,9 +27,7 @@ package source code, for more details.
 Data source limitations
 -----------------------
 
-Each SDMX web service provides a subset of the full SDMX feature set, so the
-same request made to two different sources may yield different results, or an
-error message.
+Each SDMX web service provides a subset of the full SDMX feature set, so the same request made to two different sources may yield different results, or an error message.
 
 A key difference is between sources offering SDMX-ML and SDMX-JSON APIs.
 SDMX-JSON APIs do not support metadata, or structure queries; only data queries.
@@ -58,12 +53,9 @@ In order to anticipate and handle these differences:
         },
       ]
 
-   :mod:`sdmx` will raise :class:`NotImplementedError` on an attempt to query the
-   "datastructure" API endpoint of either of these data sources.
+   :mod:`sdmx` will raise :class:`NotImplementedError` on an attempt to query the "datastructure" API endpoint of either of these data sources.
 
-2. :mod:`sdmx.source` includes adapters (subclasses of
-   :class:`~.source.Source`) with hooks used when querying sources and
-   interpreting their HTTP responses.
+2. :mod:`sdmx.source` includes adapters (subclasses of :class:`~.source.Source`) with hooks used when querying sources and interpreting their HTTP responses.
    These are documented below: ABS_, ESTAT_, and SGR_.
 
 
@@ -89,8 +81,8 @@ SDMX-ML —
 
 - Thousands of dataflows on a wide range of topics.
 - No categorisations available.
-- Long response times are reported. Increase the timeout attribute to avoid
-  timeout exceptions.
+- Long response times are reported.
+  Increase the timeout attribute to avoid timeout exceptions.
 - Does not return DSDs for dataflow requests with the ``references='all'`` query parameter.
 
 .. autoclass:: sdmx.source.estat.Source
@@ -117,13 +109,10 @@ SDMX-ML —
 - :class:`sdmx.source.ilo.Source` handles some particularities of the ILO
   web service. Others that are not handled:
 
-  - Data flow IDs take on the role of a filter. E.g., there are dataflows for
-    individual countries, ages, sexes etc. rather than merely for different
-    indicators.
-  - The service returns 413 Payload Too Large errors for some queries, with
-    messages like: "Too many results, please specify codelist ID". Test for
-    :class:`sdmx.exceptions.HTTPError`
-    (= :class:`requests.exceptions.HTTPError`) and/or specify a ``resource_id``.
+  - Data flow IDs take on the role of a filter.
+    E.g., there are dataflows for individual countries, ages, sexes etc. rather than merely for different indicators.
+  - The service returns 413 Payload Too Large errors for some queries, with messages like: "Too many results, please specify codelist ID".
+    Test for :class:`sdmx.exceptions.HTTPError` (= :class:`requests.exceptions.HTTPError`) and/or specify a ``resource_id``.
 
 - It is highly recommended to read the `API guide <http://www.ilo.org/ilostat/content/conn/ILOSTATContentServer/path/Contribution%20Folders/statistics/web_pages/static_pages/technical_page/ilostat_appl/SDMX_User_Guide.pdf>`_.
 
@@ -161,10 +150,10 @@ SDMX-ML —
 - French name: Institut national de la statistique et des études économiques.
 
 .. warning::
-   An issue has been reported apparently due to a missing pericite codelist
-   in StructureMessages. This may cause crashes. Avoid downloading
-   this type of message. Prepare the key as string using the web interface, and
-   simply download a dataset.
+   An issue has been reported apparently due to a missing pericite codelist in StructureMessages.
+   This may cause crashes.
+   Avoid downloading this type of message.
+   Prepare the key as string using the web interface, and simply download a dataset.
 
 
 ``ISTAT``: National Institute of Statistics (Italy)
@@ -214,8 +203,9 @@ SDMX-ML —
 
 - Supports preview_data and series-key based key validation.
 
-.. warning:: supports categoryscheme even though it offers very few dataflows.  Use this feature with caution. Moreover, it seems that categories confusingly
-  include dataflows which UNSD does not actually provide.
+.. warning:: supports categoryscheme even though it offers very few dataflows.
+   Use this feature with caution.
+   Moreover, it seems that categories confusingly include dataflows which UNSD does not actually provide.
 
 
 ``UNESCO``: UN Educational, Scientific and Cultural Organization
@@ -224,12 +214,10 @@ SDMX-ML —
 SDMX-ML —
 `Website <https://apiportal.uis.unesco.org/getting-started>`__
 
-- Free registration required; user credentials must be provided either as
-  parameter or HTTP header with each request.
+- Free registration required; user credentials must be provided either as parameter or HTTP header with each request.
 
 .. warning:: An issue with structure-specific datasets has been reported.
-  It seems that Series are not recognized due to some oddity
-  in the XML format.
+   It seems that Series are not recognized due to some oddity in the XML format.
 
 
 ``WB``: World Bank Group “World Integrated Trade Solution”
@@ -238,6 +226,8 @@ SDMX-ML —
 SDMX-ML —
 `Website <wits.worldbank.org>`__
 
+
+.. _WB_WDI:
 
 ``WB_WDI``: World Bank Group “World Development Indicators”
 -----------------------------------------------------------

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -232,8 +232,18 @@ SDMX-ML —
   in the XML format.
 
 
-``WB``: World Bank Group's “World Integrated Trade Solution”
-------------------------------------------------------------
+``WB``: World Bank Group “World Integrated Trade Solution”
+----------------------------------------------------------
 
 SDMX-ML —
 `Website <wits.worldbank.org>`__
+
+
+``WB_WDI``: World Bank Group “World Development Indicators”
+-----------------------------------------------------------
+
+SDMX-ML —
+`Website <https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries>`__
+
+- This web service also supports SDMX-JSON.
+  To retrieve messages in this format, pass the HTTP ``Accept:`` header described on the service website.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,6 +6,9 @@ What's new?
 Next release (vX.Y.0)
 =====================
 
+- Adjust imports for compatibility with pandas 1.1.0 (:pull:`10`).
+- Add :ref:`World Bank World Development Indicators (WDI) <WB_WDI>` service to supported sources (:pull:`10`).
+
 
 v1.2.0 (2020-06-04)
 ===================

--- a/sdmx/api.py
+++ b/sdmx/api.py
@@ -247,8 +247,10 @@ class Request:
         parameters = kwargs.pop("params", {})
         headers = kwargs.pop("headers", {})
 
-        if len(kwargs):
-            raise ValueError(f"unrecognized arguments: {kwargs!r}")
+        # kwargs with values other than None are an error
+        extra_args = dict(filter(lambda i: i[1] is not None, kwargs.items()))
+        if len(extra_args):
+            raise ValueError(f"{repr(extra_args)} supplied with get(url=...)")
 
         return requests.Request("get", url, params=parameters, headers=headers)
 
@@ -376,6 +378,8 @@ class Request:
             and `force` is not :obj:`True`.
 
         """
+        kwargs.update(dict(resource_type=resource_type, resource_id=resource_id))
+
         # Allow sources to modify request args
         # TODO this should occur after most processing, defaults, checking etc.
         #      are performed, so that core code does most of the work.
@@ -386,7 +390,6 @@ class Request:
         if "url" in kwargs:
             req = self._request_from_url(kwargs)
         else:
-            kwargs.update(dict(resource_type=resource_type, resource_id=resource_id))
             req = self._request_from_args(kwargs)
 
         req = self.session.prepare_request(req)

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -551,15 +551,23 @@ def _header(reader, elem):
 
     reader.get_single(message.Message).header = header
 
-    # TODO check whether these occur anywhere besides footer.xml
-    reader.pop_all("Timezone")
+    # TODO add these to the Message class
+    # Appearing in data messages from WB_WDI
+    reader.pop_all("Extracted")
+    # Appearing in data messages from WB_WDI and the footer.xml specimen
     reader.pop_all("DataSetAction")
     reader.pop_all("DataSetID")
+    # Apparing in the footer.xml specimen
+    reader.pop_all("Timezone")
 
 
 @end("mes:Receiver mes:Sender")
 def _header_org(reader, elem):
-    reader.push(elem, reader.nameable(class_for_tag(elem.tag), elem))
+    reader.push(
+        elem, reader.nameable(
+            class_for_tag(elem.tag), elem, contact=reader.pop_all(model.Contact)
+        )
+    )
 
 
 @end("mes:Structure", only=False)
@@ -682,7 +690,7 @@ def _structures(reader, elem):
 @end(
     "mes:DataSetAction mes:DataSetID mes:ID mes:Prepared mes:Test mes:Timezone "
     "com:AnnotationType com:AnnotationTitle com:AnnotationURL com:None com:URN "
-    "com:Value str:Email str:Telephone str:URI"
+    "com:Value mes:Email mes:Extracted str:Email str:Telephone str:URI"
 )
 def _text(reader, elem):
     reader.push(elem, elem.text)
@@ -947,7 +955,7 @@ def _cat(reader, elem):
 # §4.6: Organisations
 
 
-@end("str:Contact")
+@end("mes:Contact str:Contact")
 def _contact(reader, elem):
     contact = model.Contact(
         telephone=reader.pop_single("Telephone"),

--- a/sdmx/source/wb_wdi.py
+++ b/sdmx/source/wb_wdi.py
@@ -1,0 +1,25 @@
+from . import Source as BaseSource
+
+
+class Source(BaseSource):
+    _id = "WB_WDI"
+
+    def modify_request_args(self, kwargs):
+        """World Bank's agency ID."""
+        super().modify_request_args(kwargs)
+
+        if kwargs["resource_type"] == "categoryscheme":
+            # Service does not respond to requests for "WB" category schemes
+            kwargs["provider"] = "all"
+        elif kwargs["resource_type"] != "data":
+            # Provider's own ID differs from its ID in this package
+            kwargs.setdefault("provider", "WB")
+
+        try:
+            if isinstance(kwargs["key"], str):
+                # Data queries fail without a trailing slash
+                # TODO improve the hook integration with Request.get so this can be
+                #      done after the query URL is prepared
+                kwargs["key"] += "/"
+        except KeyError:
+            pass

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -123,5 +123,14 @@
       "agencyscheme": false,
       "provisionagreement": false
     }
+  },
+  {
+    "id": "WB_WDI",
+    "name": "World Bank World Development Indicators",
+    "url": "http://api.worldbank.org/v2/sdmx/rest",
+    "supports": {
+      "provisionagreement": false,
+      "structure-specific data": true
+    }
   }
 ]

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -12,7 +12,7 @@
             "headers": {}
         }
     },
-    "url": "http://sdw-wsrest.ecb.int/service",
+    "url": "https://sdw-wsrest.ecb.europa.eu/service",
     "name": "European Central Bank",
     "supports": {"preview": true}
   },

--- a/sdmx/tests/test_api.py
+++ b/sdmx/tests/test_api.py
@@ -75,6 +75,7 @@ def test_request_get_exceptions():
     with pytest.raises(ValueError, match=exc):
         req.get("datastructure", foo="bar")
 
+    exc = "{'foo': 'bar'} supplied with get\(url=...\)"
     with pytest.raises(ValueError, match=exc):
         sdmx.read_url("https://example.com", foo="bar")
 

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -112,10 +112,10 @@ def test_doc_usage_structure():
         )
     )
 
-    msg1 = ecb.categoryscheme()
+    msg1 = ecb.categoryscheme(provider="all")
 
     assert msg1.response.url == (
-        "http://sdw-wsrest.ecb.int/service/categoryscheme/ECB/latest"
+        "https://sdw-wsrest.ecb.europa.eu/service/categoryscheme/all/latest"
         "?references=parentsandsiblings"
     )
 

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,11 +3,11 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 14
+    assert len(source_ids) == 15
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"
-    assert source_ids[-1] == "WB"
+    assert source_ids[-1] == "WB_WDI"
 
 
 def test_source_support():

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -367,3 +367,16 @@ class TestUNSD(DataSourceTest):
 
 class TestWB(DataSourceTest):
     source_id = "WB"
+
+
+class TestWB_WDI(DataSourceTest):
+    source_id = "WB_WDI"
+
+    endpoint_args = {
+        # Example from the documentation website
+        "data": dict(
+            resource_id="WDI",
+            key="A.SP_POP_TOTL.AFG",
+            params=dict(startPeriod="2011", endPeriod="2011"),
+        )
+    }

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -3,6 +3,7 @@ from typing import Set, Union
 
 import numpy as np
 import pandas as pd
+from pandas.core.indexes.datetimes import prefix_mapping
 
 from sdmx import message, model
 from sdmx.model import (
@@ -432,7 +433,7 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
     if param["freq"]:
         # Determine frequency string, Dimension, or Attribute
         freq = param["freq"]
-        if isinstance(freq, str) and freq not in pd.offsets.prefix_mapping:
+        if isinstance(freq, str) and freq not in prefix_mapping:
             # ID of a Dimension or Attribute
             for component in chain(_get_dims(), _get_attrs()):
                 if component.id == freq:


### PR DESCRIPTION
Closes #9.

Other changes:
- Update tests for changes in targeted web services.
- Use the official domain for the ECB service.
- Fix macOS CI, since the build environment has changed.
- Adjust imports to be compatible with pandas 1.1.0.