### PR TITLE
Temporarily exclude pydantic 1.8

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -18,6 +18,9 @@ Dependencies
 
 - `pandas <http://pandas.pydata.org>`_ for data structures,
 - `pydantic <https://pydantic-docs.helpmanual.io>`_ to implement the IM,
+
+  - :mod:`sdmx` is currently not compatible with pydantic >= 1.8; see :pull:`62`.
+
 - `requests <https://pypi.python.org/pypi/requests/>`_ for HTTP requests, and
 - `lxml <http://www.lxml.de>`_ for XML processing.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,8 @@ What's new?
 .. Next release
 .. ============
 
+- Temporary exclude :mod:`pydantic` versions >= 1.8 (:pull:`62`).
+
 v2.2.0 (2021-02-26)
 ===================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >= 3.7.2
 install_requires =
     lxml >= 3.6
     pandas >= 1.0
-    pydantic >= 1.7
+    pydantic >= 1.7, <1.8
     python-dateutil
     requests >= 2.7
     setuptools >= 41


### PR DESCRIPTION
Tests began to fail today (https://github.com/khaeru/sdmx/runs/1992616989?check_suite_focus=true) because pydantic 1.8 was released and picked up.

This version includes improvements that will allow to eliminate some or all of the workarounds in `sdmx.util`; however, it also introduces samuelcolvin/pydantic#2422, for which a workaround is not obvious. This PR temporarily sets a requirement for pydantic < 1.8, until that bug is addressed. A subsequent PR will remove & also adapt to the new version.

This will require a quick patch release, v2.2.1, so that other code installing `sdmx1` gets a compatible version of pydantic.