### PR TITLE
Add 2 web services (BBK, BIS) and document CD2030

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -314,6 +314,24 @@ SDMX-ML or SDMX-JSON —
 `Web interface <https://sdmx.data.unicef.org/>`__
 
 - This source always returns structure-specific messages for SDMX-ML data queries; even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
+
+.. _CD2030:
+
+- UNICEF also serves data for the `Countdown to 2030 <https://www.countdown2030.org/about>`_ initiative under a data flow with the ID ``CONSOLIDATED``.
+  The structures can be obtained by giving the `provider` argument to a structure query, and then used to query the data:
+
+  .. code-block:: python
+
+     import sdmx
+
+     UNICEF = sdmx.Client("UNICEF")
+
+     # Use the dataflow ID to obtain the data structure definition
+     dsd = UNICEF.dataflow("CONSOLIDATED", provider="CD2030").structure[0]
+
+     # Use the DSD to construct a query for indicator D5 (“Births”)
+     client.data("CONSOLIDATED", key=dict(INDICATOR="D5"), dsd=dsd)
+
 - The example query from the UNICEF API documentation (also used in the :mod:`sdmx` test suite) returns XML like:
 
   .. code-block:: xml

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -343,7 +343,7 @@ SDMX-ML or SDMX-JSON —
        </com:StructureUsage>
      </mes:Structure>
 
-  The corresponding DSD actually has the ID ``DSD_AGGREGATE``, which is not obvious from the message.
+  Contrary to this, the corresponding DSD actually has the ID ``DSD_AGGREGATE``, not ``GLOBAL_DATAFLOW``.
   To retrieve the DSD—which is necessary to parse a data message—first query this data *flow* by ID, and select the DSD from the returned message:
 
   .. ipython:: python

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -76,7 +76,10 @@ SDMX-JSON —
 ``BBK``: German Federal Bank
 ----------------------------
 
-SDMX-ML — Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900>`__, `(de) <https://www.bundesbank.de/de/statistiken/zeitreihen-datenbanken/hilfe-zu-sdmx-webservice>`_.
+SDMX-ML —
+Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900>`__, `(de) <https://www.bundesbank.de/de/statistiken/zeitreihen-datenbanken/hilfe-zu-sdmx-webservice>`__
+
+.. versionadded:: 2.5.0
 
 - German name: Deutsche Bundesbank
 - The web service has some non-standard behaviour; see :issue:`82`.
@@ -84,6 +87,8 @@ SDMX-ML — Website `(en) <https://www.bundesbank.de/en/statistics/time-series-d
   :mod:`sdmx` discards other values with a warning.
 - Some endpoints, including :data:`.codelist`, return malformed URNs and cannot be handled with :mod:`sdmx`.
 
+.. autoclass:: sdmx.source.bbk.Source
+   :members:
 
 .. _ESTAT:
 

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -90,6 +90,19 @@ Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/h
 .. autoclass:: sdmx.source.bbk.Source
    :members:
 
+
+.. _BIS:
+
+``BIS``: Bank for International Settlements
+-------------------------------------------
+
+SDMX-ML —
+`Website <https://www.bis.org/statistics/sdmx_techspec.htm>`__ —
+`API reference <https://stats.bis.org/api-doc/v1/>`__
+
+.. versionadded:: 2.5.0
+
+
 .. _ESTAT:
 
 ``ESTAT``: Eurostat

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -311,7 +311,8 @@ SDMX-ML —
 
 SDMX-ML or SDMX-JSON —
 `API documentation <https://data.unicef.org/sdmx-api-documentation/>`__ —
-`Web interface <https://sdmx.data.unicef.org/>`__
+`Web interface <https://sdmx.data.unicef.org/>`__ —
+`Data browser <https://sdmx.data.unicef.org/databrowser/index.html>`__
 
 - This source always returns structure-specific messages for SDMX-ML data queries; even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
 

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -71,6 +71,20 @@ SDMX-JSON —
    :members:
 
 
+.. _BBK:
+
+``BBK``: German Federal Bank
+----------------------------
+
+SDMX-ML — Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900>`__, `(de) <https://www.bundesbank.de/de/statistiken/zeitreihen-datenbanken/hilfe-zu-sdmx-webservice>`_.
+
+- German name: Deutsche Bundesbank
+- The web service has some non-standard behaviour; see :issue:`82`.
+- The `version` path component is not-supported for non-data endpoints.
+  :mod:`sdmx` discards other values with a warning.
+- Some endpoints, including :data:`.codelist`, return malformed URNs and cannot be handled with :mod:`sdmx`.
+
+
 .. _ESTAT:
 
 ``ESTAT``: Eurostat

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,7 +11,12 @@ What's new?
 Next release
 ============
 
