### PR TITLE
Update test_doc_usage_structure()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ exclude = [
 [[tool.mypy.overrides]]
 # Packages/modules for which no type hints are available.
 module = [
+  "lxml.builder",  # Not covered by lxml-stubs
   "requests_mock",
 ]
 ignore_missing_imports = true

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -5,6 +5,8 @@ these tests, a command-line argument must be given:
 
 $ pytest -m network [...]
 """
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -120,10 +122,11 @@ def test_doc_usage_structure():
 
     # Check specific headers
     headers = msg1.response.headers
-    assert headers["Content-Type"] == (
-        "application/vnd.sdmx.structure+xml; " "version=2.1"
+    assert re.fullmatch(
+        r"application/vnd\.sdmx\.structure\+xml; ?version=2\.1",
+        headers["Content-Type"],
     )
-    assert all(k in headers for k in ["Connection", "Date", "Server"])
+    assert {"Connection", "Date", "Server"} <= set(headers)
 
     # Removed: in pandaSDMX 0.x this was a convenience method that (for this
     # structure message) returned two DataStructureDefinitions. Contra the


### PR DESCRIPTION
Adjust to a slight change in the Content-Type header returned by the ECB source. This change appeared in the [2023-02-19 nightly run](https://github.com/khaeru/sdmx/actions/runs/4214646680) of the "test" CI workflow, but not in [2023-02-18](https://github.com/khaeru/sdmx/actions/runs/4209646267) or earlier.