### PR TITLE
Fix SDMX 3.0 deprecation warnings

### DIFF
--- a/sdmx/model/__init__.py
+++ b/sdmx/model/__init__.py
@@ -61,6 +61,6 @@ def __getattr__(name):
                 ]
             ),
             category=DeprecationWarning,
-            stacklevel=-2,
+            stacklevel=2,
         )
         return result


### PR DESCRIPTION
#120 incorrectly used `warn(…, stacklevel=-2)`, not `stacklevel=2`. This fix causes the warnings to display at the correct location in the calling code.