### PR TITLE
Fixed typo in installation docs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -45,8 +45,8 @@ Instructions
 
    To also install optional dependencies, use commands like::
 
-    $ pip install sdmx1[cache]             # just requests-cache
-    $ pip install sdmx1[cache,docs,tests]  # all extras
+    $ pip install 'sdmx1[cache]'             # just requests-cache
+    $ pip install 'sdmx1[cache,docs,tests]'  # all extras
 
 From source
 -----------


### PR DESCRIPTION
Added single quotes for installing with optional dependecies Without single quotes the pip install qith optional dependencies will fail