### PR TITLE
Address failures in test_sources

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -60,14 +60,14 @@ jobs:
     - name: Install the Python package and dependencies
       run: pip install .[cache,docs,tests]
 
-    - name: Run pytest
-      if: ${{ github.event_name == 'pull_request' }}
-      env:
-        SDMX_TEST_DATA: ./sdmx-test-data/
-      run: pytest --cov-report=xml -ra --color=yes --verbose
+    # - name: Run pytest
+    #   if: ${{ github.event_name == 'pull_request' }}
+    #   env:
+    #     SDMX_TEST_DATA: ./sdmx-test-data/
+    #   run: pytest --cov-report=xml -ra --color=yes --verbose
 
     - name: Run pytest, including tests of specific web services
-      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && contains(matrix.os, 'ubuntu') }}
+      # if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && contains(matrix.os, 'ubuntu') }}
       env:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: pytest -m "not experimental" --cov-report=xml -ra --color=yes --verbose

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,6 +28,11 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
+    - name: Cancel previous runs that have not completed
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+
     - uses: actions/checkout@v2
 
     - name: Checkout test data

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -56,13 +56,13 @@ jobs:
       run: pip install .[cache,docs,tests]
 
     - name: Run pytest
-      if: ${{ github.event_name != 'schedule' }}
+      if: ${{ github.event_name == 'pull_request' }}
       env:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: pytest --cov-report=xml -ra --color=yes --verbose
 
     - name: Run pytest, including tests of specific web services
-      if: ${{ github.event_name == 'schedule' && contains(matrix.os, 'ubuntu') }}
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && contains(matrix.os, 'ubuntu') }}
       env:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: pytest -m "not experimental" --cov-report=xml -ra --color=yes --verbose

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -60,14 +60,14 @@ jobs:
     - name: Install the Python package and dependencies
       run: pip install .[cache,docs,tests]
 
-    # - name: Run pytest
-    #   if: ${{ github.event_name == 'pull_request' }}
-    #   env:
-    #     SDMX_TEST_DATA: ./sdmx-test-data/
-    #   run: pytest --cov-report=xml -ra --color=yes --verbose
+    - name: Run pytest
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        SDMX_TEST_DATA: ./sdmx-test-data/
+      run: pytest --cov-report=xml -ra --color=yes --verbose
 
     - name: Run pytest, including tests of specific web services
-      # if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && contains(matrix.os, 'ubuntu') }}
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && contains(matrix.os, 'ubuntu') }}
       env:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: pytest -m "not experimental" --cov-report=xml -ra --color=yes --verbose

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -133,8 +133,8 @@ def test_request_get_args():
 def test_read_url():
     # URL can be queried without instantiating Client
     sdmx.read_url(
-        "http://sdw-wsrest.ecb.int/service/datastructure/ECB/"
-        "ECB_EXR1/latest?references=all"
+        "https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/latest?"
+        "references=all"
     )
 
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -203,23 +203,28 @@ class TestISTAT(DataSourceTest):
 
     @pytest.mark.network
     def test_gh_75(self, specimen, client):
-        """Test of https://github.com/dr-leo/pandaSDMX/pull/75."""
+        """Test of https://github.com/dr-leo/pandaSDMX/pull/75.
+
+        As of the original report on 2019-06-02, the 4th dimension was ``TIPO_DATO``,
+        and the 5th ``TIPO_GESTIONE``. As of 2021-01-30, these are transposed, and the
+        4th dimension name is ``TIPO_GEST``.
+        """
 
         df_id = "47_850"
 
-        # # Reported Dataflow query works
-        # df = client.dataflow(df_id).dataflow[df_id]
-
-        with specimen("47_850-structure") as f:
-            df = sdmx.read_sdmx(f).dataflow[df_id]
+        # Reported Dataflow query works
+        # Without references="datastructure", this is a very slow query
+        df = client.dataflow(df_id, params={"references": "datastructure"}).dataflow[
+            df_id
+        ]
 
         # dict() key for the query
         data_key = dict(
             FREQ=["A"],
-            ITTER107=["001001"],
+            ITTER107=["001001+001002"],
             SETTITOLARE=["1"],
+            TIPO_GEST=["ALL"],
             TIPO_DATO=["AUTP"],
-            TIPO_GESTIONE=["ALL"],
             TIPSERVSOC=["ALL"],
         )
 
@@ -229,7 +234,9 @@ class TestISTAT(DataSourceTest):
         ) + ["TIME_PERIOD"]
 
         # Reported data query works
-        client.data(df_id, key="A.001001+001002.1.AUTP.ALL.ALL")
+        # NB the reported query key was "A.001001+001002.1.AUTP.ALL.ALL"; adjusted per
+        #    the DSD change (above).
+        client.data(df_id, key="A.001001+001002.1.ALL.AUTP.ALL")
 
         # Use a dict() key to force Client to make a sub-query for the DSD
         client.data(df_id, key=data_key)

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -54,7 +54,7 @@ class DataSourceTest:
     #    docstring to describe the nature of the problem.
     # @pytest.fixture
     # def client(self, cache_path):
-    #     """Identical to DataSourceTest, except add verify=False.
+    #     """Identical to DataSourceTest, except skip SSL certificate verification.
     #
     #     As of [DATE], this source returns an invalid certificate.
     #     """
@@ -251,6 +251,17 @@ class TestLSD(DataSourceTest):
             params=dict(startPeriod="2005-01", endPeriod="2007-01"),
         )
     }
+
+    @pytest.fixture
+    def client(self, cache_path):
+        """Identical to DataSourceTest, except skip SSL certificate verification.
+
+        As of 2021-01-30, this source returns a certificate that is treated as invalid
+        by the GitHub Actions job runner; but *not* on a local machine.
+        """
+        return Client(
+            self.source_id, cache_name=str(cache_path), backend="sqlite", verify=False
+        )
 
 
 class TestNB(DataSourceTest):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -196,7 +196,6 @@ class TestINEGI(DataSourceTest):
 
 class TestINSEE(DataSourceTest):
     source_id = "INSEE"
-    tolerate_503 = True
 
 
 class TestISTAT(DataSourceTest):


### PR DESCRIPTION
- **ECB**: `test_client.test_read_url` was using an old URL (wrong domain, no HTTPS), causing a redirect loop.
- **INSEE**: remove XFAIL expecting 503 errors. This was the last source using this setting.
- **ISTAT**: update test of workflow “47_850” for a DSD has changed since that issue was originally filed/fixed.
- **LSD**: tolerate SSL certificates treated as not valid on GHA runners. The certificates _are_ treated as valid on my local machine 🤷🏽‍♂️ 

As well:
- Run source tests immediately on push to `master`.This:
  - Allows quicker spotting of these issues versus waiting for the nightly tests.
  - Causes the benchmark test coverage to be set at 97% vs. 94%, because the source-specific code is tested.