### PR TITLE
Update for pydantic 1.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ ref
 service-endpoints.html
 
 # Editors
-.vscode/settings.json
+.vscode/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,10 +50,10 @@ extlinks = {
 # -- Options for sphinx.ext.intersphinx --------------------------------------
 
 intersphinx_mapping = {
-    "np": ("https://docs.scipy.org/doc/numpy/", None),
+    "np": ("https://numpy.org/doc/stable/", None),
     "pd": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "py": ("https://docs.python.org/3/", None),
-    "requests": ("http://2.python-requests.org/en/master/", None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
     "requests-cache": ("https://requests-cache.readthedocs.io/en/latest/", None),
 }
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,8 +8,10 @@ What's new?
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bump minimum version of :mod:`pydantic` to 1.9.2 (:pull:`98`).
 
 v2.6.2 (2022-01-11)
 ===================

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -253,7 +253,7 @@ class TestDataStructureDefinition:
 
         keys0 = list(dsd.iter_keys())
         assert all(isinstance(k, model.Key) for k in keys0)
-        assert 2 ** 3 == len(keys0)
+        assert 2**3 == len(keys0)
 
         # Iterate over only some dimensions
         keys1 = list(dsd.iter_keys(dims=["foo"]))
@@ -265,7 +265,7 @@ class TestDataStructureDefinition:
 
         # Resulting Keys have only "1" for the "foo" dimension
         keys2 = list(dsd.iter_keys(constraint=cc0))
-        assert 1 * 2 ** 2 == len(keys2)
+        assert 1 * 2**2 == len(keys2)
 
         # Use make_constraint() to create & modify a different CubeRegion
         cc1 = dsd.make_constraint(dict(baz="6"))

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -39,7 +39,7 @@ class BaseModel(pydantic.BaseModel):
     """Common settings for :class:`pydantic.BaseModel` in :mod:`sdmx`."""
 
     class Config:
-        copy_on_model_validation = False
+        copy_on_model_validation = "none"
         validate_assignment = True
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >= 3.7.2
 install_requires =
     lxml >= 3.6
     pandas >= 1.0
-    pydantic >= 1.8.1
+    pydantic >= 1.9.2
     python-dateutil
     requests >= 2.7
     setuptools >= 41


### PR DESCRIPTION
Ubuntu nightly CI tests began failing with the following, e.g. [here](https://github.com/khaeru/sdmx/runs/7800359607?check_suite_focus=true#step:12:32):
```
WARNING: 
>>>-------------------------------------------------------------------------
Warning in /home/runner/work/sdmx/sdmx/doc/howto/create.rst at block ending on line 141
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
<ipython-input-15-2eb198031efc>:7: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
  return Observation(
<<<-------------------------------------------------------------------------

Exception occurred:
  File "/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/IPython/sphinxext/ipython_directive.py", line 600, in process_input
    raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))
RuntimeError: Non Expected warning in `/home/runner/work/sdmx/sdmx/doc/howto/create.rst` line 141
The full traceback has been saved in /tmp/sphinx-err-ixs3xe24.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:20: html] Error 2
make: Leaving directory '/home/runner/work/sdmx/sdmx/doc'
Error: Process completed with exit code 2.
```

This is due to changes in pydantic 1.9.2, specifically how copy_on_model_validation is handled. This PR adjusts.