-- Tolerate malformed SDMX-JSON from :ref:`OECD` (:issue:`64`, :pull:`81`).
+- Add :ref:`BBK` and :ref:`BIS` services to supported sources (:pull:`83`).
+
+  - Work around some non-standard behaviours of ``BBK``; see :issue:`82`.
+
+- Document how :ref:`Countdown to 2030 <CD2030>` data can be accessed from the :ref:`UNICEF <UNICEF>` service (:pull:`83`).
+- Tolerate malformed SDMX-JSON from :ref:`OECD <OECD>` (:issue:`64`, :pull:`81`).
 - Reduce noise when :mod:`requests_cache` is not installed (:issue:`75`, :pull:`80`).
   An exception is still raised if (a) the package is not installed and (b) cache-related arguments are passed to :class:`Client`.
 - Bugfix: `verify` = :obj:`False` was not passed to the preliminary request used to validate a :class:`dict` key for a data request (:issue:`77`, :pull:`80`).

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -228,7 +228,7 @@ class Client:
         url_parts.extend([provider_id, resource_id])
 
         version = kwargs.pop("version", None)
-        if not version and resource_type != Resource.data:
+        if version is None and resource_type != Resource.data:
             url_parts.append("latest")
 
         key = kwargs.pop("key", None)

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -69,8 +69,8 @@ class Source(BaseModel):
     def handle_response(self, response, content):
         """Handle response content of unknown type.
 
-        This hook is called by :meth:`.Client.get` *only* when
-        the `content` cannot be parsed as XML or JSON.
+        This hook is called by :meth:`.Client.get` *only* when the `content` cannot be
+        parsed as XML or JSON.
 
         See :meth:`.estat.Source.handle_response` and
         :meth:`.sgr.Source.handle_response` for example implementations.
@@ -80,8 +80,8 @@ class Source(BaseModel):
     def finish_message(self, message, request, **kwargs):
         """Postprocess retrieved message.
 
-        This hook is called by :meth:`.Client.get` after a :class:`.Message`
-        object has been successfully parsed from the query response.
+        This hook is called by :meth:`.Client.get` after a :class:`.Message` object has
+        been successfully parsed from the query response.
 
         See :meth:`.estat.Source.finish_message` for an example implementation.
         """
@@ -90,12 +90,12 @@ class Source(BaseModel):
     def modify_request_args(self, kwargs):
         """Modify arguments used to build query URL.
 
-        This hook is called by :meth:`.Client.get` to modify the keyword
-        arguments before the query URL is built.
+        This hook is called by :meth:`.Client.get` to modify the keyword arguments
+        before the query URL is built.
 
-        The default implementation handles requests for 'structure-specific
-        data' by adding an HTTP 'Accepts:' header when a 'dsd' is supplied as
-        one of the `kwargs`.
+        The default implementation handles requests for 'structure-specific data' by
+        adding an HTTP 'Accepts:' header when a 'dsd' is supplied as one of the
+        `kwargs`.
 
         See :meth:`.sgr.Source.modify_request_args` for an example override.
 

