### PR TITLE
Handle multiple versions of StructureMessage objects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+**Required:** write a single sentence that describes the changes made by this PR.
+
+### PR checklist
+- [ ] Checks all ✅
+- [ ] Update documentation
+- [ ] Update doc/whatsnew.rst

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.7"  # Earliest supported version; actually 3.7.2
+        - "3.8"  # Earliest supported version
         - "3.9"
         - "3.10"
         - "3.11"  # Latest supported version

--- a/doc/api/reader.rst
+++ b/doc/api/reader.rst
@@ -10,6 +10,17 @@ SDMX-ML
 
 .. automodule:: sdmx.reader.xml
 
+Implementation details:
+
+- The collections of :class:`.StructureMessage` (e.g. :attr:`.StructureMessage.codelist`) are implemented by :mod:`sdmx` as :class:`.DictLike`, with :class:`str` keys, for convenience; the standard would imply these could be other collections, such as a simple :class:`list`.
+  The format of the keys in each collection depends on the content of the message parsed by :mod:`.reader.xml`:
+
+  - Simply ``{object.id}`` (:attr:`.IdentifiableArtefact.id`) of the contained objects, if these are unique;
+  - Otherwise ``{maintainer.id}:{object.id}`` (using the :class:`.Agency` id) if these are unique;
+  - Otherwise ``{maintainer.id}:{object.id}({object.version})`` (using the :attr:`.VersionableArtefact.version`).
+
+  This ensures that all objects in a parsed message are accessible.
+
 .. autoclass:: sdmx.reader.xml.Reader
     :members:
     :undoc-members:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -13,6 +13,7 @@ Next release
 
 - Bugfix: correctly handle ``&detail=referencepartial`` REST query parameter and :class:`.StructureMessage` containing ≥2 :class:`.MaintainableArtefact` with the same maintainer and ID, but different versions (:issue:`116`, :pull:`124`).
   See the documentation for :mod:`.reader.xml`.
+- :mod:`sdmx` is fully compatible with pandas 2.0.0, released 2023-04-03 (:pull:`124`).
 
 v2.8.0 (2023-03-31)
 ===================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,6 +14,7 @@ Next release
 - Bugfix: correctly handle ``&detail=referencepartial`` REST query parameter and :class:`.StructureMessage` containing ≥2 :class:`.MaintainableArtefact` with the same maintainer and ID, but different versions (:issue:`116`, :pull:`124`).
   See the documentation for :mod:`.reader.xml`.
 - :mod:`sdmx` is fully compatible with pandas 2.0.0, released 2023-04-03 (:pull:`124`).
+  The minimum version of Python is increased from 3.7 (EOL 2023-06-27) to 3.8.
 
 v2.8.0 (2023-03-31)
 ===================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,8 +8,11 @@ What's new?
    :backlinks: none
    :depth: 1
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bugfix: correctly handle ``&detail=referencepartial`` REST query parameter and :class:`.StructureMessage` containing ≥2 :class:`.MaintainableArtefact` with the same maintainer and ID, but different versions (:issue:`116`, :pull:`124`).
+  See the documentation for :mod:`.reader.xml`.
 
 v2.8.0 (2023-03-31)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.7.2"
