### PR TITLE
Add UNICEF as a supported source

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -203,10 +203,6 @@ SDMX-ML —
 
 - Supports preview_data and series-key based key validation.
 
-.. warning:: supports categoryscheme even though it offers very few dataflows.
-   Use this feature with caution.
-   Moreover, it seems that categories confusingly include dataflows which UNSD does not actually provide.
-
 
 ``UNESCO``: UN Educational, Scientific and Cultural Organization
 ----------------------------------------------------------------

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -220,6 +220,36 @@ SDMX-ML —
    It seems that Series are not recognized due to some oddity in the XML format.
 
 
+``UNICEF``: UN Children's Fund
+------------------------------
+
+SDMX-ML or SDMX-JSON —
+`API documentation <https://data.unicef.org/sdmx-api-documentation/>`__ —
+`Web interface <https://sdmx.data.unicef.org/>`__
+
+- This source always returns structure-specific messages for SDMX-ML data queries; even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
+- The example query from the UNICEF API documentation (also used in the :mod:`sdmx` test suite) returns XML like:
+
+  .. code-block:: XML
+
+     <mes:Structure structureID="UNICEF_GLOBAL_DATAFLOW_1_0" namespace="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=UNICEF:GLOBAL_DATAFLOW(1.0):ObsLevelDim:TIME_PERIOD" dimensionAtObservation="TIME_PERIOD">
+       <com:StructureUsage>
+         <Ref agencyID="UNICEF" id="GLOBAL_DATAFLOW" version="1.0"/>
+       </com:StructureUsage>
+     </mes:Structure>
+
+  This corresponding DSD actually has the ID ``DSD_AGGREGATE``, which is not obvious from the message.
+  To retrieve the proper DSD, query the data *flow* by ID, and select the DSD from the returned message:
+
+  .. code-block:: python
+
+     req = sdmx.Request("UNICEF")
+     dsd = req.dataflow("GLOBAL_DATAFLOW").structure[0]
+
+  The resulting object `dsd` can be passed as an argument to a :meth:`.Request.data` query.
+  See the `sdmx test suite <https://github.com/khaeru/sdmx/blob/master/sdmx/tests/test_sources.py>`_ for an example.
+
+
 ``WB``: World Bank Group “World Integrated Trade Solution”
 ----------------------------------------------------------
 

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -216,6 +216,8 @@ SDMX-ML —
    It seems that Series are not recognized due to some oddity in the XML format.
 
 
+.. _UNICEF:
+
 ``UNICEF``: UN Children's Fund
 ------------------------------
 
@@ -226,7 +228,7 @@ SDMX-ML or SDMX-JSON —
 - This source always returns structure-specific messages for SDMX-ML data queries; even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
 - The example query from the UNICEF API documentation (also used in the :mod:`sdmx` test suite) returns XML like:
 
-  .. code-block:: XML
+  .. code-block:: xml
 
      <mes:Structure structureID="UNICEF_GLOBAL_DATAFLOW_1_0" namespace="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=UNICEF:GLOBAL_DATAFLOW(1.0):ObsLevelDim:TIME_PERIOD" dimensionAtObservation="TIME_PERIOD">
        <com:StructureUsage>
@@ -234,15 +236,17 @@ SDMX-ML or SDMX-JSON —
        </com:StructureUsage>
      </mes:Structure>
 
-  This corresponding DSD actually has the ID ``DSD_AGGREGATE``, which is not obvious from the message.
-  To retrieve the proper DSD, query the data *flow* by ID, and select the DSD from the returned message:
+  The corresponding DSD actually has the ID ``DSD_AGGREGATE``, which is not obvious from the message.
+  To retrieve the DSD—which is necessary to parse a data message—first query this data *flow* by ID, and select the DSD from the returned message:
 
-  .. code-block:: python
+  .. ipython:: python
 
-     req = sdmx.Request("UNICEF")
-     dsd = req.dataflow("GLOBAL_DATAFLOW").structure[0]
+     import sdmx
+     msg = sdmx.Request("UNICEF").dataflow("GLOBAL_DATAFLOW")
+     msg
+     dsd = msg.structure[0]
 
