### PR TITLE
Use override inside add_source

### DIFF
--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -173,7 +173,7 @@ def add_source(info, id=None, override=False, **kwargs):
 
     info.update(kwargs)
 
-    if id in sources:
+    if not override and id in sources:
         raise ValueError("Data source '%s' already defined; use override=True", id)
 
     # Maybe import a subclass that defines a hook


### PR DESCRIPTION
Right now `override` argument of the `add_source` function is not used, so it's impossible to re-define/define multiple times source with the same id.