### PR TITLE
Adjust CI configuration for Python versions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,14 +17,17 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - '3.7.0'        # Earliest supported
-        - '3.8.5'        # Latest release
-        - '3.9.0-beta5'  # Development version
+        - "3.7"  # Earliest supported version
+        - "3.8"  # Latest supported version
+        # commented: not supported by pydantic 1.6.1
+        # - "3.9"  # Latest version
+        # commented: only enable once next Python version enters RC
+        # - "3.10.0-rc.1"  # Development version
 
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +35,8 @@ jobs:
         submodules: true
 
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/sdmx/reader/sdmxml.py
+++ b/sdmx/reader/sdmxml.py
@@ -398,7 +398,7 @@ class Reader(BaseReader):
         # MaintainableArtefact with is_external_reference=True; either a new object, or
         # reference to an existing object
         target_or_parent = self.maintainable(
-            ref.cls, None, id=ref.id, maintainer=ref.agency, version=ref.version,
+            ref.cls, None, id=ref.id, maintainer=ref.agency, version=ref.version
         )
 
         if ref.maintainable:
@@ -662,7 +662,7 @@ def _footer(reader, elem):
         args["code"] = int(args["code"])
 
     reader.get_single(message.Message).footer = message.Footer(
-        text=list(map(model.InternationalString, reader.pop_all("Text"))), **args,
+        text=list(map(model.InternationalString, reader.pop_all("Text"))), **args
     )
 
 
@@ -991,7 +991,7 @@ def _dk(reader, elem):
         # Convert MemberSelection/MemberValue from _ms() to ComponentValue
         key_value={
             ms.values_for: model.ComponentValue(
-                value_for=ms.values_for, value=ms.values.pop().value,
+                value_for=ms.values_for, value=ms.values.pop().value
             )
             for ms in reader.pop_all(model.MemberSelection)
         },
@@ -1194,7 +1194,7 @@ def _series_ss(reader, elem):
     ds.add_obs(
         reader.pop_all(model.Observation),
         ds.structured_by.make_key(
-            model.SeriesKey, elem.attrib, extend=reader.peek("SS without DSD"),
+            model.SeriesKey, elem.attrib, extend=reader.peek("SS without DSD")
         ),
     )
 
@@ -1218,7 +1218,7 @@ def _group_ss(reader, elem):
     group_id = attrib.pop(qname("xsi", "type"), None)
 
     gk = ds.structured_by.make_key(
-        model.GroupKey, attrib, extend=reader.peek("SS without DSD"),
+        model.GroupKey, attrib, extend=reader.peek("SS without DSD")
     )
 
     if group_id:

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -114,7 +114,7 @@ def test_identifiable():
 
 def test_nameable(caplog):
     na1 = model.NameableArtefact(
-        name=dict(en="Name"), description=dict(en="Description"),
+        name=dict(en="Name"), description=dict(en="Description")
     )
     na2 = model.NameableArtefact()
 

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -36,7 +36,7 @@ def test_structuremessage(tmp_path, structuremessage):
 
 
 _xf_ref = pytest.mark.xfail(
-    raises=NotImplementedError, match="Cannot write reference to .* without parent",
+    raises=NotImplementedError, match="Cannot write reference to .* without parent"
 )
 _xf_not_equal = pytest.mark.xfail(raises=AssertionError)
 
@@ -96,7 +96,7 @@ def test_data_roundtrip(pytestconfig, data_id, structure_id, tmp_path):
         ("ECB_EXR/1/structure-full.xml", False),
         ("ESTAT/apro_mk_cola-structure.xml", True),
         pytest.param(
-            "ISTAT/47_850-structure.xml", True, marks=[pytest.mark.skip(reason="Slow")],
+            "ISTAT/47_850-structure.xml", True, marks=[pytest.mark.skip(reason="Slow")]
         ),
         pytest.param("IMF/ECOFIN_DSD-structure.xml", True, marks=_xf_ref),
         ("INSEE/CNA-2010-CONSO-SI-A17-structure.xml", False),

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -312,7 +312,7 @@ def _component(obj: model.Component):
     elem = identifiable(obj)
     if obj.concept_identity:
         elem.append(
-            reference(obj.concept_identity, tag="str:ConceptIdentity", style="Ref",)
+            reference(obj.concept_identity, tag="str:ConceptIdentity", style="Ref")
         )
     if obj.local_representation:
         elem.append(


### PR DESCRIPTION
- Python 3.9 is still excluded because pydantic 1.6.1 does not support it. samuelcolvin/pydantic#1844 is merged but not yet released.
- Remove some needless trailing commas that black 20.8b1 wanted to treat differently than previous version of black.