### PR TITLE
Adjust DictLike._validate_entry for compat with pydantic 1.9.0

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,7 @@ What's new?
 Next release
 ============
 
+- Pydantic >= 1.9 is supported (:pull:`91`).
 - Python 3.10 is fully supported (:pull:`89`).
 
 v2.6.1 (2021-07-27)

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -130,7 +130,7 @@ class DictLike(dict, typing.MutableMapping[KT, VT]):
             if error:
                 raise ValidationError([error], self.__class__)
             else:
-                return v.popitem()
+                return (key, value)
 
     def compare(self, other, strict=True):
         """Return :obj:`True` if `self` is the same as `other`.


### PR DESCRIPTION
This addresses CI failures seen since the release of pydantic 1.9.0 with messages like:
```
AttributeError: 'tuple' object has no attribute 'popitem'
```