### PR TITLE
Enhance writer.xml to round-trip DataMessages

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,9 +3,29 @@
 What's new?
 ***********
 
+.. contents::
+   :local:
+   :backlinks: none
+   :depth: 1
+
 Next release
 ============
 
+New features
+------------
+
+- Enhance :func:`.to_xml` to handle :class:`DataMessages <.DataMessage>` (:pull:`13`).
+
+  In v1.4.0, this feature supports a subset of DataMessages and DataSets.
+  If you have an example of a DataMessages that :mod:`sdmx1` 1.4.0 cannot write, please `file an issue on GitHub <https://github.com/khaeru/sdmx/issues/new>`_ with a file attachment.
+  SDMX-ML features used in such examples will be prioritized for future improvements.
+
+- Add ``compare()`` methods to :class:`.DataMessage`, :class:`.DataSet`, and related classes  (:pull:`13`).
+
+Bug fixes
+---------
+
+- Fix parsing of :class:`.MeasureDimension` returned by :ref:`SGR <SGR>` for data structure queries (:pull:`14`).
 
 v1.3.0 (2020-08-02)
 ===================
@@ -34,7 +54,7 @@ Data model changes
 
 - Change :attr:`.Header.receiver` and :attr:`.Header.sender` to optional :class:`.Agency`, not :class:`str`.
 - Add :attr:`.Header.source` and :attr:`~.Header.test`.
-- :attr:`.IdentifiableArtefact.id` is strictly typed as :class:`str`, with a a singleton object (analogous to :obj:`None`) used for missing IDs.
+- :attr:`.IdentifiableArtefact.id` is strictly typed as :class:`str`, with a singleton object (analogous to :obj:`None`) used for missing IDs.
 - :attr:`.IdentifiableArtefact.id`, :attr:`.VersionableArtefact.version`, and :attr:`.MaintainableArtefact.maintainer` are inferred from a URN if one is passed during construction.
 - :meth:`.VersionableArtefact.identical` and :meth:`.MaintainableArtefact.identical` compare on version and maintainer attributes, respectively.
 - :class:`.Facet`, :class:`.Representation`, and :class:`.ISOConceptReference` are strictly validated, i.e. cannot be assigned non-IM attributes.

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -55,6 +55,29 @@ class Header(BaseModel):
         lines.extend(_summarize(self, self.__fields__.keys()))
         return "\n  ".join(lines)
 
+    def compare(self, other, strict=True):
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two Headers are the same if their corresponding attributes are equal.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
+        return all(
+            compare(attr, self, other, strict)
+            for attr in [
+                "error",
+                "id",
+                "prepared",
+                "receiver",
+                "sender",
+                "source",
+                "test",
+            ]
+        )
+
 
 class Footer(BaseModel):
     """Footer of an SDMX-ML message.
@@ -68,6 +91,21 @@ class Footer(BaseModel):
     text: List[model.InternationalString] = []
     #:
     code: Optional[int] = None
+
+    def compare(self, other, strict=True):
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two Footers are the same if their :attr:`code`, :attr:`severity`, and
+        :attr:`text` are equal.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
+        return all(
+            compare(attr, self, other, strict) for attr in ["severity", "text", "code"]
+        )
 
 
 class Message(BaseModel):
@@ -96,8 +134,20 @@ class Message(BaseModel):
         return "\n  ".join(lines)
 
     def compare(self, other, strict=True):
-        # TODO compare header, footer
-        return True
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two Messages are the same if their :attr:`header` and :attr:`footer` compare
+        equal.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
+        return self.header.compare(other.header, strict) and (
+            self.footer is other.footer is None
+            or self.footer.compare(other.footer, strict)
+        )
 
 
 class ErrorMessage(Message):
@@ -202,6 +252,20 @@ class DataMessage(Message):
         return "\n  ".join(lines)
 
     def compare(self, other, strict=True):
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two DataMessages are the same if:
+
+        - :meth:`.Message.compare` is :obj:`True`
+        - their :attr:`dataflow` and :attr:`observation_dimension` compare equal.
+        - they have the same number of :class:`DataSets <DataSet>`, and
+        - corresponding DataSets compare equal (see :meth:`.DataSet.compare`).
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
         return (
             super().compare(other, strict)
             and compare("dataflow", self, other, strict)

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Text, Union
 from requests import Response
 
 from sdmx import model
-from sdmx.util import BaseModel, DictLike, summarize_dictlike
+from sdmx.util import BaseModel, DictLike, compare, summarize_dictlike
 
 log = logging.getLogger(__name__)
 
@@ -95,6 +95,10 @@ class Message(BaseModel):
         lines.extend(_summarize(self, ["footer", "response"]))
         return "\n  ".join(lines)
 
+    def compare(self, other, strict=True):
+        # TODO compare header, footer
+        return True
+
 
 class ErrorMessage(Message):
     pass
@@ -131,7 +135,7 @@ class StructureMessage(Message):
         strict : bool, optional
             Passed to :meth:`.DictLike.compare`.
         """
