### PR TITLE
Use PyPI trusted publishers integration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   publish:
-    uses: iiasa/actions/.github/workflows/publish.yaml@main
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+    uses: iiasa/actions/.github/workflows/publish.yaml@pypi-trusted
+    permissions:
+      id-token: write


### PR DESCRIPTION
Steps:
1. Make the changes seen in the one commit.
2. Confirm the [publish.yaml](https://github.com/khaeru/sdmx/actions/workflows/publish.yaml) workflow passes. This means that the correct branch of iiasa/actions is being used, so that the formerly-required "secrets.PYPI_TOKEN" and "secrets.TESTPYPI_TOKEN" are no longer required.
3. Create a tag: `git tag v2.9.1dev0 && git push --tags`.
4. Confirm the workflow again passes. This results in new files on test.pypi.org, but does not push anything to the production instance, pypi.org.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- ~Update doc/whatsnew.rst~