--- a/sdmx/source/bbk.py
+++ b/sdmx/source/bbk.py
@@ -1,0 +1,37 @@
+import logging
+
+from pydantic import PrivateAttr
+
+from . import Source as BaseSource
+
+log = logging.getLogger(__name__)
+
+
+class Source(BaseSource):
+    """Work around non-standard behaviour of the :ref:`BBK` web service."""
+
+    _id = "BBK"
+
+    _base_url: str = PrivateAttr()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self._base_url = self.url
+
+    def modify_request_args(self, kwargs):
+        super().modify_request_args(kwargs)
+
+        if kwargs["resource_type"] != "data":
+            # Construct the URL: insert "/metadata"
+            self.url = self._base_url + "/metadata"
+
+            # Omit the version part of the URL
+            kwargs.setdefault("version", "")
+            if kwargs["version"] != "":
+                log.warning(
+                    f"URL part version={kwargs['version']} not supported; discarded"
+                )
+                kwargs["version"] = ""
+        else:
+            self.url = self._base_url

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -17,6 +17,15 @@
     }
   },
   {
+    "id": "BIS",
+    "name": "Bank for International Settlements",
+    "url": "https://stats.bis.org/api/v1",
+    "documentation": "https://www.bis.org/statistics/sdmx_techspec.htm",
+    "supports": {
+      "preview": true
+    }
+  },
+  {
     "id": "ECB",
     "resources": {
         "data": {

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -6,6 +6,17 @@
     "name": "Australian Bureau of Statistics"
   },
   {
+    "id": "BBK",
+    "url": "https://api.statistiken.bundesbank.de/rest",
+    "documentation": "https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900",
+    "name": "German Federal Bank",
+    "supports": {
+      "categoryscheme": false,
+      "provisionagreement": false,
+      "preview": true
+    }
+  },
+  {
     "id": "ECB",
     "resources": {
         "data": {

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -3,7 +3,7 @@ from sdmx.source import add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 20
+    assert len(source_ids) == 22
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -384,6 +384,14 @@ class TestUNICEF(DataSourceTest):
         dsd = client.dataflow("GLOBAL_DATAFLOW").structure[0]
         client.data("GLOBAL_DATAFLOW", key="ALB+DZA.MNCH_INSTDEL.", dsd=dsd)
 
+    @pytest.mark.network
+    def test_cd2030(self, client):
+        """Test that :ref:`Countdown to 2030 <CD2030>` data can be queried."""
+        dsd = client.dataflow("CONSOLIDATED", provider="CD2030").structure[0]
+
+        # D5: Births
+        client.data("CONSOLIDATED", key=dict(INDICATOR="D5"), dsd=dsd)
+
 
 class TestUNSD(DataSourceTest):
     source_id = "UNSD"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -13,7 +13,7 @@ import requests_mock
 
 import sdmx
 from sdmx import Client
-from sdmx.exceptions import HTTPError
+from sdmx.exceptions import HTTPError, XMLParseError
 
 # Mark the whole file so the tests can be excluded/included
 pytestmark = pytest.mark.source
@@ -79,6 +79,33 @@ class DataSourceTest:
 
 class TestABS(DataSourceTest):
     source_id = "ABS"
+
+
+class TestBBK(DataSourceTest):
+    source_id = "BBK"
+
+    # See https://github.com/khaeru/sdmx/issues/82
+    xfail = {
+        "codelist": XMLParseError,
+        "datastructure": XMLParseError,
+    }
+
+    endpoint_args = {
+        "data": dict(
+            resource_id="BBDB2",
+            key="H.DE.Y.A.C.IFRS.B.A.K.E.E001.VGH.A",
+            params=dict(startPeriod="2017-S1", endPeriod="2019-S1"),
+        ),
+        "codelist": dict(
+            resource_id="CL_BBK_ERX_RATE_TYPE", params=dict(references="none")
+        ),
+        "conceptscheme": dict(
+            resource_id="CS_BBK_ERX",
+            params=dict(detail="allstubs", references="parentsandsiblings"),
+        ),
+        "dataflow": dict(resource_id="BBEX3", params=dict(detail="referencestubs")),
+        "datastructure": dict(resource_id="BBK_QFS"),
+    }
 
 
 class TestECB(DataSourceTest):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -108,6 +108,10 @@ class TestBBK(DataSourceTest):
     }
 
 
+class TestBIS(DataSourceTest):
+    source_id = "BIS"
+
+
 class TestECB(DataSourceTest):
     source_id = "ECB"
     xfail = {

--- a/sdmx/tests/test_urn.py
+++ b/sdmx/tests/test_urn.py
@@ -1,0 +1,11 @@
+import re
+
+import pytest
+
+from sdmx.urn import match
+
+
+def test_exception():
+    urn = "urn:sdmx:org.sdmx.infomodel.codelist=BBK:CLA_BBK_COLLECTION(1.0)"
+    with pytest.raises(ValueError, match=re.escape(f"not a valid SDMX URN: {urn}")):
+        match(urn)

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict
 
 from sdmx.model import PACKAGE, MaintainableArtefact
 
@@ -42,5 +43,11 @@ def make(obj, maintainable_parent=None):
     )
 
 
-def match(string):
-    return URN.match(string).groupdict()
+def match(value: str) -> Dict[str, str]:
+    try:
+        match = URN.match(value)
+        assert match is not None
+    except AssertionError:
+        raise ValueError(f"not a valid SDMX URN: {repr(value)}")
+    else:
+        return match.groupdict()

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -48,6 +48,6 @@ def match(value: str) -> Dict[str, str]:
         match = URN.match(value)
         assert match is not None
     except AssertionError:
-        raise ValueError(f"not a valid SDMX URN: {repr(value)}")
+        raise ValueError(f"not a valid SDMX URN: {value}")
     else:
         return match.groupdict()


### PR DESCRIPTION
NB pandaSDMX handles CD2030 through duplicating the UNICEF source, which isn't necessary. This PR adds documentation to explain how to access this data using the existing source.