### PR TITLE
Adjust test_parse_elem

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 name: Publish
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     branches: [ main ]
     tags: [ "v*" ]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,11 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
     - uses: actions/setup-python@v2
-      with:
-        # This should match the "Latest supported version" in pytest.yaml
-        python-version: "3.9"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,9 +18,10 @@ jobs:
         - windows-latest
         python-version:
         - "3.7"  # Earliest supported version; actually 3.7.2
-        - "3.9"  # Latest supported version
+        - "3.9"
+        - "3.10" # Latest supported version
         # commented: only enable once next Python version enters RC
-        # - "3.10.0-rc.1"  # Development version
+        # - "3.11.0-rc.1"  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -79,7 +79,7 @@ jobs:
     - name: Check typing with mypy
       run: |
         pip install mypy types-pkg_resources types-python-dateutil types-requests
-        mypy --show-error-codes .
+        mypy --show-error-codes ./sdmx
 
     - name: Test documentation build using Sphinx
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,8 +8,10 @@ What's new?
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Python 3.10 is fully supported (:pull:`89`).
 
 v2.6.1 (2021-07-27)
 ===================

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -98,10 +98,9 @@ ELEMENTS = [
         E(qname("mes:Extracted"), "2020-08-18T00:14:31.59849Z"),
         datetime(2020, 8, 18, 0, 14, 31, 598490, tzinfo=timezone.utc),
     ),
-    pytest.param(  # with 7 decimal places AND "Z"
+    (  # with 7 decimal places AND "Z"; a message is logged on DEBUG (not checked)
         E(qname("mes:Extracted"), "2020-08-18T01:02:03.4567891Z"),
         datetime(2020, 8, 18, 1, 2, 3, 456789, tzinfo=timezone.utc),
-        marks=pytest.mark.xfail(raises=XMLParseError),
     ),
     # xml._facet()
     (

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -80,10 +80,9 @@ def test_read_ss_xml(specimen):
 # Each entry is a tuple with 2 elements:
 # 1. an instance of lxml.etree.Element to be parsed.
 # 2. Either:
-#   - A sdmx.model object, in which case the parsed element must match the
-#     object.
-#   - A string, in which case parsing the element is expected to fail, raising
-#     an exception matching the string.
+#   - A sdmx.model object, in which case the parsed element must match the object.
+#   - A string, in which case parsing the element is expected to fail, raising an
+#     exception matching the string.
 ELEMENTS = [
     # xml._datetime()
     (  # with 5 decimal places
@@ -129,9 +128,8 @@ ELEMENTS = [
 def test_parse_elem(elem, expected):
     """Test individual XML elements.
 
-    This method allows unit-level testing of specific XML elements appearing in
-    SDMX-ML messages. Add elements by extending the list passed to the
-    parametrize() decorator.
+    This method allows unit-level testing of specific XML elements appearing in SDMX-ML
+    messages. Add elements by extending the list passed to the parametrize() decorator.
     """
     # Convert to a file-like object compatible with read_message()
     tmp = BytesIO(etree.tostring(elem))

--- a/sdmx/tests/test_util.py
+++ b/sdmx/tests/test_util.py
@@ -54,8 +54,9 @@ class TestDictLike:
 
     def test_validate_dictlike(self, Foo):
         """``@validate_dictlike()`` adds a validator to a pydantic model field."""
+        # At least 1 validator is added, with the name _validate_whole
         assert 1 <= len(Foo.__fields__["items"].post_validators)
-        assert "_validate_whole" == Foo.__fields__["items"].post_validators[0].func_name
+        assert "_validate_whole" == Foo.__fields__["items"].post_validators[0].__name__
 
         # ValidationError
         f = Foo()

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -262,6 +262,14 @@ def test_write_dataset_datetime(specimen):
         sdmx.to_pandas(ds, datetime=43)
 
 
+def test_write_list_of_obs(specimen):
+    """Bare list of observations can be written."""
+    with specimen("ng-ts.xml") as f:
+        msg = sdmx.read_sdmx(f)
+
+    sdmx.to_pandas(msg.data[0].obs)
+
+
 @pytest.mark.parametrize_specimens("path", kind="structure")
 def test_writer_structure(path):
     msg = sdmx.read_sdmx(path)

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -42,7 +42,7 @@ def to_pandas(obj, *args, **kwargs):
 def _list(obj: list, *args, **kwargs):
     """Convert a :class:`list` of SDMX objects."""
     if isinstance(obj[0], Observation):
-        return write_dataset(obj, *args, **kwargs)
+        return write_dataset(model.DataSet(obs=obj), *args, **kwargs)
     elif isinstance(obj[0], DataSet) and len(obj) == 1:
         return writer.recurse(obj[0], *args, **kwargs)
     elif isinstance(obj[0], SeriesKey):
@@ -289,7 +289,7 @@ def write_dataset(
 
     # Iterate on observations
     data = {}
-    for observation in getattr(obj, "obs", obj):
+    for observation in obj.obs:
         # Check that the Observation is within the constraint, if any
         key = observation.key.order()
         if constraint and key not in constraint:
@@ -304,7 +304,7 @@ def write_dataset(
             row.update(observation.attrib)
         if "d" in attributes:
             # Add the attributes of the data set
-            row.update(getattr(obj, "attrib", dict()))
+            row.update(obj.attrib)
 
         data[tuple(map(str, key.get_values()))] = row
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
 


### PR DESCRIPTION
- Minor change to the test suite, mainly to reactivate scheduled GHA runs.
- Enable/use default Python 3.10 for CI.