### PR TITLE
Adjust for mypy 1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-
 [tool.pytest.ini_options]
 addopts = """
     sdmx

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -53,6 +53,7 @@ from sdmx.rest import Resource
 from sdmx.util import (
     BaseModel,
     DictLike,
+    Field,
     compare,
     dictlike_field,
     only,
@@ -1016,9 +1017,9 @@ class Contact(BaseModel):
     #:
     responsibility: InternationalString = InternationalString()
     #:
-    email: List[str]
+    email: List[str] = Field(default_factory=list)
     #:
-    uri: List[str]
+    uri: List[str] = Field(default_factory=list)
 
 
 class Organisation(Item["Organisation"]):

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -23,7 +23,6 @@ Details of the implementation:
 import logging
 from collections import ChainMap
 from copy import copy
-from dataclasses import _MISSING_TYPE, MISSING
 from datetime import date, datetime, timedelta
 from enum import Enum
 from functools import lru_cache
@@ -208,7 +207,8 @@ class InternationalString:
 
 
 _TInternationalString = Union[InternationalString, InternationalString._CONVERTIBLE]
-_TInternationalStringInit = Union[_TInternationalString, _MISSING_TYPE, None]
+# _TInternationalStringInit = Union[_TInternationalString, _MISSING_TYPE, None]
+_TInternationalStringInit = Union[_TInternationalString, None]
 
 
 class Annotation(BaseModel):
@@ -224,8 +224,8 @@ class Annotation(BaseModel):
     #: Content of the annotation.
     text: InternationalString = InternationalString()
 
-    def __init__(self, *, text: _TInternationalStringInit = MISSING, **kwargs):
-        if text is not MISSING:
+    def __init__(self, *, text: _TInternationalStringInit = None, **kwargs):
+        if text is not None:
             kwargs["text"] = InternationalString(text)
         super().__init__(**kwargs)
 
@@ -358,13 +358,13 @@ class NameableArtefact(IdentifiableArtefact):
     def __init__(
         self,
         *,
-        name: _TInternationalStringInit = MISSING,
-        description: _TInternationalStringInit = MISSING,
+        name: _TInternationalStringInit = None,
+        description: _TInternationalStringInit = None,
         **kwargs,
     ):
-        if name is not MISSING:
+        if name is not None:
             kwargs["name"] = InternationalString(name)
-        if description is not MISSING:
+        if description is not None:
             kwargs["description"] = InternationalString(description)
         super().__init__(**kwargs)
 
@@ -1056,16 +1056,16 @@ class Contact(BaseModel):
     def __init__(
         self,
         *,
-        name: _TInternationalStringInit = MISSING,
-        org_unit: _TInternationalStringInit = MISSING,
-        responsibility: _TInternationalStringInit = MISSING,
+        name: _TInternationalStringInit = None,
+        org_unit: _TInternationalStringInit = None,
+        responsibility: _TInternationalStringInit = None,
         **kwargs,
     ):
-        if name is not MISSING:
+        if name is not None:
             kwargs["name"] = InternationalString(name)
-        if org_unit is not MISSING:
+        if org_unit is not None:
             kwargs["org_unit"] = InternationalString(org_unit)
-        if responsibility is not MISSING:
+        if responsibility is not None:
             kwargs["responsibility"] = InternationalString(responsibility)
         super().__init__(**kwargs)
 

--- a/sdmx/model.py
+++ b/sdmx/model.py
@@ -224,6 +224,11 @@ class Annotation(BaseModel):
     #: Content of the annotation.
     text: InternationalString = InternationalString()
 
+    def __init__(self, *, text: _TInternationalStringInit = MISSING, **kwargs):
+        if text is not MISSING:
+            kwargs["text"] = InternationalString(text)
+        super().__init__(**kwargs)
+
 
 class AnnotableArtefact(BaseModel):
     #: :class:`Annotations <.Annotation>` of the object.
@@ -349,6 +354,19 @@ class NameableArtefact(IdentifiableArtefact):
     name: InternationalString = InternationalString()
     #: Multi-lingual description of the object.
     description: InternationalString = InternationalString()
+
+    def __init__(
+        self,
+        *,
+        name: _TInternationalStringInit = MISSING,
+        description: _TInternationalStringInit = MISSING,
+        **kwargs,
+    ):
+        if name is not MISSING:
+            kwargs["name"] = InternationalString(name)
+        if description is not MISSING:
+            kwargs["description"] = InternationalString(description)
+        super().__init__(**kwargs)
 
     def compare(self, other, strict=True):
         """Return :obj:`True` if `self` is the same as `other`.
