### PR TITLE
Support observation values which are falsy

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,8 +8,13 @@ What's new?
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+Bug fixes
+---------
+
+- :mod:`.reader.xml` ignored values like ``0`` or ``0.0`` that evaluated equivalent to :obj:`False` (:pull:`86`).
 
 v2.6.0 (2021-07-11)
 ===================

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -72,21 +72,29 @@ def test_ds(dsd, obs):
 
 def test_ds_structurespecific(dsd):
     series_key = dsd.make_key(m.SeriesKey, dict(FOO=1, BAR=2))
-    dimension_key = dsd.make_key(m.Key, dict(BAZ=3))
     primary_measure = m.PrimaryMeasure(id="OBS_VALUE")
-    observation = m.Observation(
-        series_key=series_key,
-        dimension=dimension_key,
-        value_for=primary_measure,
-        value=25,
-    )
-    series = {series_key: [observation]}
+    observations = [
+        m.Observation(
+            series_key=series_key,
+            dimension=dsd.make_key(m.Key, dict(BAZ=3)),
+            value_for=primary_measure,
+            value=25,
+        ),
+        m.Observation(
+            series_key=series_key,
+            dimension=dsd.make_key(m.Key, dict(BAZ=4)),
+            value_for=primary_measure,
+            value=0,
+        ),
+    ]
+    series = {series_key: observations}
     ds = m.StructureSpecificDataSet(structured_by=dsd, series=series)
     dm = message.DataMessage(data=[ds])
     result = sdmx.to_xml(dm, pretty_print=True)
     exp = (
         '    <Series FOO="1" BAR="2">\n'
         '      <Obs OBS_VALUE="25" BAZ="3"/>\n'
+        '      <Obs OBS_VALUE="0" BAZ="4"/>\n'
         "    </Series>"
     )
     assert exp in result.decode()

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -574,7 +574,7 @@ def _obs(obj: model.Observation, struct_spec=False):
         obs_attrs = {}
         for key, av in obj.attached_attribute.items():
             obs_attrs[key] = str(av.value)
-        if obj.value is not None:
+        if obj.value:
             if obj.value_for is None:
                 raise ValueError(
                     "Observation.value_for is None when writing structure-specific data"

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -574,7 +574,7 @@ def _obs(obj: model.Observation, struct_spec=False):
         obs_attrs = {}
         for key, av in obj.attached_attribute.items():
             obs_attrs[key] = str(av.value)
-        if obj.value:
+        if obj.value is not None:
             if obj.value_for is None:
                 raise ValueError(
                     "Observation.value_for is None when writing structure-specific data"


### PR DESCRIPTION
If an observation value is falsy (like 0.0) then the structure specific XML writer is skipping it. This PR explicitly checks for `None`, to allow the falsy observation values to make it into the output.