-        return all(
+        return super().compare(other, strict) and all(
             getattr(self, attr).compare(getattr(other, attr), strict)
             for attr in (
                 "categorisation",
@@ -196,3 +200,12 @@ class DataMessage(Message):
         lines.extend(_summarize(self, ("dataflow", "observation_dimension")))
 
         return "\n  ".join(lines)
+
+    def compare(self, other, strict=True):
+        return (
+            super().compare(other, strict)
+            and compare("dataflow", self, other, strict)
+            and compare("observation_dimension", self, other, strict)
+            and len(self.data) == len(other.data)
+            and all(ds[0].compare(ds[1], strict) for ds in zip(self.data, other.data))
+        )

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -1894,6 +1894,17 @@ class DataSet(AnnotableArtefact):
         else:
             return ActionType[value]
 
+    def compare(self, other, strict=True):
+        # TODO compare indivial observations, series- and group-keys
+        return (
+            compare("action", self, other, strict)
+            and compare("valid_from", self, other, strict)
+            and self.attrib.compare(other.attrib, strict)
+            and len(self.obs) == len(other.obs)
+            and len(self.series) == len(other.series)
+            and len(self.group) == len(other.group)
+        )
+
 
 class StructureSpecificDataSet(DataSet):
     """SDMX-IM StructureSpecificDataSet."""

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -1585,6 +1585,21 @@ class AttributeValue(BaseModel):
     def __repr__(self):
         return "<{}: {}={}>".format(self.__class__.__name__, self.value_for, self.value)
 
+    def compare(self, other, strict=True):
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two AttributeValues are equal if their properties are equal.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
+        return all(
+            compare(attr, self, other, strict)
+            for attr in ["start_date", "value", "value_for"]
+        )
+
 
 @validate_dictlike("attrib", "values")
 class Key(BaseModel):
@@ -1824,6 +1839,30 @@ class Observation(BaseModel):
     def __str__(self):
         return "{0.key}: {0.value}".format(self)
 
+    def compare(self, other, strict=True):
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two Observations are equal if:
+
+        - their :attr:`dimension`, :attr:`value`, :attr:`series_key`, and
+          :attr:`value_for` are all equal,
+        - their corresponding :attr:`attached_attribute` and :attr:`group_keys` are all
+          equal.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
+        return (
+            all(
+                compare(attr, self, other, strict)
+                for attr in ["dimension", "series_key", "value", "value_for"]
+            )
+            and self.attached_attribute.compare(other.attached_attribute)
+            and self.group_keys == other.group_keys
+        )
+
 
 @validate_dictlike("attrib")
 class DataSet(AnnotableArtefact):
@@ -1895,7 +1934,19 @@ class DataSet(AnnotableArtefact):
             return ActionType[value]
 
     def compare(self, other, strict=True):
-        # TODO compare indivial observations, series- and group-keys
+        """Return :obj:`True` if `self` is the same as `other`.
+
+        Two DataSets are the same if:
+
+        - their :attr:`action`, :attr:`valid_from` compare equal.
+        - all dataset-level attached attributes compare equal.
+        - they have the same number of observations, series, and groups.
+
+        Parameters
+        ----------
+        strict : bool, optional
+            Passed to :func:`.compare`.
+        """
         return (
             compare("action", self, other, strict)
             and compare("valid_from", self, other, strict)
@@ -1903,6 +1954,7 @@ class DataSet(AnnotableArtefact):
             and len(self.obs) == len(other.obs)
             and len(self.series) == len(other.series)
             and len(self.group) == len(other.group)
+            and all(o[0].compare(o[1], strict) for o in zip(self.obs, other.obs))
         )
 
 

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -526,7 +526,7 @@ def _message(reader, elem):
     elif "StructureSpecific" not in elem.tag and reader.get_single(
         model.DataStructureDefinition
     ):
-        log.warning("Ambiguous: dsd=… argument for non–structure-specific message")
+        log.info("Use supplied dsd=… argument for non–structure-specific message")
 
     # Store values for other methods
     reader.push("SS without DSD", ss_without_dsd)

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -482,7 +482,8 @@ class Reader(BaseReader):
                 existing.is_external_reference = False
 
                 # Update `existing` from `obj` to preserve references
-                for attr in list(kwargs.keys()):
+                # If `existing` was a forward reference <Ref/>, its URN was not stored.
+                for attr in list(kwargs.keys()) + ["urn"]:
                     # log.info(
                     #     f"Updating {attr} {getattr(existing, attr)} "
                     #     f"{getattr(obj, attr)}"

--- a/sdmx/tests/data/__init__.py
+++ b/sdmx/tests/data/__init__.py
@@ -39,7 +39,10 @@ BASE_PATH = Path(__file__).parent
 
 # List of specimen files.
 # Each is a tuple: (path, format (xml|json), kind (data|structure))
-TEST_FILES = [(BASE_PATH / "INSEE" / "IPI-2010-A21.xml", "xml", "data")]
+TEST_FILES = [
+    (BASE_PATH / "INSEE" / "CNA-2010-CONSO-SI-A17.xml", "xml", "data"),
+    (BASE_PATH / "INSEE" / "IPI-2010-A21.xml", "xml", "data"),
+]
 
 # XML data files for the ECB exchange rate data flow
 for path in (BASE_PATH / "ECB_EXR").rglob("*.xml"):

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -39,7 +39,6 @@ def test_dataset():
     # Enumeration values can be used to initialize
     from sdmx.model import ActionType
 
-    print(ActionType)
     DataSet(action=ActionType["information"])
 
 

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -43,7 +43,14 @@ _xf_not_equal = pytest.mark.xfail(raises=AssertionError)
 
 @pytest.mark.parametrize(
     "data_id, structure_id",
-    [("ECB_EXR/1/M.USD.EUR.SP00.A.xml", "ECB_EXR/1/structure.xml")],
+    [
+        (
+            "INSEE/CNA-2010-CONSO-SI-A17.xml",
+            "INSEE/CNA-2010-CONSO-SI-A17-structure.xml",
+        ),
+        ("INSEE/IPI-2010-A21.xml", "INSEE/IPI-2010-A21-structure.xml"),
+        ("ECB_EXR/1/M.USD.EUR.SP00.A.xml", "ECB_EXR/1/structure.xml"),
+    ],
 )
 def test_data_roundtrip(pytestconfig, data_id, structure_id, tmp_path):
     """Test that SDMX-ML DataMessages can be 'round-tripped'."""

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -50,6 +50,11 @@ _xf_not_equal = pytest.mark.xfail(raises=AssertionError)
         ),
         ("INSEE/IPI-2010-A21.xml", "INSEE/IPI-2010-A21-structure.xml"),
         ("ECB_EXR/1/M.USD.EUR.SP00.A.xml", "ECB_EXR/1/structure.xml"),
+        pytest.param(
+            "ECB_EXR/ng-ts.xml",
+            "ECB_EXR/ng-structure-full.xml",
+            marks=pytest.mark.xfail(raises=NotImplementedError),
+        ),
     ],
 )
 def test_data_roundtrip(pytestconfig, data_id, structure_id, tmp_path):

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -50,9 +50,17 @@ _xf_not_equal = pytest.mark.xfail(raises=AssertionError)
         ),
         ("INSEE/IPI-2010-A21.xml", "INSEE/IPI-2010-A21-structure.xml"),
         ("ECB_EXR/1/M.USD.EUR.SP00.A.xml", "ECB_EXR/1/structure.xml"),
