### PR TITLE
Fix sdmx.__version__ bug #68

### DIFF
--- a/sdmx/__init__.py
+++ b/sdmx/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 
 
 try:
-    __version__ = pkg_resources.get_distribution("sdmx").version
+    __version__ = pkg_resources.get_distribution("sdmx1").version
 except Exception:
     # Local copy or not installed with setuptools
     __version__ = "999"


### PR DESCRIPTION
Variable sdmx.__version__ is initialised with
'pkg_resources.get_distribution' using the appropriate
Distribution Package name 'sdmx1'.