### PR TITLE
Add a new source with tests and doc for NBB (National Bank of Belgium)

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -189,7 +189,7 @@ SDMX-ML —
 .. _NBB:
 
 ``NBB``: National Bank of Belgium (Belgium)
------------------------------------------
+-------------------------------------------
 
 SDMX-JSON —
 `Website <https://stat.nbb.be/>`__

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -174,7 +174,7 @@ SDMX-ML —
 `Website <https://osp.stat.gov.lt/rdb-rest>`__
 
 - Lithuanian name: Lietuvos statistikos.
-- This web service returns the non-standard HTTP content-type "application/force-download"; :mod:`sdmx` replaces it with "application/xml"
+- This web service returns the non-standard HTTP content-type "application/force-download"; :mod:`sdmx` replaces it with "application/xml".
 
 
 ``NB``: Norges Bank (Norway)
@@ -186,17 +186,20 @@ SDMX-ML —
 - Few dataflows. So do not use categoryscheme.
 - It is unknown whether NB supports series-keys-only.
 
+
 .. _NBB:
 
 ``NBB``: National Bank of Belgium (Belgium)
 -------------------------------------------
 
 SDMX-JSON —
-`Website <https://stat.nbb.be/>`__
+`Website <https://stat.nbb.be/>`__ —
 API documentation `(en) <https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf>`__
 
 - French name: Banque Nationale de Belgique.
 - Dutch name: Nationale Bank van België.
+- As of 2020-12-13, this web service (like STAT_EE) uses server software that serves SDMX-ML 2.0 or SDMX-JSON.
+  Since :mod:`sdmx` does not support SDMX-ML 2.0, the package is configured to use the JSON endpoint.
 
 ``OECD``: Organisation for Economic Cooperation and Development
 ---------------------------------------------------------------
@@ -227,6 +230,8 @@ SDMX-JSON —
 API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf>`__, `(et) <https://www.stat.ee/sites/default/files/2020-09/API-juhend.pdf>`__
 
 - Estonian name: Eesti Statistika.
+- As of 2020-12-13, this web service (like NBB) uses server software that serves SDMX-ML 2.0 or SDMX-JSON.
+  Since :mod:`sdmx` does not support SDMX-ML 2.0, the package is configured to use the JSON endpoint.
 
 
 ``UNSD``: United Nations Statistics Division

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -186,6 +186,17 @@ SDMX-ML —
 - Few dataflows. So do not use categoryscheme.
 - It is unknown whether NB supports series-keys-only.
 
+.. _NBB:
+
+``NBB``: National Bank of Belgium (Belgium)
+-----------------------------------------
+
+SDMX-JSON —
+`Website <https://stat.nbb.be/>`__
+API documentation `(en) <https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf>`__
+
+- French name: Banque Nationale de Belgique.
+- Dutch name: Nationale Bank van België.
 
 ``OECD``: Organisation for Economic Cooperation and Development
 ---------------------------------------------------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,7 @@ What's new?
 Next release
 ============
 
+- Add :ref:`National Bank of Belgium <NBB>` as a data source (:pull:`32`).
 - Add :ref:`Statistics Lithuania <LSD>` as a data source (:pull:`33`).
 - Bugfix: data set-level attributes were not collected by :class:`.sdmxml.Reader` (:issue:`29`, :pull:`33`).
 - Respect `HTTP[S]_PROXY` environment variables (:issue:`26`, :pull:`27`).

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -91,6 +91,13 @@
     }
   },
   {
+    "id": "NBB",
+    "data_content_type": "JSON",
+    "documentation": "https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf",
+    "url": "https://stat.nbb.be/sdmx-json",
+    "name": "National Bank of Belgium"
+  },
+  {
     "id": "OECD",
     "data_content_type": "JSON",
     "url": "https://stats.oecd.org/SDMX-JSON",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,7 +3,7 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 18
+    assert len(source_ids) == 19
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -341,6 +341,16 @@ class TestNB(DataSourceTest):
     # This source returns a valid SDMX Error message (100 No Results Found)
     # for the 'categoryscheme' endpoint.
 
+class TestNBB(DataSourceTest):
+    source_id = "NBB"
+
+    endpoint_args = {
+        "data": dict(
+            resource_id="REGPOP",
+            key="POPULA.000.A",
+            params=dict(startTime=2013, endTime=2017),
+        )
+    }
 
 class TestOECD(DataSourceTest):
     source_id = "OECD"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -341,6 +341,7 @@ class TestNB(DataSourceTest):
     # This source returns a valid SDMX Error message (100 No Results Found)
     # for the 'categoryscheme' endpoint.
 
+
 class TestNBB(DataSourceTest):
     source_id = "NBB"
 
@@ -351,6 +352,7 @@ class TestNBB(DataSourceTest):
             params=dict(startTime=2013, endTime=2017),
         )
     }
+
 
 class TestOECD(DataSourceTest):
     source_id = "OECD"


### PR DESCRIPTION
@khaeru please find attached a new source for the National Bank of Belgium. As STAT_EE, it is based on the same server as the OECD, hence limited to SDMX 2.0 and SDMX-json.