+        ("ECB_EXR/ng-ts.xml", "ECB_EXR/ng-structure-full.xml"),
+        # DSD reference does not round-trip correctly
         pytest.param(
-            "ECB_EXR/ng-ts.xml",
-            "ECB_EXR/ng-structure-full.xml",
+            "ECB_EXR/rg-xs.xml",
+            "ECB_EXR/rg-structure-full.xml",
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        # Example of a not-implemented feature: DataSet with groups
+        pytest.param(
+            "ECB_EXR/sg-ts-gf.xml",
+            "ECB_EXR/sg-structure-full.xml",
             marks=pytest.mark.xfail(raises=NotImplementedError),
         ),
     ],

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -113,13 +113,9 @@ def _dm(obj: message.DataMessage):
                 dimensionAtObservation=obj.observation_dimension.id,
             )
         )
-        try:
-            # TODO if a URN is missing, use a <Ref>
-            header[-1].append(reference(ds.structured_by, tag="com:Structure"))
-        except TypeError:
-            raise NotImplementedError(
-                "to_xml() for DataMessage with DSD lacking a URN"
-            )
+        # Reference by URN if possible, otherwise with a <Ref> tag
+        style = "URN" if ds.structured_by.urn else "Ref"
+        header[-1].append(reference(ds.structured_by, tag="com:Structure", style=style))
 
         elem.append(writer.recurse(ds))
 
