### PR TITLE
Add SPC PDH.stat to sources

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -222,6 +222,17 @@ SDMX-ML —
    :members:
 
 
+.. _SPC:
+
+``SPC``: Pacific Data Hub DotStat by the Pacific Community (SPC)
+-----------------------------
+
+SDMX-ML —
+`API documentation <https://docs.pacificdata.org/dotstat/>`__ —
+`Web interface <https://stats.pacificdata.org/>`__
+
+- French name: Communauté du Pacifique
+
 .. _STAT_EE:
 
 ``STAT_EE``: Statistics Estonia (Estonia)

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -225,13 +225,14 @@ SDMX-ML —
 .. _SPC:
 
 ``SPC``: Pacific Data Hub DotStat by the Pacific Community (SPC)
------------------------------
+----------------------------------------------------------------
 
 SDMX-ML —
 `API documentation <https://docs.pacificdata.org/dotstat/>`__ —
 `Web interface <https://stats.pacificdata.org/>`__
 
 - French name: Communauté du Pacifique
+
 
 .. _STAT_EE:
 

--- a/doc/walkthrough.rst
+++ b/doc/walkthrough.rst
@@ -254,9 +254,12 @@ Let's return to explore the :class:`.ContentConstraint` that came with our metad
 
     # Get the valid members for two dimensions
     c1 = sdmx.to_pandas(cr.member['CURRENCY'].values)
+    # Convert list() to set()
+    c1 = set(c1)
     len(c1)
 
     c2 = sdmx.to_pandas(cr.member['CURRENCY_DENOM'].values)
+    c2 = set(c2)
     len(c2)
 
     # Explore the contents

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,7 +11,7 @@ What's new?
 Next release
 ============
 
-- Add The Pacific Community's (SPC) Pacific Data Hub DotStat (PDHSTAT) as a data source (:pull:`30`).
+- Add :ref:`The Pacific Community's Pacific Data Hub <SPC>` as a data source (:pull:`30`).
 - Add classes to :mod:`sdmx.model`: :class:`.TimeRangeValue`, :class:`.Period`, :class:`RangePeriod`, and parse ``<com:TimeRange>`` and related tags in SDMX-ML (:pull:`30`).
 
 v1.6.0 (2020-12-16)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -27,7 +27,7 @@ Bug fixes
 
 - Data set-level attributes were not collected by :class:`.sdmxml.Reader` (:issue:`29`, :pull:`33`).
 - Respect `HTTP[S]_PROXY` environment variables (:issue:`26`, :pull:`27`).
-
+- Add The Pacific Community's (SPC) Pacific Data Hub DotStat (PDHSTAT) as a data source
 
 v1.5.0 (2020-11-12)
 ===================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,8 @@ What's new?
 Next release
 ============
 
+- Add The Pacific Community's (SPC) Pacific Data Hub DotStat (PDHSTAT) as a data source (:pull:`30`).
+- Add classes to :mod:`sdmx.model`: :class:`.TimeRangeValue`, :class:`.Period`, :class:`RangePeriod`, and parse ``<com:TimeRange>`` and related tags in SDMX-ML (:pull:`30`).
 
 v1.6.0 (2020-12-16)
 ===================
@@ -27,7 +29,6 @@ Bug fixes
 
 - Data set-level attributes were not collected by :class:`.sdmxml.Reader` (:issue:`29`, :pull:`33`).
 - Respect `HTTP[S]_PROXY` environment variables (:issue:`26`, :pull:`27`).
-- Add The Pacific Community's (SPC) Pacific Data Hub DotStat (PDHSTAT) as a data source
 
 v1.5.0 (2020-11-12)
 ===================

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -1071,13 +1071,28 @@ class MemberValue(SelectionValue):
             return self.value == other
 
 
+class TimeRangeValue(BaseModel):
+    """SDMX-IM TimeRangeValue."""
+
+
+class Period(BaseModel):
+    is_inclusive: bool
+    period: datetime
+
+
+class RangePeriod(TimeRangeValue):
+    start: Period
+    end: Period
+
+
 class MemberSelection(BaseModel):
     #:
     included: bool = True
     #:
     values_for: Component
-    #: NB the spec does not say what this feature should be named
-    values: Set[MemberValue] = set()
+    #: Value(s) included in the selection. Note that the name of this attribute is not
+    #: stated in the IM, so 'values' is chosen for the implementation in this package.
+    values: List[SelectionValue] = []
 
     def __contains__(self, value):
         """Compare KeyValue to MemberValue."""

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -1071,7 +1071,7 @@ class MemberValue(SelectionValue):
             return self.value == other
 
 
