### PR TITLE
Update ESTAT API URL and other improvements

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,4 +14,14 @@ jobs:
       # If the "Latest version testable on GitHub Actions" in pytest.yaml
       # is not the latest 3.x stable version, adjust here to match:
       # python-version: "3.10"
-      type-hint-packages: pydantic types-Jinja2 types-python-dateutil types-requests types-setuptools
+      type-hint-packages: >-
+        pydantic
+        pandas-stubs
+        pytest
+        requests-cache
+        requests-mock
+        types-Jinja2
+        types-lxml
+        types-python-dateutil
+        types-requests
+        types-setuptools

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,11 +15,11 @@ jobs:
       # is not the latest 3.x stable version, adjust here to match:
       # python-version: "3.10"
       type-hint-packages: >-
+        numpy
         pydantic
         pandas-stubs
         pytest
         requests-cache
-        requests-mock
         types-Jinja2
         types-lxml
         types-python-dateutil

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,29 +8,10 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-
-    continue-on-error: true
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-        cache: pip
-        cache-dependency-path: "**/setup.cfg"
-
-    - name: Upgrade pip, wheel
-      run: |
-        python -m pip install --upgrade pip wheel
-
-    - name: Check "black" code style
-      run: |
-        pip install black
-        black --check .
-
-    - name: Lint with flake8 & isort
-      run: |
-        pip install flake8 isort
-        flake8 --count --max-complexity=27 --show-source --statistics
-        isort --check-only .
+    uses: iiasa/actions/.github/workflows/lint.yaml@main
+    with:
+      max-complexity: 27
+      # If the "Latest version testable on GitHub Actions" in pytest.yaml
+      # is not the latest 3.x stable version, adjust here to match:
+      # python-version: "3.10"
+      type-hint-packages: pydantic types-Jinja2 types-python-dateutil types-requests types-setuptools

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
-name: Publish
+name: Build package / publish
 
 on:
-  pull_request:
+  pull_request:  # Check that package can be built even on PRs
     branches: [ main ]
   push:
     branches: [ main ]