@@ -485,6 +481,9 @@ def _obs(obj: model.Observation):
 
 @writer
 def _ds(obj: model.DataSet):
+    if len(obj.group):
+        raise NotImplementedError("to_xml() for DataSet with groups")
+
     elem = Element("mes:DataSet", action=obj.action, structureRef=obj.structured_by.id)
 
     for sk, observations in obj.series.items():

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -166,6 +166,8 @@ def _header(obj: message.Header):
         elem.append(Element("mes:Prepared", obj.prepared))
     if obj.sender:
         elem.append(writer.recurse(obj.sender, _tag="mes:Sender"))
+    if obj.source:
+        elem.extend(i11lstring(obj.source, "mes:Source"))
     if obj.receiver:
         elem.append(writer.recurse(obj.receiver, _tag="mes:Receiver"))
     return elem

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -113,7 +113,13 @@ def _dm(obj: message.DataMessage):
                 dimensionAtObservation=obj.observation_dimension.id,
             )
         )
-        header[-1].append(reference(ds.structured_by, tag="com:Structure"))
+        try:
+            # TODO if a URN is missing, use a <Ref>
+            header[-1].append(reference(ds.structured_by, tag="com:Structure"))
+        except TypeError:
+            raise NotImplementedError(
+                "to_xml() for DataMessage with DSD lacking a URN"
+            )
 
         elem.append(writer.recurse(ds))
 


### PR DESCRIPTION
Will close #7.

- [x] Complete new `compare()` methods.
- [x] Document new `compare()` methods.
- [x] Test >1 other DataMessage; ensure `writer.xml` gives intelligible/NotImplemented errors for unsupported messages.
- [x] Update What's new.