+requires-python = ">=3.8"
 dependencies = [
   "lxml >= 3.6",
   "pandas >= 1.0",

--- a/sdmx/__init__.py
+++ b/sdmx/__init__.py
@@ -1,6 +1,5 @@
 import logging
-
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 from sdmx.client import Client, Request, read_url
 from sdmx.reader import read_sdmx
@@ -23,8 +22,8 @@ __all__ = [
 
 
 try:
-    __version__ = pkg_resources.get_distribution("sdmx1").version
-except Exception:  # pragma: no cover
+    __version__ = version("sdmx1")
+except PackageNotFoundError:  # pragma: no cover
     # Local copy or not installed with setuptools
     __version__ = "999"
 

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -28,6 +28,9 @@ class _MissingID(str):
     def __str__(self):
         return "(missing id)"
 
+    def __hash__(self):
+        return hash(None)
+
     def __eq__(self, other):
         return isinstance(other, self.__class__)
 

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -772,7 +772,7 @@ def _structures(reader, elem):
 
         # Store using maintainer, ID, and version
         tmp = {
-            (obj.maintainer.id, obj.id, obj.version): obj
+            (getattr(obj.maintainer, "id", None), obj.id, obj.version): obj
             for obj in reader.pop_all(name, subclass=True)
         }
 

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -906,7 +906,7 @@ def _item(reader, elem):
 def _itemscheme(reader, elem):
     cls = class_for_tag(elem.tag)
 
-    is_ = reader.maintainable(cls, elem)
+    is_ = reader.maintainable(cls, elem, is_partial=elem.attrib.get("isPartial"))
 
     # Iterate over all Item objects *and* their children
     iter_all = chain(*[iter(item) for item in reader.pop_all(cls._Item)])

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -1,4 +1,4 @@
-"""SDMXML v2.1 reader."""
+"""SDMX-ML v2.1 reader."""
 # Contents of this file are organized in the order:
 #
 # - Utility methods and global variables.

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -445,7 +445,9 @@ class Reader(BaseReader):
             return ref
 
         # Try to get the target directly
-        target = self.get_single(ref.target_cls, ref.target_id, subclass=True)
+        target = self.get_single(
+            ref.target_cls, ref.target_id, ref.version, subclass=True
+        )
 
         if target:
             return target

--- a/sdmx/reader/xml.py
+++ b/sdmx/reader/xml.py
@@ -367,6 +367,7 @@ class Reader(BaseReader):
         self,
         cls_or_name: Union[Type, str],
         id: Optional[str] = None,
+        version: Optional[str] = None,
         subclass: bool = False,
     ) -> Optional[Any]:
         """Return a reference to an object while leaving it in its stack.
@@ -374,7 +375,8 @@ class Reader(BaseReader):
         Always returns 1 object. Returns :obj:`None` if no matching object exists, or if
         2 or more objects meet the conditions.
 
-        If `id` is given, only return an IdentifiableArtefact with the matching ID.
+        If `id` (and `version`) is/are given, only return an IdentifiableArtefact with
+        the matching ID (and version).
 
         If `cls_or_name` is a class and `subclass` is :obj:`True`; check all objects in
         the stack `cls_or_name` *or any stack for a subclass of this class*.
@@ -387,7 +389,12 @@ class Reader(BaseReader):
         else:
             results = self.stack.get(cls_or_name, dict())
 
-        if id:
+        if id and version:
+            for v in results.values():
+                if v.id == id and v.version == version:
+                    return v
+            return None
+        elif id:
             return results.get(id)
         elif len(results) != 1:
             # 0 or ≥2 results

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -1,10 +1,10 @@
+import importlib.resources
 import json
 from enum import Enum
 from importlib import import_module
 from io import IOBase, TextIOWrapper
 from typing import Any, Dict, Optional, Tuple, Union
 
-from pkg_resources import resource_stream
 from requests import Response
 
 from sdmx.model.v21 import DataStructureDefinition
@@ -221,7 +221,8 @@ def list_sources():
 
 def load_package_sources():
     """Discover all sources listed in :file:`sources.json`."""
-    with resource_stream("sdmx", "sources.json") as f:
+    ref = importlib.resources.files("sdmx").joinpath("sources.json")
+    with ref.open("rb") as f:
         # TextIOWrapper is for Python 3.5 compatibility
         for info in json.load(TextIOWrapper(f)):
             add_source(info)

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -2,7 +2,7 @@ import importlib.resources
 import json
 from enum import Enum
 from importlib import import_module
-from io import IOBase, TextIOWrapper
+from io import IOBase
 from typing import Any, Dict, Optional, Tuple, Union
 
 from requests import Response
@@ -221,10 +221,16 @@ def list_sources():
 
 def load_package_sources():
     """Discover all sources listed in :file:`sources.json`."""
-    ref = importlib.resources.files("sdmx").joinpath("sources.json")
+    try:
+        ref = importlib.resources.files("sdmx").joinpath("sources.json")
+    except AttributeError:  # Python <3.9
+        from copy import copy
+
+        with importlib.resources.path("sdmx", "sources.json") as path:
+            ref = copy(path)
+
     with ref.open("rb") as f:
-        # TextIOWrapper is for Python 3.5 compatibility
-        for info in json.load(TextIOWrapper(f)):
+        for info in json.load(f):
             add_source(info)
 
 

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -258,6 +258,7 @@ class SpecimenCollection:
             for parts in [
                 ("ECB", "orgscheme.xml"),
                 ("ESTAT", "apro_mk_cola-structure.xml"),
+                ("ESTAT", "GOV_10Q_GGNFA.xml"),
                 ("IMF", "1PI-structure.xml"),
                 # Manually reduced subset of the response for this DSD. Test for
                 # <str:CubeRegion> containing both <com:KeyValue> and <com:Attribute>

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -101,6 +101,34 @@ def test_gh_104(caplog, specimen):
     )
 
 
+def test_gh_116(specimen):
+    """Test of https://github.com/khaeru/sdmx/issues/116.
+
+    See also
+    --------
+    .test_sources.TestESTAT.test_gh_116
+    """
+    with specimen("ESTAT/GOV_10Q_GGNFA.xml") as f:
+        msg = sdmx.read_sdmx(f)
+
+    # Both versions of the GEO codelist are accessible in the message
+    cl1 = msg.codelist["ESTAT:GEO(13.0)"]
+    cl2 = msg.codelist["ESTAT:GEO(13.1)"]
+
+    # cl1 is complete and items are available
+    assert not cl1.is_partial and 0 < len(cl1)
+    # cl2 is partial, and fewer codes are included than in cl1
+    assert cl2.is_partial and 0 < len(cl2) < len(cl1)
+
+    cl3 = msg.codelist["ESTAT:UNIT(15.1)"]
+    cl4 = msg.codelist["ESTAT:UNIT(15.2)"]
+
+    # cl3 is complete and items are available
+    assert not cl3.is_partial and 0 < len(cl3)
+    # cl4 is partial, and fewer codes are included than in cl1
+    assert cl4.is_partial and 0 < len(cl4) < len(cl3)
+
+
 # Each entry is a tuple with 2 elements:
 # 1. an instance of lxml.etree.Element to be parsed.
 # 2. Either:

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -207,6 +207,29 @@ class TestESTAT(DataSourceTest):
         )
         client.data(**args)
 
+    @pytest.mark.network
+    def test_gh_116(self, caplog, cache_path, client):
+        """Test of https://github.com/khaeru/sdmx/issues/116."""
+        msg = client.get(
+            "dataflow", "GOV_10Q_GGNFA", params=dict(detail="referencepartial")
+        )
+        # Both versions of the GEO codelist are accessible in the message
+        cl1 = msg.codelist["ESTAT:GEO(13.0)"]
+        cl2 = msg.codelist["ESTAT:GEO(13.1)"]
+
+        # cl1 is complete and items are available
+        assert not cl1.is_partial and 0 < len(cl1)
+        # cl2 is partial, and fewer codes are included than in cl1
+        assert cl2.is_partial and 0 < len(cl2) < len(cl1)
+
+        cl3 = msg.codelist["ESTAT:UNIT(15.1)"]
+        cl4 = msg.codelist["ESTAT:UNIT(15.2)"]
+
+        # cl3 is complete and items are available
+        assert not cl3.is_partial and 0 < len(cl3)
+        # cl4 is partial, and fewer codes are included than in cl1
+        assert cl4.is_partial and 0 < len(cl4) < len(cl3)
+
 
 class TestILO(DataSourceTest):
     source_id = "ILO"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -209,10 +209,16 @@ class TestESTAT(DataSourceTest):
 
     @pytest.mark.network
     def test_gh_116(self, caplog, cache_path, client):
-        """Test of https://github.com/khaeru/sdmx/issues/116."""
+        """Test of https://github.com/khaeru/sdmx/issues/116.
+
+        See also
+        --------
+        .test_reader_xml.test_gh_116
+        """
         msg = client.get(
             "dataflow", "GOV_10Q_GGNFA", params=dict(detail="referencepartial")
         )
+
         # Both versions of the GEO codelist are accessible in the message
         cl1 = msg.codelist["ESTAT:GEO(13.0)"]
         cl2 = msg.codelist["ESTAT:GEO(13.1)"]

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -436,7 +436,7 @@ def _maybe_convert_datetime(df, arg, obj, dsd=None):
     # Unstack all but the time dimension and convert
     other_dims = list(filter(lambda d: d != param["dim"], df.index.names))
     df = df.unstack(other_dims)
-    df.index = pd.to_datetime(df.index)
+    df.index = pd.to_datetime(df.index, format="mixed")
 
     if param["freq"]:
         # Determine frequency string, Dimension, or Attribute


### PR DESCRIPTION
Closes #116.

Housekeeping:
- Support pandas 2.0.0.
- Remove usage of deprecated `pkg_resources`; use `importlib.{metadata,resources}`.
- Drop support for Python 3.7.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst