### PR TITLE
Add Statistics Estonia as a source in sdmx/sources.json.

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -194,6 +194,18 @@ SDMX-ML —
    :members:
 
 
+.. _STAT_EE:
+
+``STAT_EE``: Statistics Estonia (Estonia)
+-----------------------------------------
+
+SDMX-JSON —
+`Website <http://andmebaas.stat.ee>`__ (et) —
+API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf>`__, `(et) <https://www.stat.ee/sites/default/files/2020-09/API-juhend.pdf>`__
+
+- Estonian name: Eesti Statistika.
+
+
 ``UNSD``: United Nations Statistics Division
 --------------------------------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,7 @@ What's new?
 Next release
 ============
 
+- Add :ref:`Statistics Estonia <STAT_EE>` as a data source (:pull:`25`).
 - Supply provider=“ALL” to :ref:`INSEE <INSEE>` structure queries by default (:issue:`21`, :pull:`22`)
 
 v1.4.0 (2020-08-17)

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -101,6 +101,13 @@
     "name": "SDMX Global Registry"
   },
   {
+    "id": "STAT_EE",
+    "data_content_type": "JSON",
+    "documentation": "https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf",
+    "url": "http://andmebaas.stat.ee/sdmx-json",
+    "name": "Statistics Estonia"
+  },
+  {
     "id": "UNESCO",
     "name": "UN Educational, Scientific and Cultural Organization",
     "url": "http://api.uis.unesco.org/sdmx",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,7 +3,7 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 16
+    assert len(source_ids) == 17
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -328,6 +328,19 @@ class TestSGR(DataSourceTest):
     source_id = "SGR"
 
 
+class TestSTAT_EE(DataSourceTest):
+    source_id = "STAT_EE"
+
+    endpoint_args = {
+        # Using the example from the documentation
+        "data": dict(
+            resource_id="VK12",
+            key="TRD_VAL+TRD_VAL_PREV..TOTAL.A",
+            params=dict(startTime=2013, endTime=2017),
+        )
+    }
+
+
 class TestUNESCO(DataSourceTest):
     source_id = "UNESCO"
     xfail = {


### PR DESCRIPTION
Please find attached a pull request adding a new source: Statistics Estonia uses the same server as the OECD (SDMX 2.0 and JSON).

Cheers,
Bertrand