-class TimeRangeValue(BaseModel):
+class TimeRangeValue(SelectionValue):
     """SDMX-IM TimeRangeValue."""
 
 

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -120,6 +120,12 @@
     "name": "SDMX Global Registry"
   },
   {
+    "id": "SPC",
+    "name": "Pacific Data Hub DotStat by the Pacific Community (SPC)",
+    "url": "https://stats-nsi-stable.pacificdata.org/rest",
+    "documentation": "https://docs.pacificdata.org/dotstat"
+  },
+  {
     "id": "STAT_EE",
     "data_content_type": "JSON",
     "documentation": "https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf",

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -121,9 +121,10 @@
   },
   {
     "id": "SPC",
-    "name": "Pacific Data Hub DotStat by the Pacific Community (SPC)",
+    "name": "Pacific Data Hub DotStat by The Pacific Community (SPC)",
     "url": "https://stats-nsi-stable.pacificdata.org/rest",
-    "documentation": "https://docs.pacificdata.org/dotstat"
+    "documentation": "https://docs.pacificdata.org/dotstat",
+    "supports": {"provisionagreement": false}
   },
   {
     "id": "STAT_EE",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,7 +3,7 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 19
+    assert len(source_ids) == 20
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -368,6 +368,10 @@ class TestSGR(DataSourceTest):
     source_id = "SGR"
 
 
+class TestSPC(DataSourceTest):
+    source_id = "SPC"
+
+
 class TestSTAT_EE(DataSourceTest):
     source_id = "STAT_EE"
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -370,7 +370,14 @@ class TestSGR(DataSourceTest):
 
 class TestSPC(DataSourceTest):
     source_id = "SPC"
-
+    
+    endpoint_args = {
+        "data": dict(
+            resource_id="DF_CPI",
+            key="A.CK+FJ..",
+            params=dict(startPeriod=2010, endPeriod=2015),
+        )
+    }
 
 class TestSTAT_EE(DataSourceTest):
     source_id = "STAT_EE"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -370,7 +370,7 @@ class TestSGR(DataSourceTest):
 
 class TestSPC(DataSourceTest):
     source_id = "SPC"
-    
+
     endpoint_args = {
         "data": dict(
             resource_id="DF_CPI",
@@ -378,6 +378,7 @@ class TestSPC(DataSourceTest):
             params=dict(startPeriod=2010, endPeriod=2015),
         )
     }
+
 
 class TestSTAT_EE(DataSourceTest):
     source_id = "STAT_EE"

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -34,6 +34,8 @@ def make(obj, maintainable_parent=None):
         raise ValueError(
             f"Neither {repr(obj)} nor {repr(maintainable_parent)} are maintainable"
         )
+    elif ma.maintainer is None:
+        raise ValueError(f"Cannot construct URL for {repr(ma)} without maintainer")
 
     return _BASE.format(
         package=PACKAGE[obj.__class__], obj=obj, ma=ma, extra_id=extra_id

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Set, Union
+from typing import Set, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -195,7 +195,9 @@ def _cr(obj: model.CubeRegion, **kwargs):
     result: DictLike[str, pd.Series] = DictLike()
     for dim, memberselection in obj.member.items():
         result[dim.id] = pd.Series(
-            [mv.value for mv in memberselection.values], name=dim.id
+            # cast(): as of PR#30, only MemberValue is supported here
+            [cast(model.MemberValue, mv).value for mv in memberselection.values],
+            name=dim.id,
         )
     return result
 

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -368,7 +368,11 @@ def _cat(obj: model.Categorisation):
 @writer
 def _ms(obj: model.MemberSelection):
     elem = Element("com:KeyValue", id=obj.values_for.id)
-    elem.extend(Element("com:Value", mv.value) for mv in obj.values)
+    elem.extend(
+        # cast(): as of PR#30, only MemberValue is supported here
+        Element("com:Value", cast(model.MemberValue, mv).value)
+        for mv in obj.values
+    )
     return elem
 
 


### PR DESCRIPTION
- Add The Pacific Community's (SPC) DotStat instance "Pacific Data Hub DotStat" (PDH.stat) to data sources
- Update sources.json, docs, tests, and What's new
- Add support for handling `common:TimeRange`

**PR checklist**
- [x] Include a description (above).
- [x] (Maybe) Mark unsupported endpoints in sources.json.
- [x] Add to doc/sources.rst and ensure it is linked from doc/whatsnew.rst.
- [x] Add a specific data query to `test_sources.TestSPC`.
- [x] Increment the number in `test_list_sources()`.
- [x] Extend SDMX-ML reader for `<com:TimeRange>` (@khaeru)
- [x] Extend `writer.pandas` to handle `model.RangePeriod` (@khaeru)