### PR TITLE
Prepare and pass kwargs, including proxies, to requests.Session.send()

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,9 @@ What's new?
 
 Next release
 ============
- 
+
+- Respect `HTTP[S]_PROXY` environment variables (:issue:`26`, :pull:`27`).
+
 
 v1.5.0 (2020-11-12)
 ===================


### PR DESCRIPTION
Closes #26.

## How to review

Attempt to make requests using an HTTP proxy.