@@ -520,8 +538,8 @@ class Item(NameableArtefact, Generic[IT]):
     parent: Optional[Union[IT, "ItemScheme"]] = None
     child: List[IT] = []
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         # Add this Item as a child of its parent
         parent = kwargs.get("parent", None)
@@ -979,6 +997,11 @@ class ComponentList(IdentifiableArtefact, Generic[CT]):
 class Code(Item["Code"]):
     """SDMX-IM Code."""
 
+    # NB this exists solely to prevent mypy errors when name= is given as a type other
+    # than InternationalString, eventually handled by NameableArtefact
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
 
 class Codelist(ItemScheme[Code]):
     _Item = Code
@@ -1029,6 +1052,22 @@ class Contact(BaseModel):
     email: List[str] = Field(default_factory=list)
     #:
     uri: List[str] = Field(default_factory=list)
+
+    def __init__(
+        self,
+        *,
+        name: _TInternationalStringInit = MISSING,
+        org_unit: _TInternationalStringInit = MISSING,
+        responsibility: _TInternationalStringInit = MISSING,
+        **kwargs,
+    ):
+        if name is not MISSING:
+            kwargs["name"] = InternationalString(name)
+        if org_unit is not MISSING:
+            kwargs["org_unit"] = InternationalString(org_unit)
+        if responsibility is not MISSING:
+            kwargs["responsibility"] = InternationalString(responsibility)
+        super().__init__(**kwargs)
 
 
 class Organisation(Item["Organisation"]):

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -152,12 +152,10 @@ class Source(BaseModel):
 
 
 class _NoSource(Source):
-    id = ""
-    url = ""
-    name = ""
+    pass
 
 
-NoSource = _NoSource()
+NoSource = _NoSource(id="", url="", name="")
 
 
 def add_source(

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -446,11 +446,7 @@ def test_internationalstring() -> None:
     # str() uses the default locale
     assert str(i2.name) == "European Central Bank"
 
-    # Creating with name=None raises an exception…
-    with raises(pydantic.ValidationError, match="none is not an allowed value"):
-        Item(id="ECB", name=None)
-
-    # …giving empty dict is equivalent to giving nothing
+    # Giving empty dict is equivalent to giving nothing
     i3: Item = Item(id="ECB", name={})
     assert i3.name.localizations == Item(id="ECB").name.localizations
 

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -359,7 +359,7 @@ class TestIdentifiableArtefact:
             sorted([DataStructureDefinition(id="c")] + items)
 
 
-def test_nameable(caplog):
+def test_nameable(caplog) -> None:
     na1 = model.NameableArtefact(
         name=dict(en="Name"), description=dict(en="Description")
     )
@@ -397,9 +397,9 @@ def test_maintainable():
         model.MaintainableArtefact(maintainer=model.Agency(id="FOO"), urn=urn)
 
 
-def test_internationalstring():
+def test_internationalstring() -> None:
     # Constructor; the .name attribute is an InternationalString
-    i = Item(id="ECB")
+    i: Item = Item(id="ECB")
 
     # Set and get using the attribute directly
     i.name.localizations["DE"] = "Europäische Zentralbank"
@@ -416,24 +416,24 @@ def test_internationalstring():
     )
 
     # Setting with a string directly sets the value in the default locale
-    i.name = "European Central Bank"
+    i.name = "European Central Bank"  # type: ignore [assignment]
     assert len(i.name.localizations) == 1
     assert i.name.localizations[DEFAULT_LOCALE] == "European Central Bank"
 
     # Setting with a (locale, text) tuple