-  The resulting object `dsd` can be passed as an argument to a :meth:`.Request.data` query.
+  The resulting object `dsd` can be passed as an argument to a :meth:`.Request.get` data query.
   See the `sdmx test suite <https://github.com/khaeru/sdmx/blob/master/sdmx/tests/test_sources.py>`_ for an example.
 
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,6 +14,7 @@ Next release
 New features
 ------------
 
+- Add :ref:`UNICEF <UNICEF>` service to supported sources (:pull:`15`).
 - Enhance :func:`.to_xml` to handle :class:`DataMessages <.DataMessage>` (:pull:`13`).
 
   In v1.4.0, this feature supports a subset of DataMessages and DataSets.

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -8,6 +8,7 @@
 returned by data sources.
 """
 import logging
+from datetime import datetime
 from typing import List, Optional, Text, Union
 
 from requests import Response
@@ -35,10 +36,16 @@ class Header(BaseModel):
 
     #: (optional) Error code for the message.
     error: Optional[Text] = None
+    #: Date and time at which the data was extracted.
+    extracted: Optional[datetime] = None
     #: Identifier for the message.
     id: Optional[Text] = None
     #: Date and time at which the message was generated.
-    prepared: Optional[Text] = None
+    prepared: Optional[datetime] = None
+    #: Start of the time period covered by a :class:`.DataMessage`.
+    reporting_begin: Optional[datetime] = None
+    #: End of the time period covered by a :class:`.DataMessage`.
+    reporting_end: Optional[datetime] = None
     #: Intended recipient of the message, e.g. the user's name for an
     #: authenticated service.
     receiver: Optional[model.Agency] = None
@@ -69,8 +76,11 @@ class Header(BaseModel):
             compare(attr, self, other, strict)
             for attr in [
                 "error",
+                "extracted",
                 "id",
                 "prepared",
+                "reporting_begin",
+                "reporting_end",
                 "receiver",
                 "sender",
                 "source",

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -25,6 +25,8 @@ def _summarize(obj, fields):
         attr = getattr(obj, name)
         if attr is None:
             continue
+        elif isinstance(attr, datetime):
+            attr = attr.isoformat()
         yield f"{name}: {repr(attr)}"
 
 

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -702,15 +702,12 @@ def _text(reader, elem):
 
 @end("mes:Extracted mes:Prepared mes:ReportingBegin mes:ReportingEnd")
 def _datetime(reader, elem):
-    text = elem.text
-    replace = dict()
-
     # Handle "Z" as a shorthand for "+00:00", i.e. UTC
-    if text.endswith("Z"):
-        text = text[:-1]
-        replace["tzinfo"] = timezone.utc
+    text = re.sub(r"(.*)Z$", r"\1+00:00", elem.text)
+    # Truncate seconds decimal places beyond the 6th; incorrectly returned by e.g. UNSD
+    text = re.sub(r"(.*\.)(\d{6})\d+(\+.*)", r"\1\2\3", text)
 
-    reader.push(elem, datetime.fromisoformat(text).replace(**replace))
+    reader.push(elem, datetime.fromisoformat(text))
 
 
 @end(

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -10,6 +10,7 @@ import logging
 import re
 from collections import defaultdict
 from copy import copy
+from datetime import datetime, timezone
 from itertools import chain, product
 from operator import itemgetter
 from sys import maxsize
@@ -542,8 +543,11 @@ def _message(reader, elem):
 def _header(reader, elem):
     # Attach to the Message
     header = message.Header(
+        extracted=reader.pop_single("Extracted") or None,
         id=reader.pop_single("ID") or None,
         prepared=reader.pop_single("Prepared") or None,
+        reporting_begin=reader.pop_single("ReportingBegin") or None,
+        reporting_end=reader.pop_single("ReportingEnd") or None,
         receiver=reader.pop_single("Receiver") or None,
         sender=reader.pop_single("Sender") or None,
         test=str(reader.pop_single("Test")).lower() == "true",
@@ -553,8 +557,6 @@ def _header(reader, elem):
     reader.get_single(message.Message).header = header
 
     # TODO add these to the Message class
-    # Appearing in data messages from WB_WDI
-    reader.pop_all("Extracted")
     # Appearing in data messages from WB_WDI and the footer.xml specimen
     reader.pop_all("DataSetAction")
     reader.pop_all("DataSetID")
@@ -690,12 +692,25 @@ def _structures(reader, elem):
 
 
 @end(
-    "mes:DataSetAction mes:DataSetID mes:ID mes:Prepared mes:Test mes:Timezone "
-    "com:AnnotationType com:AnnotationTitle com:AnnotationURL com:None com:URN "
-    "com:Value mes:Email mes:Extracted str:Email str:Telephone str:URI"
+    "com:AnnotationTitle com:AnnotationType com:AnnotationURL com:None com:URN "
+    "com:Value mes:DataSetAction mes:DataSetID mes:Email mes:ID mes:Test mes:Timezone "
+    "str:Email str:Telephone str:URI"
 )
 def _text(reader, elem):
     reader.push(elem, elem.text)
+
+
+@end("mes:Extracted mes:Prepared mes:ReportingBegin mes:ReportingEnd")
+def _datetime(reader, elem):
+    text = elem.text
+    replace = dict()
+
+    # Handle "Z" as a shorthand for "+00:00", i.e. UTC
+    if text.endswith("Z"):
+        text = text[:-1]
+        replace["tzinfo"] = timezone.utc
+
+    reader.push(elem, datetime.fromisoformat(text).replace(**replace))
 
 
 @end(

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -110,6 +110,12 @@
     "supports": {"datastructure": false}
   },
   {
+    "id": "UNICEF",
+    "name": "UN Children's Fund",
+    "url": "https://sdmx.data.unicef.org/ws/public/sdmxapi/rest",
+    "supports": {"structure-specific data": true}
+  },
+  {
     "id": "UNSD",
     "name": "United Nations Statistics Division",
     "url": "http://data.un.org/WS/rest",

--- a/sdmx/tests/test_message.py
+++ b/sdmx/tests/test_message.py
@@ -14,7 +14,7 @@ EXPECTED = [
         """<sdmx.StructureMessage>
   <Header>
     id: 'categorisation_1450864290565'
