### PR TITLE
Fix common test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ doc/*.xml
 prof/
 htmlcov
 ref
-service-endpoints.html
+service-endpoints/
 
 # Editors
 .vscode/

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,13 +12,20 @@ Next release
 ============
 
 - Bump minimum version of :mod:`pydantic` to 1.9.2 (:pull:`98`).
+- Always return all objects parsed from a SDMX-ML :class:`.StructureMessage` (:pull:`99`).
+
+  If two or more :class:`.MaintainableArtefact` have the same ID (e.g. "CL_FOO"); :mod:`sdmx` would formerly store only the last one parsed.
+  Now, each is returned, with keys like ``{maintainer's id}:{object id}`` such as would appear in an SDMX URI; for example, "AGENCY_A:CL_FOO", "AGENCY_B:CL_FOO", etc.
+- Recognize the MIME type ``application/vnd.sdmx.generic+xml;version=2.1`` (:pull:`99`).
+- Catch some cases where :attr:`~.NameableArtefact.name` and :attr:`~.NameableArtefact.description` were discarded when parsing SDMX-ML (:pull:`99`).
 
 v2.6.2 (2022-01-11)
 ===================
 
 This release contains mainly compatibility updates and testing changes.
 
-- https://khaeru.github.io/sdmx/ now serves a dashboard summarizing automatic, daily tests of every SDMX 2.1 REST API endpoints for every :doc:`data source <sources>` built-in to :mod:`sdmx`. See :ref:`service-policy` (:pull:`90`).
+- https://khaeru.github.io/sdmx/ now serves a dashboard summarizing automatic, daily tests of every SDMX 2.1 REST API endpoints for every :doc:`data source <sources>` built-in to :mod:`sdmx`.
+  See :ref:`source-policy` (:pull:`90`).
 - Pydantic >= 1.9 is supported (:pull:`91`).
 - Python 3.10 is fully supported (:pull:`89`).
 

--- a/sdmx/format/__init__.py
+++ b/sdmx/format/__init__.py
@@ -21,6 +21,7 @@ Extra = IntFlag("Extra", "ss ts")
 #:   - ``ss``: for structure-specific (meta)data.
 #:   - ``ts``: for time-series data.
 FORMATS = [
+    Format("application/vnd.sdmx.generic+xml;version=2.1", "xml", True, False, 0),
     Format("application/vnd.sdmx.genericdata+xml;version=2.1", "xml", True, False, 0),
     Format(
         "application/vnd.sdmx.structurespecificdata+xml;version=2.1",

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -716,7 +716,17 @@ def _structures(reader, elem):
         ("structure", model.DataStructureDefinition),
     ):
         for obj in reader.pop_all(name, subclass=True):
-            getattr(msg, attr)[obj.id] = obj
+            target = getattr(msg, attr)
+            if obj.id not in target:
+                # Store using ID alone
+                target[obj.id] = obj
+            else:
+                # ID already exists; this occurs when two MaintainableArtefacts have the
+                # same ID, but different maintainers. Re-store using IDs that will be
+                # unique
+                existing = target.pop(obj.id)
+                target[f"{existing.maintainer.id}:{existing.id}"] = existing
+                target[f"{obj.maintainer.id}:{obj.id}"] = obj
 
 
 # Parsers for sdmx.model classes

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -808,9 +808,13 @@ def _item_start(reader, elem):
 def _item(reader, elem):
     try:
         # <str:DataProvider> may be a reference, e.g. in <str:ConstraintAttachment>
-        return Reference(elem)
+        item = Reference(elem)
     except NotReference:
         pass
+    else:
+        # Restore "Name" and "Description" that may have been stashed by _item_start
+        reader.unstash()
+        return item
 
     cls = class_for_tag(elem.tag)
     item = reader.nameable(cls, elem)

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -330,7 +330,7 @@ class Reader(BaseReader):
         Calls to :meth:`.stash` and :meth:`.unstash` should be matched 1-to-1; if the
         latter outnumber the former, this will raise :class:`.KeyError`.
         """
-        for s, values in self.pop_single("_stash").items():
+        for s, values in (self.pop_single("_stash") or {}).items():
             self.stack[s].update(values)
 
     def get_single(

--- a/sdmx/testing/report.py
+++ b/sdmx/testing/report.py
@@ -123,7 +123,7 @@ class ServiceReporter:
         self.path = config.invocation_params.dir.joinpath(
             "service-endpoints", "index.html"
         )
-        self.path.parent.mkdir()
+        self.path.parent.mkdir(exist_ok=True)
         self.data = {}
         self.resources = set()
 
@@ -166,6 +166,6 @@ class ServiceReporter:
                     data=self.data,
                     abbrev=ABBREV,
                     resources=sorted(self.resources),
-                    env=os.environ,
+                    env=dict(GITHUB_REPOSITORY="", GITHUB_RUN_ID="") | os.environ,
                 )
             )

--- a/sdmx/tests/format/test_xml.py
+++ b/sdmx/tests/format/test_xml.py
@@ -3,7 +3,7 @@ from sdmx.format import xml
 
 
 def test_content_types():
-    assert 10 == len(xml.CONTENT_TYPES)
+    assert 11 == len(xml.CONTENT_TYPES)
 
 
 def test_tag_for_class():

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -52,14 +52,14 @@ def test_write_agencyscheme(specimen):
         msg = sdmx.read_sdmx(f)
         data = sdmx.to_pandas(msg)
 
-    assert data["organisation_scheme"]["AGENCIES"]["ESTAT"] == "Eurostat"
+    assert data["organisation_scheme"]["SDMX:AGENCIES"]["ESTAT"] == "Eurostat"
 
     # to_pandas only returns keys for non-empty attributes of StructureMessage
     # https://github.com/dr-leo/pandaSDMX/issues/90
     assert set(data.keys()) == {"organisation_scheme"}
 
     # Attribute access works
-    assert data.organisation_scheme.AGENCIES.ESTAT == "Eurostat"
+    assert data.organisation_scheme["SDMX:AGENCIES"].ESTAT == "Eurostat"
 
     with pytest.raises(AttributeError):
         data.codelist


### PR DESCRIPTION
Fix two issues that were causing failures of nightly CI jobs:
- Add a MIME type sometimes returned by Eurostat.
- Ensure names and descriptions are not lost when parsing ItemSchemes from SDMX-ML.

Also:
- Ensure all retrieved objects are present in a StructureMessage by using the maintainer's ID in the dictionary key; e.g. "AGENCY_A:CL_FOO" and "AGENCY_B:CL_FOO" instead of one entry "CL_FOO" that happens to be the last one parsed.