@@ -11,35 +11,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.x
-        cache: pip
-        cache-dependency-path: "**/setup.cfg"
-
-    - name: Upgrade pip, setuptools-scm, twine, wheel
-      run: python -m pip install --upgrade pip setuptools-scm twine wheel
-
-    - name: Build package
-      run: |
-        python3 setup.py bdist_wheel sdist
-        twine check dist/*
-
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.1
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      with:
-        user: __token__
-        password: ${{ secrets.TESTPYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.1
-      if: github.event_name == 'release'
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+    uses: iiasa/actions/.github/workflows/publish.yaml@main
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,10 @@ jobs:
         - "3.10"
         - "3.11"  # Latest supported version
         # commented: only enable once next Python version enters RC
-        # - "3.11.0-rc.1"  # Development version
+        # - "3.12.0-rc.1"  # Development version
+
+        exclude:
+        - { os: windows-latest, python-version: "3.11" }  # no wheels for lxml
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,7 +19,8 @@ jobs:
         python-version:
         - "3.7"  # Earliest supported version; actually 3.7.2
         - "3.9"
-        - "3.10"  # Latest supported version
+        - "3.10"
+        - "3.11"  # Latest supported version
         # commented: only enable once next Python version enters RC
         # - "3.11.0-rc.1"  # Development version
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -63,11 +63,6 @@ jobs:
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v3
 
-    - name: Check typing with mypy
-      run: |
-        pip install mypy types-pkg_resources types-python-dateutil types-requests
-        mypy --show-error-codes ./sdmx
-
     - name: Test documentation build using Sphinx
       if: contains(matrix.os, 'ubuntu')
       run: make --directory=doc html

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ service-endpoints/
 
 # Editors
 .vscode/
+.idea/

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -85,6 +85,12 @@ SDMX-ML
 .. autoclass:: sdmx.session.ResponseIO
 
 
+``urn``: Uniform Resource Names (URNs) for SDMX objects
+-------------------------------------------------------
+.. automodule:: sdmx.urn
+   :members:
+
+
 ``util``: Utilities
 -------------------
 .. automodule:: sdmx.util

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -7,48 +7,50 @@ All we need to know in advance is the data provider: Eurostat.
 :mod:`sdmx` makes it easy to search the directory of dataflows, and the complete structural metadata about the datasets available through the selected dataflow.
 (This example skips these steps; see :doc:`the walkthrough <walkthrough>`.)
 
-The data we want is in a *data flow* with the identifier ``une_rt_a``.
-This dataflow references a *data structure definition* (DSD) with the ID ``DSD_une_rt_a``.
+The data we want is in a **data flow** with the identifier ‘UNE_RT_A’.
+This dataflow references a **data structure definition** (**DSD**) that also has an ID ‘UNE_RT_A’.
 The DSD, in turn, contains or references all the metadata describing data sets available through this dataflow: the concepts, things measured, dimensions, and lists of codes used to label each dimension.
 
 .. ipython:: python
 
     import sdmx
-    estat = sdmx.Client('ESTAT')
+    estat = sdmx.Client("ESTAT")
 
 Download the metadata and expose:
 
 .. ipython:: python
 
-    metadata = estat.datastructure('DSD_une_rt_a')
+    metadata = estat.datastructure("UNE_RT_A")
     metadata
 
 Explore the contents of some code lists:
 
 .. ipython:: python
 
-    for cl in 'CL_AGE', 'CL_UNIT':
+    for cl in "AGE", "UNIT":
         print(sdmx.to_pandas(metadata.codelist[cl]))
 
-Next we download a dataset.
-To obtain data on Greece, Ireland and Spain only, we use codes from the code list 'CL_GEO' to specify a *key* for the dimension named ‘GEO’.
-We also use a query *parameter*, 'startPeriod', to limit the scope of the data returned:
+Next we download a **data set** containing a subset of the data from this data flow, structured by this DSD.
+To obtain data on Greece, Ireland and Spain only, we use codes from the code list with the ID ‘GEO’ to specify a **key** for the dimension with the ID ‘geo’ (note the difference: SDMX IDs are case-sensitive).
+We also use a **query parameter**, ‘startPeriod’, to limit the scope of the data returned:
 
 .. ipython:: python
 
     resp = estat.data(
-        'une_rt_a',
-        key={'GEO': 'EL+ES+IE'},
-        params={'startPeriod': '2007'},
-        )
+        "UNE_RT_A",
+        key={"geo": "EL+ES+IE"},
+        params={"startPeriod": "2007"},
+    )
 
 ``resp`` is now a :class:`.DataMessage` object.
-We use the built-in :func:`.to_pandas` function to convert it to a :class:`pandas.Series`, then select on the ``AGE`` dimension:
+We use the :func:`sdmx.to_pandas` function to convert it to a :class:`pandas.Series`, then select on the ‘age’ dimension:
 
 .. ipython:: python
 
-    data = (sdmx.to_pandas(resp)
-                .xs('Y15-74', level='AGE', drop_level=False))
+    data = (
+        sdmx.to_pandas(resp)
+        .xs("Y15-74", level="age", drop_level=False)
+    )
 
 We can now explore the data set as expressed in a familiar pandas object.
 First, show dimension names:
@@ -64,8 +66,8 @@ First, show dimension names:
 
     data.index.levels
 
-Select some data of interest: show aggregate unemployment rates across ages ('Y15-74' on the ``AGE`` dimension) and sexes ('T' on the ``SEX`` dimension), expressed as a percentage of active population ('PC_ACT' on the ``UNIT`` dimension):
+Select some data of interest: show aggregate unemployment rates across ages ("Y15-74" on the ‘age’ dimension) and sexes ("T" on the ‘sex’ dimension), expressed as a percentage of active population ("PC_ACT" on the ‘unit’ dimension):
 
 .. ipython:: python
 
-    data.loc[('A', 'Y15-74', 'PC_ACT', 'T')]
+    data.loc[("A", "Y15-74", "PC_ACT", "T")]

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -137,6 +137,19 @@ SDMX-ML —
 .. versionadded:: 2.5.0
 
 
+.. _ECB:
+
+``ECB``: European Central Bank
+------------------------------
+
+SDMX-ML —
+`Website <http://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__
+
+- Supports categorisations of data-flows.
+- Supports preview_data and series-key based key validation.
+- In general short response times.
+
+
 .. _ESTAT:
 
 ``ESTAT``: Eurostat
@@ -153,17 +166,6 @@ SDMX-ML —
 
 .. autoclass:: sdmx.source.estat.Source()
    :members:
-
-
-``ECB``: European Central Bank
-------------------------------
-
-SDMX-ML —
-`Website <http://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__
-
-- Supports categorisations of data-flows.
-- Supports preview_data and series-key based key validation.
-- In general short response times.
 
 
 .. _ILO:
@@ -202,6 +204,8 @@ SDMX-ML —
 - Subset of the data available on http://data.imf.org.
 - Supports series-key-only and hence dataset-based key validation and construction.
 
+
+.. _INEGI:
 
 ``INEGI``: National Institute of Statistics and Geography (Mexico)
 ------------------------------------------------------------------
@@ -244,6 +248,7 @@ Website `(en) <https://www.istat.it/en/methods-and-tools/sdmx-web-service>`__, `
 
   …see the above URLs for details.
 
+
 .. _LSD:
 
 ``LSD``: National Institute of Statistics (Lithuania)
@@ -255,6 +260,8 @@ SDMX-ML —
 - Lithuanian name: Lietuvos statistikos.
 - This web service returns the non-standard HTTP content-type "application/force-download"; :mod:`sdmx` replaces it with "application/xml".
 
+
+.. _NB:
 
 ``NB``: Norges Bank (Norway)
 ----------------------------
@@ -330,14 +337,7 @@ API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-ins
   Since :mod:`sdmx` does not support SDMX-ML 2.0, the package is configured to use the JSON endpoint.
 
 
-``UNSD``: United Nations Statistics Division
---------------------------------------------
-
-SDMX-ML —
-`Website <https://unstats.un.org/home/>`__
-
-- Supports preview_data and series-key based key validation.
-
+.. _UNESCO:
 
 ``UNESCO``: UN Educational, Scientific and Cultural Organization
 ----------------------------------------------------------------
@@ -403,6 +403,19 @@ SDMX-ML or SDMX-JSON —
   The resulting object `dsd` can be passed as an argument to a :meth:`.Client.get` data query.
   See the `sdmx test suite <https://github.com/khaeru/sdmx/blob/main/sdmx/tests/test_sources.py>`_ for an example.
 
+
+.. _UNSD:
+
+``UNSD``: United Nations Statistics Division
+--------------------------------------------
+
+SDMX-ML —
+`Website <https://unstats.un.org/home/>`__
+
+- Supports preview_data and series-key based key validation.
+
+
+.. _WB:
 
 ``WB``: World Bank Group “World Integrated Trade Solution”
 ----------------------------------------------------------

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -77,6 +77,8 @@ Please `open an issue <https://github.com/khaeru/sdmx/issues/new>`__ if the supp
     The :class:`.Client` is constructing a standards-compliant URL, but the service idiosyncratically rejects it.
     Handling these idiosyncrasies is currently out-of-scope for :mod:`sdmx`.
 
+.. _source-matrix:
+
 - Because of the large number of services and endpoints, the matrix of support is only periodically updated.
   To mitigate: https://khaeru.github.io/sdmx/ displays a summary of every SDMX 2.1 REST API endpoint for every data source built-in to :mod:`sdmx`; this summary is updated daily by an automatic run of the test suite.
   These include all endpoints known to return a non-404 reply, even if the reply is an error message of some sort.
@@ -156,7 +158,7 @@ SDMX-ML —
 -------------------
 
 SDMX-ML —
-`Website <https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1>`__
+Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555>`__, `2 <https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1>`__
 
 - Thousands of dataflows on a wide range of topics.
 - No categorisations available.

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -160,11 +160,8 @@ SDMX-ML —
 SDMX-ML —
 Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555>`__, `2 <https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1>`__
 
-- Thousands of dataflows on a wide range of topics.
-- No categorisations available.
-- Long response times are reported.
-  Increase the timeout attribute to avoid timeout exceptions.
-- Does not return DSDs for dataflow requests with the ``references='all'`` query parameter.
+- In some cases, the service can have a long response time, so :mod:`sdmx` will time out.
+  Increase the timeout attribute if necessary.
 
 .. autoclass:: sdmx.source.estat.Source()
    :members:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -32,7 +32,7 @@ Next release
 v2.6.3 (2022-09-29)
 ===================
 
-- Update :ref:`ILO` web service URL and quirks handling (:pull:`97`).
+- Update :ref:`ILO` web service URL and quirks handling (:pull:`97`, thanks :gh-user:`ethangelbach`).
 - Use HTTPS for :ref:`ESTAT` (:pull:`97`).
 - Bump minimum version of :mod:`pydantic` to 1.9.2 (:pull:`98`).
 - Always return all objects parsed from a SDMX-ML :class:`.StructureMessage` (:pull:`99`).
@@ -94,7 +94,6 @@ v2.6.0 (2021-07-11)
   - Improve typing.
   - Expand test coverage.
 
-
 v2.5.0 (2021-06-27)
 ===================
 
@@ -106,7 +105,7 @@ v2.5.0 (2021-06-27)
 - Tolerate malformed SDMX-JSON from :ref:`OECD <OECD>` (:issue:`64`, :pull:`81`).
 - Reduce noise when :mod:`requests_cache` is not installed (:issue:`75`, :pull:`80`).
   An exception is still raised if (a) the package is not installed and (b) cache-related arguments are passed to :class:`Client`.
-- Bugfix: `verify` = :obj:`False` was not passed to the preliminary request used to validate a :class:`dict` key for a data request (:issue:`77`, :pull:`80`).
+- Bugfix: `verify` = :obj:`False` was not passed to the preliminary request used to validate a :class:`dict` key for a data request (:pull:`80`; thanks :gh-user:`albertame` for :issue:`77`).
 - Handle ``<mes:Department>`` and ``<mes:Role>>`` in SDMX-ML headers (:issue:`78`, :pull:`79`).
 
 v2.4.1 (2021-04-12)
@@ -162,7 +161,6 @@ v2.1.0 (2021-02-22)
 - New convenience method :meth:`.StructureMessage.get` to retrieve objects by ID across the multiple collections in StructureMessage (:pull:`58`).
 - New convenience method :meth:`.AnnotableArtefact.pop_annotation` to locate, remove, and return a Annotation, e.g. by its ID (:pull:`58`).
 - :func:`len` of a :class:`.DataKeySet` gives the length of :attr:`.DataKeySet.keys` (:pull:`58`).
-
 
 v2.0.1 (2021-01-31)
 ===================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,9 +11,23 @@ What's new?
 Next release
 ============
 
-- Update :ref:`ISTAT` web service URL (:pull:`105`).
-- Add :class:`MetadataflowDefinition`, :class:`MetadataStructureDefinition`, and handle references to these in :mod:`.reader.xml` (:pull:`105`).
-- Work around :issue:`102`, an error in some :ref:`IMF` structure messages (:pull:`103`).
+- Python 3.11 is fully supported (:pull:`109`).
+- Changes for specific data sources:
+
+  - :ref:`ESTAT`: update web service URL, quirks handling (:class:`.estat.Source`), tests, and usage throughout documentation (:pull:`107`, :pull:`109`, thanks :gh-user:`zymon`).
+  - :ref:`IMF`: work around :issue:`102` (thanks :gh-user:`zymon`), an error in some structure messages (:pull:`103`).
+  - :ref:`ISTAT`: update web service URL (:pull:`105`; thanks :gh-user:`miccoli` for :issue:`104`).
+
+- Add :class:`.MetadataflowDefinition`, :class:`.MetadataStructureDefinition`, and handle references to these in :mod:`.reader.xml` (:pull:`105`).
+- Correctly parse "." in item IDs in URNs (:data:`~sdmx.urn.URN`, :pull:`109`).
+- Handle SDMX-ML observed in the wild (:pull:`109`):
+
+  - Elements that normally contain text but appear without even a text node, e.g. ``<com:AnnotationURL/>``.
+  - XML namespaces defined on the message element, e.g. ``<mes:StructureSpecificData xmlns:u="...">`` followed by ``<u:DataSet>`` instead of ``<mes:DataSet>``.
+- Expand the :ref:`source/endpoint test matrix <source-matrix>` (:pull:`109`).
+  Every REST API endpoint is queried for every data source, even if it is known to be not implemented.
+  This allows to spot when source implementations change.
+- Sort entries in :file:`sources.json` (:pull:`109`).
 
 v2.6.3 (2022-09-29)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,14 @@ exclude = [
     "^build/",
 ]
 
+[[tool.mypy.overrides]]
+# Packages/modules for which no type hints are available.
+module = [
+  "requests_mock",
+]
+ignore_missing_imports = true
+
+
 [tool.pytest.ini_options]
 addopts = """
     sdmx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+
+[tool.coverage.run]
+omit = [
+  "sdmx/experimental.py",
+  "sdmx/tests/writer/test_protobuf.py",
+  "sdmx/writer/protobuf.py",
+]
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+exclude = [
+    "^build/",
+]
+
+[tool.pytest.ini_options]
+addopts = """
+    sdmx
+    --cov sdmx --cov-report=
+    -m "not experimental and not source"
+"""
+markers = [
+    "experimental: test of experimental features",
+    "network: tests requiring a network connection",
+    "source: slower, network tests of individual SDMX web services",
+]

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -183,7 +183,7 @@ class Client:
         except KeyError:
             raise ValueError(
                 f"resource_type ({resource_type!r}) must be in {Resource.describe()}"
-            )
+            ) from None
 
         if resource:
             # Resource object is given
@@ -205,8 +205,8 @@ class Client:
         force = kwargs.pop("force", False)
         if not (force or self.source.supports[resource_type]):
             raise NotImplementedError(
-                f"{self.source.id} does not support the {resource_type!r} API "
-                "endpoint. Use force=True to override"
+                f"{self.source.id} does not implement or support the {resource_type!r} "
+                "API endpoint. Use force=True to override"
             )
 
         # Construct the URL
@@ -233,7 +233,7 @@ class Client:
             key, dsd = self._make_key(resource_type, resource_id, key, dsd)
             kwargs["dsd"] = dsd
         elif not (key is None or isinstance(key, str)):
-            raise TypeError(f"key must be str or dict; got {type(key)}")
+            raise TypeError(f"key must be str or dict; got {key.__class__.__name__}")
 
         url.key = key
 

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -80,15 +80,14 @@ class Client:
     def __getattr__(self, name):
         """Convenience methods."""
         try:
-            # Provide resource_type as a positional argument, so that the
-            # first positional argument to the convenience method is treated as
-            # resource_id
+            # Provide resource_type as a positional argument, so that the first
+            # positional argument to the convenience method is treated as resource_id
             func = partial(self.get, Resource[name])
         except KeyError:
             raise AttributeError
         else:
-            # Modify the docstring to explain the argument fixed by the
-            # convenience method
+            # Modify the docstring to explain the argument fixed by the convenience
+            # method
             func.__doc__ = self.get.__doc__.replace(
                 ".\n", f" with resource_type={repr(name)}.\n", 1
             )
@@ -156,8 +155,8 @@ class Client:
             )
 
             if dsd.is_external_reference:
-                # DataStructureDefinition was not retrieved with the Dataflow
-                # query; retrieve it explicitly
+                # DataStructureDefinition was not retrieved with the Dataflow query;
+                # retrieve it explicitly
                 dsd = self.get(resource=dsd, use_cache=True).structure[dsd.id]
         else:
             # Construct a DSD from the keys
@@ -183,7 +182,7 @@ class Client:
                 resource_type = Resource[resource_type]
         except KeyError:
             raise ValueError(
-                f"resource_type ({resource_type!r}) must be in " + Resource.describe()
+                f"resource_type ({resource_type!r}) must be in {Resource.describe()}"
             )
 
         if resource:
@@ -206,7 +205,7 @@ class Client:
         force = kwargs.pop("force", False)
         if not (force or self.source.supports[resource_type]):
             raise NotImplementedError(
-                f"{self.source.id} does not support the {repr(resource_type)} API "
+                f"{self.source.id} does not support the {resource_type!r} API "
                 "endpoint. Use force=True to override"
             )
 
@@ -457,7 +456,7 @@ class Client:
             # Convert a 501 response to a Python NotImplementedError
             if e.response.status_code == 501:
                 raise NotImplementedError(
-                    "{!r} endpoint at {}".format(resource_type, e.request.url)
+                    f"{resource_type!r} endpoint at {e.request.url}"
                 )
             else:
                 raise
@@ -476,9 +475,8 @@ class Client:
             Reader = get_reader_for_content_type(content_type)
         except ValueError:
             raise ValueError(
-                "can't determine a SDMX reader for response content type "
-                + repr(content_type)
-            )
+                f"can't determine a reader for response content type {content_type!r}"
+            ) from None
 
         # Instantiate reader
         reader = Reader()

--- a/sdmx/exceptions.py
+++ b/sdmx/exceptions.py
@@ -1,4 +1,12 @@
-from requests import HTTPError  # noqa: F401
+from requests import HTTPError
+from requests.exceptions import SSLError
+
+__all__ = [
+    "HTTPError",
+    "ParseError",
+    "SSLError",
+    "XMLParseError",
+]
 
 
 class ParseError(Exception):

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -239,7 +239,9 @@ class Reader(BaseReader):
 
         try:
             # Use the etree event-driven parser
-            for event, element in etree.iterparse(source, events=("start", "end")):
+            for event, element in etree.iterparse(  # type: ignore [attr-defined]
+                source, events=("start", "end")
+            ):
                 try:
                     # Retrieve the parsing function for this element & event
                     func = PARSE[element.tag, event]

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -37,8 +37,9 @@ SKIP = (
     # Tags that are bare containers for other XML elements
     "str:Categorisations str:CategorySchemes str:Codelists str:Concepts "
     "str:ConstraintAttachment str:Constraints str:Dataflows "
-    "str:DataStructureComponents str:DataStructures str:Metadataflows str:None "
-    "str:OrganisationSchemes str:ProvisionAgreements str:StructureSets "
+    "str:DataStructureComponents str:DataStructures str:HierarchicalCodelists "
+    "str:Metadataflows str:MetadataStructures str:None str:OrganisationSchemes "
+    "str:ProvisionAgreements str:StructureSets "
     # Contents of references
     ":Ref :URN"
 )

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional, Type, Union, cast
 
 from dateutil.parser import isoparse
 from lxml import etree
-from lxml.etree import QName
+from lxml.etree import _Element, QName
 
 import sdmx.urn
 from sdmx import message, model
@@ -293,7 +293,7 @@ class Reader(BaseReader):
 
     def push(self, stack_or_obj, obj=None):
         """Push an object onto a stack."""
-        if stack_or_obj is None:
+        if stack_or_obj is None or (isinstance(stack_or_obj, _Element) and obj is None):
             return
         elif obj is None:
             # Add the object to a stack based on its class

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional, Type, Union, cast
 
 from dateutil.parser import isoparse
 from lxml import etree
-from lxml.etree import _Element, QName
+from lxml.etree import QName, _Element
 
 import sdmx.urn
 from sdmx import message, model
@@ -469,7 +469,7 @@ class Reader(BaseReader):
     def maintainable(self, cls, elem, **kwargs):
         """Create or retrieve a MaintainableArtefact of `cls` from `elem` and `kwargs`.
 
-        Following the SDMX-IM class hierachy, :meth:`maintainable` calls
+        Following the SDMX-IM class hierarchy, :meth:`maintainable` calls
         :meth:`nameable`, which in turn calls :meth:`identifiable`, etc. (Since no
         concrete class is versionable but not maintainable, no separate method is
         created, for better performance). For all of these methods:
@@ -595,7 +595,7 @@ def _header(reader, elem):
     # Appearing in data messages from WB_WDI and the footer.xml specimen
     reader.pop_all("DataSetAction")
     reader.pop_all("DataSetID")
-    # Apparing in the footer.xml specimen
+    # Appearing in the footer.xml specimen
     reader.pop_all("Timezone")
 
 
@@ -690,7 +690,7 @@ def _header_structure(reader, elem):
 
 @end("footer:Footer")
 def _footer(reader, elem):
-    # Get attributes from the child <footer:Messsage>
+    # Get attributes from the child <footer:Message>
     args = dict()
     setdefault_attrib(args, elem[0], "code", "severity")
     if "code" in args:

--- a/sdmx/rest.py
+++ b/sdmx/rest.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 from warnings import warn
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import sdmx.source
 
 # Mapping from Resource value to class name.

--- a/sdmx/rest.py
+++ b/sdmx/rest.py
@@ -1,5 +1,11 @@
 """Information related to the SDMX-REST web service standard."""
+from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING, Optional
+from warnings import warn
+
+if TYPE_CHECKING:
+    import sdmx.source
 
 # Mapping from Resource value to class name.
 CLASS_NAME = {
@@ -9,6 +15,22 @@ CLASS_NAME = {
 
 # Inverse of :data:`CLASS_NAME`.
 VALUE = {v: k for k, v in CLASS_NAME.items()}
+
+#: Response codes defined by the SDMX-REST standard.
+RESPONSE_CODE = {
+    200: "OK",
+    304: "No changes",
+    400: "Bad syntax",
+    401: "Unauthorized",
+    403: "Semantic error",  # or "Forbidden"
+    404: "Not found",
+    406: "Not acceptable",
+    413: "Request entity too large",
+    414: "URI too long",
+    500: "Internal server error",
+    501: "Not implemented",
+    503: "Unavailable",
+}
 
 
 class Resource(str, Enum):
@@ -106,18 +128,55 @@ class Resource(str, Enum):
         return "{" + " ".join(v.name for v in cls._member_map_.values()) + "}"
 
 
-#: Response codes defined by the SDMX-REST standard.
-RESPONSE_CODE = {
-    200: "OK",
-    304: "No changes",
-    400: "Bad syntax",
-    401: "Unauthorized",
-    403: "Semantic error",  # or "Forbidden"
-    404: "Not found",
-    406: "Not acceptable",
-    413: "Request entity too large",
-    414: "URI too long",
-    500: "Internal server error",
-    501: "Not implemented",
-    503: "Unavailable",
-}
+@dataclass
+class URL:
+    """Utility class to build SDMX REST URLs.
+
+    See also
+    --------
+    https://github.com/sdmx-twg/sdmx-rest/blob/v1.5.0/v2_1/ws/rest/src/sdmx-rest.yaml
+    """
+
+    source: "sdmx.source.Source"
+
+    resource_type: Resource
+
+    resource_id: str
+
+    provider: Optional[str] = None
+
+    # Data provider ID to use in the URL
+    agencyID: Optional[str] = None
+
+    version: Optional[str] = None
+
+    key: Optional[str] = None
+
+    def __post_init__(self):
+        if self.resource_type == Resource.data:
+            # Requests for data do not specific an agency in the URL
+            if self.provider is not None:
+                warn(f"'provider' argument is redundant for {self.resource_type!r}")
+            self.agency_id = None
+        else:
+            self.agency_id = (
+                self.provider if self.provider else getattr(self.source, "id", None)
+            )
+
+    def join(self) -> str:
+        """Join the URL parts, returning a complete URL."""
+        resource_id = "all" if self.resource_id is None else self.resource_id
+        version = "latest" if self.version is None else self.version
+
+        parts = [self.source.url, self.resource_type.name]
+
+        if self.resource_type == Resource.data:
+            parts.append(self.resource_id)
+            if self.key:
+                parts.append(self.key)
+        else:
+            parts.extend([self.agency_id, resource_id, version])
+
+        assert None not in parts, parts
+
+        return "/".join(parts)

--- a/sdmx/rest.py
+++ b/sdmx/rest.py
@@ -53,6 +53,8 @@ class Resource(str, Enum):
     ``dataconsumerscheme``        :class:`.DataConsumerScheme`
     ``dataproviderscheme``        :class:`.DataProviderScheme`
     ``datastructure``             :class:`.DataStructureDefinition`
+    ``metadataflow``              :class:`.MetadataflowDefinition`
+    ``metadatastructure``         :class:`.MetadataStructureDefinition`
     ``organisationscheme``        :class:`.OrganisationScheme`
     ``provisionagreement``        :class:`.ProvisionAgreement`
     ``structure``                 Mixed.
@@ -60,8 +62,6 @@ class Resource(str, Enum):
     ``customtypescheme``          Not implemented.
     ``hierarchicalcodelist``      Not implemented.
     ``metadata``                  Not implemented.
-    ``metadataflow``              Not implemented.
-    ``metadatastructure``         Not implemented.
     ``namepersonalisationscheme`` Not implemented.
     ``organisationunitscheme``    Not implemented.
     ``process``                   Not implemented.

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -57,16 +57,9 @@ class Source(BaseModel):
     #:   specific data messages.
     supports: Dict[Union[str, Resource], bool] = {
         Resource.data: True,
-        Resource.actualconstraint: False,
-        Resource.allowedconstraint: False,
         Resource.attachementconstraint: False,
         Resource.customtypescheme: False,
-        Resource.dataconsumerscheme: False,
-        Resource.dataproviderscheme: False,
-        Resource.hierarchicalcodelist: False,
         Resource.metadata: False,
-        Resource.metadataflow: False,
-        Resource.metadatastructure: False,
         Resource.namepersonalisationscheme: False,
         Resource.organisationunitscheme: False,
         Resource.process: False,

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -30,18 +30,14 @@ class Source(BaseSource):
         kwargs.pop("get_footer_url", None)
 
         resource_type = kwargs["resource_type"]
-        if resource_type != Resource.data:
+        if resource_type != Resource.data or "resource" in kwargs:
             parameters = kwargs.setdefault("params", {})
+            parameters["references"] = "descendants"
 
-            if resource_type == Resource.dataflow:
-                parameters["references"] = "none"
-
-                resource_id = kwargs["resource_id"]
-                if resource_id is None:
-                    kwargs["resource_id"] = "all"
-
-            elif resource_type == Resource.datastructure:
-                parameters["references"] = "descendants"
+            # handle get all dataflows case
+            if resource_type == Resource.dataflow and kwargs["resource_id"] is None:
+                kwargs["resource_id"] = "all"
+                parameters["references"] = None
 
     def finish_message(self, message, request, get_footer_url=(30, 3), **kwargs):
         """Handle the initial response.

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import requests
 
 from . import Source as BaseSource
-
+from sdmx.rest import Resource
 
 class Source(BaseSource):
     """Handle Eurostat's mechanism for large datasets.
@@ -28,6 +28,20 @@ class Source(BaseSource):
         super().modify_request_args(kwargs)
 
         kwargs.pop("get_footer_url", None)
+
+        resource_type = kwargs["resource_type"]
+        if resource_type != Resource.data:
+            parameters = kwargs.setdefault("params", {})
+
+            if resource_type == Resource.dataflow:
+                parameters["references"] = "none"
+
+                resource_id = kwargs["resource_id"]
+                if resource_id is None:
+                    kwargs["resource_id"] = "all"
+
+            elif resource_type == Resource.datastructure:
+                parameters["references"] = "descendants"
 
     def finish_message(self, message, request, get_footer_url=(30, 3), **kwargs):
         """Handle the initial response.

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -5,15 +5,16 @@ from zipfile import ZipFile
 
 import requests
 
-from . import Source as BaseSource
 from sdmx.rest import Resource
+from sdmx.source import Source as BaseSource
+
 
 class Source(BaseSource):
     """Handle Eurostat's mechanism for large datasets.
 
-    For some requests, ESTAT returns a DataMessage that has no content except
-    for a ``<footer:Footer>`` element containing a URL where the data will be
-    made available as a ZIP file.
+    For some requests, ESTAT returns a DataMessage that has no content except for a
+    ``<footer:Footer>`` element containing a URL where the data will be made available
+    as a ZIP file.
 
     To configure :meth:`finish_message`, pass its `get_footer_url` argument to
     :meth:`.Client.get`.
@@ -87,7 +88,6 @@ class Source(BaseSource):
         The request for the indicated ZIP file URL returns an octet-stream;
         this handler saves it, opens it, and returns the content of the single
         contained XML file.
-
         """
 
         if response.headers["content-type"] != "application/octet-stream":

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 class Source(BaseSource):
-    """Handle Eurostat's mechanism for large datasets.
+    """Handle Eurostat's mechanism for large datasets and other quirks.
 
     For some requests, ESTAT returns a DataMessage that has no content except for a
     ``<footer:Footer>`` element containing a URL where the data will be made available
@@ -23,6 +23,10 @@ class Source(BaseSource):
     :meth:`.Client.get`.
 
     .. versionadded:: 0.2.1
+
+    See also
+    --------
+    :meth:`modify_request_args`
     """
 
     _id = "ESTAT"
@@ -34,6 +38,10 @@ class Source(BaseSource):
         values "children", "descendants", or "none". Other values—including the "all" or
         "parentsandsiblings" used as defaults by :class:`.Client` cause errors. Replace
         unsupported values with "none", and use "descendants" as default.
+
+        See also
+        --------
+        :pull:`107`, :pull:`108`
         """
         super().modify_request_args(kwargs)
 

--- a/sdmx/source/wb_wdi.py
+++ b/sdmx/source/wb_wdi.py
@@ -18,8 +18,8 @@ class Source(BaseSource):
         try:
             if isinstance(kwargs["key"], str):
                 # Data queries fail without a trailing slash
-                # TODO improve the hook integration with Client.get so this can be
-                #      done after the query URL is prepared
+                # TODO improve the hook integration with Client.get so this can be done
+                #      after the query URL is prepared
                 kwargs["key"] += "/"
         except KeyError:
             pass

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -49,8 +49,8 @@
   },
   {
     "id": "ESTAT",
-    "documentation": "https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1",
-    "url": "https://ec.europa.eu/eurostat/SDMX/diss-web/rest",
+    "documentation": "https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555",
+    "url": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1",
     "name": "Eurostat",
     "supports": {
       "agencyscheme": false,

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -50,9 +50,9 @@
   {
     "id": "ECB",
     "resources": {
-        "data": {
-            "headers": {}
-        }
+      "data": {
+        "headers": {}
+      }
     },
     "url": "https://sdw-wsrest.ecb.europa.eu/service",
     "name": "European Central Bank",
@@ -94,7 +94,7 @@
     "name": "International Labor Organization",
     "url": "http://www.ilo.org/sdmx/rest",
     "headers": {
-        "accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"
+      "accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"
     },
     "supports": {
       "actualconstraint": false,
@@ -144,9 +144,9 @@
     "name": "Institut national de la statistique et des études économiques (FR)",
     "url": "https://www.bdm.insee.fr/series/sdmx",
     "headers": {
-        "data": {
-            "Accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
-        }
+      "data": {
+        "Accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
+      }
     },
     "supports": {
       "actualconstraint": false,
@@ -199,19 +199,6 @@
     }
   },
   {
-    "id": "NBB",
-    "data_content_type": "JSON",
-    "documentation": "https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf",
-    "url": "https://stat.nbb.be/sdmx-json",
-    "name": "National Bank of Belgium"
-  },
-  {
-    "id": "OECD",
-    "data_content_type": "JSON",
-    "url": "https://stats.oecd.org/SDMX-JSON",
-    "name": "Organisation for Economic Co-operation and Development"
-  },
-  {
     "id": "NB",
     "name": "Norges Bank (NO)",
     "url": "https://data.norges-bank.no/api",
@@ -230,10 +217,23 @@
       "structure-specific data": true
     },
     "headers": {
-        "data": {
-            "accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
-        }
+      "data": {
+        "accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
+      }
     }
+  },
+  {
+    "id": "NBB",
+    "data_content_type": "JSON",
+    "documentation": "https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf",
+    "url": "https://stat.nbb.be/sdmx-json",
+    "name": "National Bank of Belgium"
+  },
+  {
+    "id": "OECD",
+    "data_content_type": "JSON",
+    "url": "https://stats.oecd.org/SDMX-JSON",
+    "name": "Organisation for Economic Co-operation and Development"
   },
   {
     "id": "SGR",
@@ -271,7 +271,7 @@
     "name": "UN Educational, Scientific and Cultural Organization",
     "url": "http://api.uis.unesco.org/sdmx",
     "headers": {
-        "accept": "application/vnd.sdmx.structure+xml;version=2.1"
+      "accept": "application/vnd.sdmx.structure+xml;version=2.1"
     },
     "supports": {
       "actualconstraint": false,

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -11,10 +11,17 @@
     "documentation": "https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900",
     "name": "German Federal Bank",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "categorisation": false,
       "categoryscheme": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "organisationscheme": false,
       "provisionagreement": false,
       "structure": false,
@@ -29,6 +36,13 @@
     "documentation": "https://www.bis.org/statistics/sdmx_techspec.htm",
     "supports": {
       "agencyscheme": false,
+      "allowedconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "organisationscheme": false,
+      "provisionagreement": false,
       "structureset": false,
       "preview": true
     }
@@ -43,6 +57,13 @@
     "url": "https://sdw-wsrest.ecb.europa.eu/service",
     "name": "European Central Bank",
     "supports": {
+      "actualconstraint": false,
+      "allowedconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "preview": true,
       "provisionagreement": false
     }
@@ -53,11 +74,19 @@
     "url": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1",
     "name": "Eurostat",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
-      "categoryscheme": false,
-      "codelist": false,
-      "conceptscheme": false,
-      "provisionagreement": false
+      "allowedconstraint": false,
+      "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "organisationscheme": false,
+      "provisionagreement": false,
+      "structure": false,
+      "structureset": false
     }
   },
   {
@@ -68,7 +97,14 @@
         "accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"
     },
     "supports": {
-      "provisionagreement": false
+      "actualconstraint": false,
+      "allowedconstraint": false,
+      "dataconsumerscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "provisionagreement": false,
+      "structure": false
     }
   },
   {
@@ -76,6 +112,11 @@
     "url": "https://sdmxcentral.imf.org/ws/public/sdmxapi/rest",
     "name": "International Monetary Fund",
     "supports": {
+      "actualconstraint": false,
+      "allowedconstraint": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "provisionagreement": false
     }
   },
@@ -84,8 +125,15 @@
     "url": "http://sdmx.snieg.mx/service/rest",
     "name": "Instituto Nacional de Estadística y Geografía (MX)",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "provisionagreement": false,
       "structureset": false,
       "structure-specific data": true
@@ -100,7 +148,16 @@
             "Accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
         }
     },
-    "supports": {"provisionagreement": false}
+    "supports": {
+      "actualconstraint": false,
+      "allowedconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "provisionagreement": false
+    }
   },
   {
     "id": "ISTAT",
@@ -108,6 +165,9 @@
     "url": "https://esploradati.istat.it/SDMXWS/rest",
     "supports": {
       "agencyscheme": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
       "provisionagreement": false,
       "structureset": false,
       "structure-specific data": true
@@ -119,12 +179,19 @@
     "url": "https://osp-rs.stat.gov.lt/rest_xml",
     "name": "Statistics Lithuania",
     "supports": {
+      "actualconstraint": false,
+      "allowedconstraint": false,
       "agencyscheme": false,
       "categorisation": false,
       "categoryscheme": false,
       "codelist": false,
       "conceptscheme": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "organisationscheme": false,
       "provisionagreement": false,
       "structure": false,
@@ -149,10 +216,16 @@
     "name": "Norges Bank (NO)",
     "url": "https://data.norges-bank.no/api",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "categorisation": false,
       "categoryscheme": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "structureset": false,
       "structure-specific data": true
     },
@@ -165,7 +238,12 @@
   {
     "id": "SGR",
     "url": "https://registry.sdmx.org/ws/rest",
-    "name": "SDMX Global Registry"
+    "name": "SDMX Global Registry",
+    "supports": {
+      "actualconstraint": false,
+      "allowedconstraint": false,
+      "metadataflow": false
+    }
   },
   {
     "id": "SPC",
@@ -173,6 +251,10 @@
     "url": "https://stats-nsi-stable.pacificdata.org/rest",
     "documentation": "https://docs.pacificdata.org/dotstat",
     "supports": {
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
       "provisionagreement": false,
       "structureset": false
     }
@@ -192,10 +274,17 @@
         "accept": "application/vnd.sdmx.structure+xml;version=2.1"
     },
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "categorisation": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
       "datastructure": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "organisationscheme": false,
       "structure": false,
       "structureset": false
@@ -206,7 +295,11 @@
     "name": "UN Children's Fund",
     "url": "https://sdmx.data.unicef.org/ws/public/sdmxapi/rest",
     "supports": {
+      "actualconstraint": false,
       "categorisation": false,
+      "dataconsumerscheme": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "structureset": false,
       "structure-specific data": true
     }
@@ -216,8 +309,15 @@
     "name": "United Nations Statistics Division",
     "url": "http://data.un.org/WS/rest",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "provisionagreement": false,
       "structureset": false,
       "preview": true
@@ -228,7 +328,14 @@
     "name": "World Bank World Integrated Trade Solution",
     "url": "http://wits.worldbank.org/API/V1/SDMX/V21/rest",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
       "provisionagreement": false
     }
   },
@@ -237,13 +344,26 @@
     "name": "World Bank World Development Indicators",
     "url": "http://api.worldbank.org/v2/sdmx/rest",
     "supports": {
+      "actualconstraint": false,
       "agencyscheme": false,
+      "allowedconstraint": false,
       "categorisation": false,
+      "categoryscheme": false,
+      "codelist": false,
+      "conceptscheme": false,
       "contentconstraint": false,
+      "dataconsumerscheme": false,
+      "dataflow": false,
+      "dataproviderscheme": false,
+      "datastructure": false,
+      "hierarchicalcodelist": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "organisationscheme": false,
       "provisionagreement": false,
+      "structure-specific data": true,
       "structure": false,
-      "structureset": false,
-      "structure-specific data": true
+      "structureset": false
     }
   }
 ]

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -199,10 +199,7 @@ class SpecimenCollection:
     def __init__(self, base_path):
         self.base_path = base_path
 
-        specimens = [
-            (base_path / "INSEE" / "CNA-2010-CONSO-SI-A17.xml", "xml", "data"),
-            (base_path / "INSEE" / "IPI-2010-A21.xml", "xml", "data"),
-        ]
+        specimens = []
 
         # XML data files for the ECB exchange rate data flow
         for path in (base_path / "ECB_EXR").rglob("*.xml"):
@@ -211,14 +208,23 @@ class SpecimenCollection:
                 kind = "structure"
             specimens.append((path, "xml", kind))
 
-        # JSON data files for the ECB exchange rate data flow
-        for fp in (base_path / "ECB_EXR").rglob("*.json"):
-            specimens.append((fp, "json", "data"))
-        for fp in (base_path / "OECD").rglob("*.json"):
-            specimens.append((fp, "json", "data"))
+        # JSON data files for ECB and OECD data flows
+        for source_id in ("ECB_EXR", "OECD"):
+            specimens.extend(
+                (fp, "json", "data")
+                for fp in base_path.joinpath(source_id).rglob("*.json")
+            )
 
         # Miscellaneous XML data files
-        specimens.append((base_path / "ESTAT" / "footer.xml", "xml", "data"))
+        specimens.extend(
+            (base_path.joinpath(*parts), "xml", "data")
+            for parts in [
+                ("INSEE", "CNA-2010-CONSO-SI-A17.xml"),
+                ("INSEE", "IPI-2010-A21.xml"),
+                ("ESTAT", "footer.xml"),
+                ("ESTAT", "NAMA_10_GDP-ss.xml"),
+            ]
+        )
 
         # Miscellaneous XML structure files
         specimens.extend(

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -119,6 +119,12 @@ ELEMENTS = [
         E(qname("str:TextFormat"), invalidFacetTypeAttr="foo"),
         re.compile("ValidationError: .* extra fields not permitted", flags=re.DOTALL),
     ),
+    # xml._dk
+    (E(qname("str:Key")), None),
+    # xml._dks
+    (E(qname("str:DataKeySet"), isIncluded="true"), None),
+    # xml._pa
+    (E(qname("str:ProvisionAgreement")), None),
 ]
 
 

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -118,6 +118,19 @@ class TestClient:
             client.notanendpoint()
 
     def test_request_from_args(self, caplog, client):
+        # Raises for invalid resource type
+        kwargs = dict(resource_type="foo")
+        with pytest.raises(ValueError, match=r"resource_type \('foo'\) must be in"):
+            client._request_from_args(kwargs)
+
+        # Raises for not implemented endpoint
+        with pytest.raises(NotImplementedError, match="OECD does not implement"):
+            sdmx.Client("OECD").get("datastructure")
+
+        # Raises for invalid key type
+        with pytest.raises(TypeError, match="must be str or dict; got int"):
+            client.get("data", key=12345)
+
         # Warns for deprecated argument
         with pytest.warns(
             DeprecationWarning, match="validate= keyword argument to Client.get"

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -172,7 +172,7 @@ def test_request_get_args():
         )
 
     # Using an unknown endpoint is an exception
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         ESTAT.get("badendpoint", "id")
 
     # TODO test Client.get(obj) with IdentifiableArtefact subclasses

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -145,8 +145,8 @@ def test_request_get_args():
 
     # Client._make_key accepts '+'-separated values
     args = dict(
-        resource_id="une_rt_a",
-        key={"GEO": "EL+ES+IE"},
+        resource_id="UNE_RT_A",
+        key={"geo": "EL+ES+IE"},
         params={"startPeriod": "2007"},
         dry_run=True,
         use_cache=True,
@@ -155,7 +155,7 @@ def test_request_get_args():
     url = ESTAT.data(**args).url
 
     # Using an iterable of key values gives the same URL
-    args["key"] = {"GEO": ["EL", "ES", "IE"]}
+    args["key"] = {"geo": ["EL", "ES", "IE"]}
     assert ESTAT.data(**args).url == url
 
     # Using a direct string for a key gives the same URL
@@ -165,8 +165,8 @@ def test_request_get_args():
     # Giving 'provider' is redundant for a data request, causes a warning
     with pytest.warns(UserWarning, match="'provider' argument is redundant"):
         ESTAT.data(
-            "une_rt_a",
-            key={"GEO": "EL+ES+IE"},
+            "UNE_RT_A",
+            key={"geo": "EL+ES+IE"},
             params={"startPeriod": "2007"},
             provider="ESTAT",
         )

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -79,7 +79,8 @@ def test_doc_index1():
     s = sdmx.to_pandas(structure_response)
     expected = pd.Series(
         {
-            "ACP": "African, Caribbean and Pacific Group of States, signatories of the Partnership Agreement",
+            "ACP": "African, Caribbean and Pacific Group of States, signatories of the "
+            "Partnership Agreement",
             "ACP_AFR": "African ACP states",
             "ACP_CRB": "Caribbean ACP states",
             "ACP_PAC": "Pacific ACP states",
@@ -113,7 +114,7 @@ def test_doc_usage_structure():
     msg1 = ecb.categoryscheme(provider="all")
 
     assert msg1.response.url == (
-        "https://sdw-wsrest.ecb.europa.eu/service/categoryscheme/all/latest"
+        "https://sdw-wsrest.ecb.europa.eu/service/categoryscheme/all/all/latest"
         "?references=parentsandsiblings"
     )
 

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -23,23 +23,23 @@ def test_doc_example():
 
     estat = sdmx.Client("ESTAT")
 
-    metadata = estat.datastructure("DSD_une_rt_a")
+    metadata = estat.datastructure("UNE_RT_A")
 
-    for cl in "CL_AGE", "CL_UNIT":
+    for cl in "AGE", "UNIT":
         print(sdmx.to_pandas(metadata.codelist[cl]))
 
     resp = estat.data(
-        "une_rt_a", key={"GEO": "EL+ES+IE"}, params={"startPeriod": "2007"}
+        "UNE_RT_A", key={"geo": "EL+ES+IE"}, params={"startPeriod": "2007"}
     )
 
-    data = sdmx.to_pandas(resp).xs("Y15-74", level="AGE", drop_level=False)
+    data = sdmx.to_pandas(resp).xs("Y15-74", level="age", drop_level=False)
 
     data.loc[("A", "Y15-74", "PC_ACT", "T")]
 
     # Further checks per https://github.com/dr-leo/pandaSDMX/issues/157
 
     # DimensionDescriptor for the structure message
-    dd1 = metadata.structure.DSD_une_rt_a.dimensions
+    dd1 = metadata.structure.UNE_RT_A.dimensions
 
     # DimensionDescriptor retrieved whilst validating the data message
     dd2 = resp.data[0].structured_by.dimensions
@@ -58,41 +58,41 @@ def test_doc_example():
 def test_doc_index1():
     """First code example in index.rst."""
     estat = Client("ESTAT")
-    flow_response = estat.dataflow("une_rt_a")
+    flow_response = estat.dataflow("UNE_RT_A")
 
     with pytest.raises(TypeError):
         # This presumes the DataStructureDefinition instance can conduct a
         # network request for its own content
-        structure_response = flow_response.dataflow.une_rt_a.structure(
+        structure_response = flow_response.dataflow.UNE_RT_A.structure(
             request=True, target_only=False
         )
 
     # Same effect
     structure_response = estat.get(
-        "datastructure", flow_response.dataflow.une_rt_a.structure.id
+        "datastructure", flow_response.dataflow.UNE_RT_A.structure.id
     )
 
     # Even better: Client.get(…) should examine the class and ID of the object
-    # structure = estat.get(flow_response.dataflow.une_rt_a.structure)
+    # structure = estat.get(flow_response.dataflow.UNE_RT_A.structure)
 
     # Show some codelists
     s = sdmx.to_pandas(structure_response)
     expected = pd.Series(
         {
-            "AT": "Austria",
-            "BE": "Belgium",
-            "BG": "Bulgaria",
-            "CH": "Switzerland",
-            "CY": "Cyprus",
+            "ACP": "African, Caribbean and Pacific Group of States, signatories of the Partnership Agreement",
+            "ACP_AFR": "African ACP states",
+            "ACP_CRB": "Caribbean ACP states",
+            "ACP_PAC": "Pacific ACP states",
+            "AD": "Andorra",
         },
-        name="GEO",
-    ).rename_axis("CL_GEO")
+        name="Geopolitical entity (reporting)",
+    ).rename_axis("GEO")
 
     # Codelists are converted to a DictLike
     assert isinstance(s.codelist, DictLike)
 
     # Same effect
-    assert_pd_equal(s.codelist["CL_GEO"].sort_index().head(), expected)
+    assert_pd_equal(s.codelist["GEO"].sort_index().head(), expected)
 
 
 @pytest.mark.network

--- a/sdmx/tests/test_rest.py
+++ b/sdmx/tests/test_rest.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from sdmx import Resource
@@ -16,3 +18,8 @@ class TestResource:
     )
     def test_class_name(self, value, expected):
         assert expected == Resource.class_name(value)
+
+    def test_describe(self):
+        assert re.fullmatch(
+            "{actualconstraint .* vtlmappingscheme}", Resource.describe()
+        )

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -17,7 +17,7 @@ def test_source_support():
     assert sources["ILO"].supports["categoryscheme"]
 
     # Specifically unsupported endpoint
-    assert not sources["ESTAT"].supports["categoryscheme"]
+    assert not sources["ESTAT"].supports["contentconstraint"]
 
     # Explicitly supported structure-specific data
     assert sources["INEGI"].supports["structure-specific data"]

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -1,6 +1,7 @@
 import pytest
 
-from sdmx.source import add_source, list_sources, sources
+from sdmx import model
+from sdmx.source import Source, add_source, list_sources, sources
 
 
 def test_list_sources():
@@ -45,3 +46,16 @@ def test_add_source():
         ValueError, match="Data source 'ECB' already defined; use override=True"
     ):
         add_source(dict(id="ECB", name="Demo source", url="https://example.com/sdmx"))
+
+
+class TestSource:
+    @pytest.fixture
+    def s(self):
+        """An instance of the class."""
+        yield Source(id="FOO", name="Test source", url="https://example.com")
+
+    def test_modify_request_args(self, s):
+        kwargs = dict(dsd=model.DataStructureDefinition())
+
+        s.modify_request_args(kwargs)
+        assert "structurespecificdata" in kwargs["headers"]["Accept"]

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -234,7 +234,10 @@ class TestILO(DataSourceTest):
     @pytest.mark.network
     def test_gh_96(self, caplog, cache_path, client):
         client.get("codelist", "CL_ECO", params=dict(references="parentsandsiblings"))
-        assert "ILO does not support references = parentsandsiblings; discarded"
+        assert (
+            "ILO does not support references='parentsandsiblings'; discarded"
+            in caplog.messages
+        )
 
 
 class TestINEGI(DataSourceTest):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -208,10 +208,6 @@ class TestESTAT(DataSourceTest):
         client.data(**args)
 
 
-class TestIMF(DataSourceTest):
-    source_id = "IMF"
-
-
 class TestILO(DataSourceTest):
     source_id = "ILO"
     xfail = {
@@ -238,6 +234,10 @@ class TestILO(DataSourceTest):
             "ILO does not support references='parentsandsiblings'; discarded"
             in caplog.messages
         )
+
+
+class TestIMF(DataSourceTest):
+    source_id = "IMF"
 
 
 class TestINEGI(DataSourceTest):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -181,14 +181,14 @@ class TestESTAT(DataSourceTest):
         Examples from:
         https://ec.europa.eu/eurostat/web/sdmx-web-services/example-queries
         """
-        df_id = "nama_10_gdp"
+        df_id = "NAMA_10_GDP"
         args = dict(resource_id=df_id)
 
         # Query for the DSD
         dsd = client.dataflow(**args).dataflow[df_id].structure
 
-        # Even with ?references=all, ESTAT returns a short message with the
-        # DSD as an external reference. Query again to get its actual contents.
+        # Even with ?references=all, ESTAT returns a short message with the DSD as an
+        # external reference. Query again to get its actual contents.
         if dsd.is_external_reference:
             dsd = client.get(resource=dsd).structure[0]
             log.info(repr(dsd))
@@ -198,11 +198,11 @@ class TestESTAT(DataSourceTest):
         # Example query, using the DSD already retrieved
         args.update(
             dict(
-                key=dict(UNIT=["CP_MEUR"], NA_ITEM=["B1GQ"], GEO=["LU"]),
+                key=dict(unit=["CP_MEUR"], na_item=["B1GQ"], geo=["LU"]),
                 params={"startPeriod": "2012", "endPeriod": "2015"},
                 dsd=dsd,
                 # commented: for debugging
-                # tofile='temp.xml',
+                # tofile="temp.xml",
             )
         )
         client.data(**args)

--- a/sdmx/tests/test_urn.py
+++ b/sdmx/tests/test_urn.py
@@ -43,6 +43,14 @@ def test_make():
 
 
 def test_match():
+    # Value containing a "." in the ID
+    urn = (
+        "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=LSD:"
+        "TSTT1201R001_MIT1938_1_1._1(1.0)"
+    )
+    assert "TSTT1201R001_MIT1938_1_1._1" == match(urn)["id"]
+
+    # Invalid value (only the "package" component, no "class")
     urn = "urn:sdmx:org.sdmx.infomodel.codelist=BBK:CLA_BBK_COLLECTION(1.0)"
     with pytest.raises(ValueError, match=re.escape(f"not a valid SDMX URN: {urn}")):
         match(urn)

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -8,7 +8,7 @@ URN = re.compile(
     r"urn:sdmx:org\.sdmx\.infomodel"
     r"\.(?P<package>[^\.]*)"
     r"\.(?P<class>[^=]*)=((?P<agency>[^:]*):)?"
-    r"(?P<id>[^\(\.]*)(\((?P<version>[\d\.]*)\))?"
+    r"(?P<id>[^\(]*)(\((?P<version>[\d\.]*)\))?"
     r"(\.(?P<item_id>.*))?"
 )
 

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from sdmx.model import PACKAGE, MaintainableArtefact
 
-# Regular expression for URNs
+#: Regular expression for URNs.
 URN = re.compile(
     r"urn:sdmx:org\.sdmx\.infomodel"
     r"\.(?P<package>[^\.]*)"
@@ -46,6 +46,7 @@ def make(obj, maintainable_parent=None, strict=False):
 
 
 def match(value: str) -> Dict[str, str]:
+    """Match :data:`URN` in `value`, returning a :class:`dict` with the match groups."""
     try:
         match = URN.match(value)
         assert match is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,50 +65,8 @@ formats = gztar
 [bdist_wheel]
 universal=1
 
-[tool:pytest]
-addopts = sdmx
-    --cov sdmx --cov-report=
-    -m "not experimental and not source"
-markers =
-    experimental: test of experimental features
-    network: tests requiring a network connection
-    source: slower, network tests of individual SDMX web services
-
-[coverage:run]
-omit =
-    sdmx/experimental.py
-    sdmx/tests/writer/test_protobuf.py
-    sdmx/writer/protobuf.py
-
-[isort]
-force_grid_wrap = 0
-include_trailing_comma = True
-known_first_party = sdmx
-line_length = 88
-multi_line_output = 3
-use_parentheses = True
-
 [flake8]
 max-line-length = 88
 ignore =
     # line break before binary operator
     W503
-
-[mypy]
-# Empty section required as of mypy 0.800;
-# see https://github.com/python/mypy/issues/9940
-
-[mypy-lxml.*]
-ignore_missing_imports = True
-[mypy-numpy.*]
-ignore_missing_imports = True
-[mypy-pandas.*]
-ignore_missing_imports = True
-[mypy-pytest.*]
-ignore_missing_imports = True
-[mypy-requests_cache.*]
-ignore_missing_imports = True
-[mypy-requests_mock.*]
-ignore_missing_imports = True
-[mypy-setuptools.*]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
     Topic :: Scientific/Engineering :: Information Analysis
 
 [options]
-packages = sdmx
+packages = find:
 zip_safe = True
 include_package_data = True
 python_requires = >= 3.7.2


### PR DESCRIPTION
- Supersedes and incorporates #107 (thanks @zymon!)
- SDMX-ML:
  - Handle text elements like `<com:AnnotationURL/>` that have no text, rather than being simply empty.
  - Handle additional XML namespaces mapped on on `<mes:StructureSpecificData>` and similar, with a specimen and test.
- Add `sdmx.rest.URL` class for constructing REST API URLs.
- All endpoints are now tested for every supported data source, even if they are expected to fail; sources.json and the test suite records and reports the expected failures.