-    prepared: '2015-12-23T09:51:30.565Z'
+    prepared: '2015-12-23T09:51:30.565000+00:00'
     receiver: <Agency unknown>
     sender: <Agency FR1: Institut national de la statistique et des études économiques>
     source: fr: Banque de données macro-économiques
@@ -32,7 +32,7 @@ EXPECTED = [
         """<sdmx.StructureMessage>
   <Header>
     id: 'dataflow_ENQ-CONJ-TRES-IND-PERSP_1450865196042'
-    prepared: '2015-12-23T10:06:36.042Z'
+    prepared: '2015-12-23T10:06:36.042000+00:00'
     receiver: <Agency unknown>
     sender: <Agency FR1: Institut national de la statistique et des études économiques>
     source: fr: Banque de données macro-économiques
@@ -61,7 +61,7 @@ EXPECTED = [
         """<sdmx.DataMessage>
   <Header>
     id: '62b5f19d-f1c9-495d-8446-a3661ed24753'
-    prepared: '2012-11-29T08:40:26Z'
+    prepared: '2012-11-29T08:40:26+00:00'
     sender: <Agency ECB: European Central Bank>
     source: """
         """

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,7 +3,7 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 15
+    assert len(source_ids) == 16
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -354,6 +354,15 @@ class TestUNESCO(DataSourceTest):
     }
 
 
+class TestUNICEF(DataSourceTest):
+    source_id = "UNICEF"
+
+    @pytest.mark.network
+    def test_data(self, req):
+        dsd = req.dataflow("GLOBAL_DATAFLOW").structure[0]
+        req.data("GLOBAL_DATAFLOW", key="ALB+DZA.MNCH_INSTDEL.", dsd=dsd)
+
+
 class TestUNSD(DataSourceTest):
     source_id = "UNSD"
 

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -167,7 +167,7 @@ def _header(obj: message.Header):
     if obj.id:
         elem.append(Element("mes:ID", obj.id))
     if obj.prepared:
-        elem.append(Element("mes:Prepared", obj.prepared))
+        elem.append(Element("mes:Prepared", obj.prepared.isoformat()))
     if obj.sender:
         elem.append(writer.recurse(obj.sender, _tag="mes:Sender"))
     if obj.source:


### PR DESCRIPTION
- Update sources.json, docs, tests, and What's new.
- UNICEF returns ReportingBegin and ReportingEnd header fields; add these to `message.Header`
- Use Python's built-in datetime objects for Header fields, read/write strings in XML.