-    i.name = ("FI", "Euroopan keskuspankki")
+    i.name = ("FI", "Euroopan keskuspankki")  # type: ignore [assignment]
     assert len(i.name.localizations) == 1
 
     # Setting with a dict()
-    i.name = {"IT": "Banca centrale europea"}
+    i.name = {"IT": "Banca centrale europea"}  # type: ignore [assignment]
     assert len(i.name.localizations) == 1
 
     # Using some other type is an error
     with raises(pydantic.ValidationError):
-        i.name = 123
+        i.name = 123  # type: ignore [assignment]
 
     # Same, but in the constructor
-    i2 = Item(id="ECB", name="European Central Bank")
+    i2: Item = Item(id="ECB", name="European Central Bank")
 
     # str() uses the default locale
     assert str(i2.name) == "European Central Bank"
@@ -443,11 +443,11 @@ def test_internationalstring():
         Item(id="ECB", name=None)
 
     # …giving empty dict is equivalent to giving nothing
-    i3 = Item(id="ECB", name={})
+    i3: Item = Item(id="ECB", name={})
     assert i3.name.localizations == Item(id="ECB").name.localizations
 
     # Create with iterable of 2-tuples
-    i4 = Item(
+    i4: Item = Item(
         id="ECB",
         name=[("DE", "Europäische Zentralbank"), ("FR", "Banque centrale européenne")],
     )

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -29,6 +29,14 @@ from sdmx.model import (
 )
 
 
+class TestAnnotation:
+    def test_text(self) -> None:
+        """`text` can be :class:`str`."""
+        a = model.Annotation(text="Foo")
+
+        assert a.text.localizations["en"] == "Foo"
+
+
 class TestAnnotableArtefact:
     def test_get_annotation(self):
         aa = model.AnnotableArtefact(
@@ -460,6 +468,10 @@ def test_internationalstring() -> None:
 
 
 class TestItem:
+    def test_name(self) -> None:
+        """`name` can be :class:`str`."""
+        Item(name="Foo")
+
     def test_general(self):
         # Add a tree of 10 items
         items = []
@@ -569,6 +581,13 @@ def test_itemscheme_compare(caplog):
         "Not identical: name <en: Foo> != <en: Bar>",
         "…for items with id='foo'",
     ]
+
+
+class TestCode:
+    def test_name(self) -> None:
+        c = model.Code(id="FOO", name=("en", "Foo"))
+
+        assert "Foo" == c.name.localizations["en"]
 
 
 class TestAttributeValue:
@@ -685,6 +704,13 @@ class TestDataKeySet:
     def test_len(self, dks):
         """__len__() works."""
         assert 0 == len(dks)
+
+
+class TestContact:
+    def test_init(self) -> None:
+        model.Contact(
+            name="Jane Smith", org_unit="Statistics Office", responsibility="Director"
+        )
 
 
 @pytest.mark.parametrize(

--- a/sdmx/util.py
+++ b/sdmx/util.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 __all__ = [
     "BaseModel",
     "DictLike",
+    "Field",
     "compare",
     "dictlike_field",
     "only",

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 
 [options]
 packages = find:
-zip_safe = True
+zip_safe = False
 include_package_data = True
 python_requires = >= 3.7.2
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,6 @@ install_requires =
     python-dateutil
     requests >= 2.7
     setuptools >= 41
-setup_requires =
-    setuptools >= 41
-    setuptools_scm
 
 [options.extras_require]
 cache =


### PR DESCRIPTION
[Mypy 1.1.1 was released on 2023-03-07](https://pypi.org/project/mypy/#history). Although there is no changelog or itemized list of changes in the release (cf. python/mypy#13279), it appears changes in this version cause mypy to now find errors in `sdmx` and downstream code.

In particular, this occurs when code sets InternationalString attributes with values that are not precisely InternationalString—for example, `str`:
```
from sdmx.model import Code

c = Code(id="FOO", name="Foo")
```

This PR adjusts.

I explored more elaborate solutions per e.g. https://stackoverflow.com/a/75242020/2362198, but the current approach appeared simplest.