### PR TITLE
Update sources

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,8 +33,13 @@ extensions = [
 html_theme = "sphinx_book_theme"
 
 html_theme_options = dict(
+    path_to_docs="doc",
     repository_url="https://github.com/khaeru/sdmx",
+    show_navbar_depth=2,
+    use_edit_page_button=True,
+    use_issues_button=True,
     use_repository_button=True,
+    use_source_button=True,
 )
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "sdmx"
-copyright = "2014–2022 sdmx1 developers"
+copyright = "2014–2023 sdmx1 developers"
 
 
 # -- General configuration ------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,20 +1,17 @@
 # Configuration file for the Sphinx documentation builder.
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
+# For a full list of options, see
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Project information -----------------------------------------------------
+# -- Project information ---------------------------------------------------------------
 
 project = "sdmx"
 copyright = "2014–2023 sdmx1 developers"
 
 
-# -- General configuration ------------------------------------------------
+# -- General configuration -------------------------------------------------------------
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
+# Sphinx extension module names
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -27,7 +24,7 @@ extensions = [
     "IPython.sphinxext.ipython_directive",
 ]
 
-# -- Options for HTML output ----------------------------------------------
+# -- Options for HTML output -----------------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.
 html_theme = "sphinx_book_theme"
@@ -43,7 +40,7 @@ html_theme_options = dict(
 )
 
 
-# -- Options for sphinx.ext.extlinks -----------------------------------------
+# -- Options for sphinx.ext.extlinks ---------------------------------------------------
 
 extlinks = {
     "issue": ("https://github.com/khaeru/sdmx/issues/%s", "#%s"),
@@ -52,7 +49,7 @@ extlinks = {
 }
 
 
-# -- Options for sphinx.ext.intersphinx --------------------------------------
+# -- Options for sphinx.ext.intersphinx ------------------------------------------------
 
 intersphinx_mapping = {
     "np": ("https://numpy.org/doc/stable/", None),
@@ -72,14 +69,13 @@ def linkcode_resolve(domain, info):
     return f"https://github.com/khaeru/sdmx/tree/main/{filename}.py"
 
 
-# -- Options for sphinx.ext.todo ---------------------------------------------
+# -- Options for sphinx.ext.todo -------------------------------------------------------
 
-# If True, todo and todolist produce output, else they produce nothing.
+# If True, todo and todolist produce output, else they produce nothing
 todo_include_todos = True
 
 
-# -- Options for IPython.sphinxext.ipython_directive -------------------------
+# -- Options for IPython.sphinxext.ipython_directive -----------------------------------
 
-# Specify if the embedded Sphinx shell should import Matplotlib and set the
-# backend.
+# Specify if the embedded Sphinx shell should import Matplotlib and set the backend
 ipython_mplbackend = ""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,9 +20,9 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.viewcode",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
 ]
@@ -61,6 +61,15 @@ intersphinx_mapping = {
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
     "requests-cache": ("https://requests-cache.readthedocs.io/en/latest/", None),
 }
+
+# -- Options for sphinx.ext.linkcode ---------------------------------------------------
+
+
+def linkcode_resolve(domain, info):
+    if domain != "py" or not info["module"]:
+        return None
+    filename = info["module"].replace(".", "/")
+    return f"https://github.com/khaeru/sdmx/tree/main/{filename}.py"
 
 
 # -- Options for sphinx.ext.todo ---------------------------------------------

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -341,12 +341,18 @@ SDMX-ML —
 -----------------------------------------
 
 SDMX-JSON —
-`Website <http://andmebaas.stat.ee>`__ (et) —
+`Website <https://andmebaas.stat.ee>`__ (et) —
 API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf>`__, `(et) <https://www.stat.ee/sites/default/files/2020-09/API-juhend.pdf>`__
 
 - Estonian name: Eesti Statistika.
-- As of 2020-12-13, this web service (like NBB) uses server software that serves SDMX-ML 2.0 or SDMX-JSON.
-  Since :mod:`sdmx` does not support SDMX-ML 2.0, the package is configured to use the JSON endpoint.
+- As of 2023-05-19, the site displays a message:
+
+    From March 2023 onwards, data in this database are no longer updated!
+    Official statistics can be found in the database at `andmed.stat.ee <https://andmed.stat.ee>`__.
+
+  The latter URL indicates an API is provided, but it is not an SDMX API, and thus not supported.
+- As of 2020-12-13, this web service (like NBB) uses server software that serves SDMX-JSON or SDMX-ML 2.0.
+  The latter is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
 
 
 .. _UNESCO:

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -161,19 +161,53 @@ SDMX-ML —
 
 .. _ESTAT:
 
-``ESTAT``: Eurostat
--------------------
+``ESTAT``: Eurostat and related
+-------------------------------
 
 SDMX-ML —
 Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=40708145>`__,
 `2 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555>`__
 
+- Eurostat also maintains four additional SDMX REST API endpoints, available in :mod:`sdmx` with the IDs below.
+  These are described at URL (2) above.
+
+.. contents::
+    :local:
 
 - In some cases, the service can have a long response time, so :mod:`sdmx` will time out.
   Increase the timeout attribute if necessary.
 
 .. autoclass:: sdmx.source.estat.Source()
    :members:
+
+.. _ESTAT_COMEXT:
+
+``ESTAT_COMEXT``: Eurostat Comext and Prodcom databases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The :class:`.Agency` ID for data is still ``ESTAT``.
+
+.. _COMP:
+.. _EMPL:
+.. _GROW:
+
+``COMP``, ``EMPL``, ``GROW``: Directorates General of the European Commission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are, respectively:
+
+- ``COMP``: Directorate General for Competition.
+- ``EMPL``: Directorate General for Employment, Social Affairs and inclusion.
+- ``GROW``: Directorate General for Internal Market, Industry, Entrepreneurship and SMEs.
+
+No separate online documentation appears to exist for these API endpoints.
+In order to identify available data flows:
+
+.. code-block:: python
+
+   COMP = sdmx.Client("COMP")
+   sm = COMP.dataflow()
+   print(sm.dataflow)
 
 
 .. _ILO:

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -120,7 +120,8 @@ SDMX-JSON —
 ----------------------------
 
 SDMX-ML —
-Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900>`__, `(de) <https://www.bundesbank.de/de/statistiken/zeitreihen-datenbanken/hilfe-zu-sdmx-webservice>`__
+Website `(en) <https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900>`__,
+`(de) <https://www.bundesbank.de/de/statistiken/zeitreihen-datenbanken/hilfe-zu-sdmx-webservice>`__
 
 .. versionadded:: 2.5.0
 
@@ -376,7 +377,8 @@ SDMX-ML —
 
 SDMX-JSON —
 `Website <https://andmebaas.stat.ee>`__ (et) —
-API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf>`__, `(et) <https://www.stat.ee/sites/default/files/2020-09/API-juhend.pdf>`__
+API documentation `(en) <https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf>`__,
+`(et) <https://www.stat.ee/sites/default/files/2020-09/API-juhend.pdf>`__
 
 - Estonian name: Eesti Statistika.
 - As of 2023-05-19, the site displays a message:

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -152,7 +152,7 @@ SDMX-ML —
 ------------------------------
 
 SDMX-ML —
-`Website <http://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__
+`Website <https://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__
 
 - Supports categorisations of data-flows.
 - Supports preview_data and series-key based key validation.
@@ -165,7 +165,9 @@ SDMX-ML —
 -------------------
 
 SDMX-ML —
-Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555>`__, `2 <https://ec.europa.eu/eurostat/web/sdmx-web-services/rest-sdmx-2.1>`__
+Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=40708145>`__,
+`2 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555>`__
+
 
 - In some cases, the service can have a long response time, so :mod:`sdmx` will time out.
   Increase the timeout attribute if necessary.
@@ -228,7 +230,8 @@ SDMX-ML —
 -------------------------------------------------------------------------
 
 SDMX-ML —
-`Website <http://www.bdm.insee.fr/bdm2/statique?page=sdmx>`__
+Website `(en) <https://www.insee.fr/en/information/2868055>`__,
+`(fr) <https://www.insee.fr/fr/information/2862759>`__
 
 - French name: Institut national de la statistique et des études économiques.
 
@@ -242,7 +245,8 @@ SDMX-ML —
 ---------------------------------------------------
 
 SDMX-ML —
-Website `(en) <https://www.istat.it/en/methods-and-tools/sdmx-web-service>`__, `(it) <https://www.istat.it/it/metodi-e-strumenti/web-service-sdmx>`__
+Website `(en) <https://www.istat.it/en/methods-and-tools/sdmx-web-service>`__,
+`(it) <https://www.istat.it/it/metodi-e-strumenti/web-service-sdmx>`__
 
 - Italian name: Istituto Nazionale di Statistica.
 - Similar server platform to Eurostat, with similar capabilities.
@@ -302,7 +306,9 @@ API documentation `(en) <https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_sta
 ---------------------------------------------------------------
 
 SDMX-JSON —
-`Website <http://stats.oecd.org/SDMX-JSON/>`__
+`Website <https://data.oecd.org/api/sdmx-json-documentation/>`__
+
+The OECD website `describes an SDMX-ML API <https://data.oecd.org/api/sdmx-ml-documentation/>`__, but this is an implementation of SDMX 2.0, which is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
 
 
 .. _SGR:
@@ -311,7 +317,7 @@ SDMX-JSON —
 -----------------------------
 
 SDMX-ML —
-`Website <https://registry.sdmx.org/ws/rest>`__
+`Website <https://registry.sdmx.org/overview.html>`__
 
 .. autoclass:: sdmx.source.sgr.Source()
    :members:
@@ -427,7 +433,7 @@ SDMX-ML —
 ----------------------------------------------------------
 
 SDMX-ML —
-`Website <wits.worldbank.org>`__
+`Website <https://wits.worldbank.org>`__
 
 
 .. _WB_WDI:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -33,6 +33,8 @@ Next release
 
 - :mod:`.reader.json` properly parses :attr:`.Header.prepared` as a :class:`~datetime.datetime` object from SDMX-JSON data messages (:pull:`128`).
 - :mod:`.writer.xml` no longer writes objects in a SDMX-ML :class:`.StructureMessage` if :attr:`.MaintainableArtefact.is_external_reference` is :data:`True` (:pull:`128`).
+- Add four new :ref:`ESTAT <ESTAT>`-related data sources: :ref:`ESTAT_COMEXT` and :ref:`COMP` (:pull:`130`).
+- Update broken links and other information for some :doc:`sources` (:pull:`130`).
 - Update :ref:`ABS` to support the ABS' recently-added “beta” SDMX-ML API (:pull:`129`).
 - Rename the corresponding SDMX-JSON source :ref:`ABS_JSON`, update web service URL and quirks handling (:class:`.abs_json.Source`) (:pull:`129`, :pull:`130`).
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,7 +34,7 @@ Next release
 - :mod:`.reader.json` properly parses :attr:`.Header.prepared` as a :class:`~datetime.datetime` object from SDMX-JSON data messages (:pull:`128`).
 - :mod:`.writer.xml` no longer writes objects in a SDMX-ML :class:`.StructureMessage` if :attr:`.MaintainableArtefact.is_external_reference` is :data:`True` (:pull:`128`).
 - Update :ref:`ABS` to support the ABS' recently-added “beta” SDMX-ML API (:pull:`129`).
-- Rename the corresponding SDMX-JSON source :ref:`ABS_JSON`, update web service URL and quirks handling (:class:`.abs_json.Source`) (:pull:`129`).
+- Rename the corresponding SDMX-JSON source :ref:`ABS_JSON`, update web service URL and quirks handling (:class:`.abs_json.Source`) (:pull:`129`, :pull:`130`).
 
 v2.9.0 (2023-04-30)
 ===================

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -757,7 +757,10 @@ class Organisation(Item["Organisation"]):
 
 
 class Agency(Organisation):
-    pass
+    """SDMX-IM Organization.
+
+    This class is identical to its parent class.
+    """
 
 
 # DataProvider delayed until after ConstrainableArtefact, below

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -51,13 +51,13 @@ class Source:
        modify_request_args
     """
 
-    #: ID of the data source
+    #: ID of the data source.
     id: str
 
-    #: Base URL for queries
+    #: Base URL for queries.
     url: str
 
-    #: Human-readable name of the data source
+    #: Human-readable name of the data source.
     name: str
 
     #: Documentation URL.

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -41,9 +41,11 @@ SDMX_ML_SUPPORTS = {
 class Source:
     """SDMX-IM RESTDatasource.
 
-    This class describes the location and features supported by an SDMX data source.
-    Subclasses may override the hooks in order to handle specific features of different
-    REST web services:
+    This class describes the location and features supported by an SDMX REST API data
+    source/web service.
+
+    It also provides three hooks, with default implementations. Subclasses may override
+    the hooks in order to handle specific features of different REST web services:
 
     .. autosummary::
        handle_response
@@ -51,34 +53,30 @@ class Source:
        modify_request_args
     """
 
-    #: ID of the data source.
+    #: :attr:`~.IdentifiableArtefact.id` of the :attr:`DataProvider`.
     id: str
 
-    #: Base URL for queries.
+    #: Base URL (API endpoint) for queries.
     url: str
 
     #: Human-readable name of the data source.
     name: str
 
-    #: Documentation URL.
-    documentation: Optional[str] = None
-
-    # TODO handle this
-    resources: Dict[str, Any] = field(default_factory=dict)
-
+    #: Additional HTTP headers to supply by default with all requests.
     headers: Dict[str, Any] = field(default_factory=dict)
 
     #: :class:`.DataContentType` indicating the type of data returned by the source.
     data_content_type: DataContentType = DataContentType.XML
 
     #: Mapping from :class:`.Resource` values to :class:`bool` indicating support for
-    #: SDMX-REST endpoints and features.
+    #: SDMX-REST endpoints and features. If not supplied, the defaults from
+    #: :data:`SDMX_ML_SUPPORTS` are used.
     #:
     #: Two additional keys are valid:
     #:
-    #: - ``'preview'=True`` if the source supports ``?detail=serieskeysonly``.
+    #: - ``"preview"=True`` if the source supports ``?detail=serieskeysonly``.
     #:   See :meth:`.preview_data`.
-    #: - ``'structure-specific data'=True`` if the source can return structure-
+    #: - ``"structure-specific data"=True`` if the source can return structure-
     #:   specific data messages.
     supports: Dict[Union[str, Resource], bool] = field(default_factory=dict)
 

--- a/sdmx/source/abs_json.py
+++ b/sdmx/source/abs_json.py
@@ -1,8 +1,5 @@
-from . import Source as BaseSource
 from .abs import Source as ABS
 
 
-class Source(BaseSource):
+class Source(ABS):
     _id = "ABS_JSON"
-
-    handle_response = ABS.handle_response

--- a/sdmx/source/estat_comext.py
+++ b/sdmx/source/estat_comext.py
@@ -1,0 +1,19 @@
+from .estat import Source as ESTAT
+
+
+class Source(ESTAT):
+    _id = "ESTAT_COMEXT"
+
+    def modify_request_args(self, kwargs):
+        """Supply explicit provider agency ID for ESTAT_COMEXT.
+
+        This hook sets the provider to "ESTAT" for structure queries if it is not given
+        explicitly.
+        """
+        super().modify_request_args(kwargs)
+
+        # NB this is an indirect test for resource_type != 'data'; because of
+        #    the way the hook is called, resource_type is not available
+        #    directly.
+        if "key" not in kwargs:
+            kwargs.setdefault("provider", "ESTAT")

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -29,7 +29,6 @@
   {
     "id": "BBK",
     "url": "https://api.statistiken.bundesbank.de/rest",
-    "documentation": "https://www.bundesbank.de/en/statistics/time-series-databases/-/help-for-sdmx-web-service-855900",
     "name": "German Federal Bank",
     "supports": {
       "actualconstraint": false,
@@ -54,7 +53,6 @@
     "id": "BIS",
     "name": "Bank for International Settlements",
     "url": "https://stats.bis.org/api/v1",
-    "documentation": "https://www.bis.org/statistics/sdmx_techspec.htm",
     "supports": {
       "agencyscheme": false,
       "allowedconstraint": false,
@@ -75,11 +73,6 @@
   },
   {
     "id": "ECB",
-    "resources": {
-      "data": {
-        "headers": {}
-      }
-    },
     "url": "https://sdw-wsrest.ecb.europa.eu/service",
     "name": "European Central Bank",
     "supports": {
@@ -101,7 +94,6 @@
   },
   {
     "id": "ESTAT",
-    "documentation": "https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555",
     "url": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1",
     "name": "Eurostat",
     "supports": {
@@ -135,7 +127,9 @@
     "name": "International Labor Organization",
     "url": "http://www.ilo.org/sdmx/rest",
     "headers": {
-      "accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"
+      "data": {
+        "Accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"
+      }
     },
     "supports": {
       "actualconstraint": false,
@@ -216,7 +210,6 @@
   },
   {
     "id": "LSD",
-    "documentation": "https://osp.stat.gov.lt/rdb-rest",
     "url": "https://osp-rs.stat.gov.lt/rest_xml",
     "name": "Statistics Lithuania",
     "supports": {
@@ -259,14 +252,13 @@
     },
     "headers": {
       "data": {
-        "accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
+        "Accept": "application/vnd.sdmx.genericdata+xml;version=2.1"
       }
     }
   },
   {
     "id": "NBB",
     "data_content_type": "JSON",
-    "documentation": "https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_stat-technical-manual.pdf",
     "url": "https://stat.nbb.be/sdmx-json",
     "name": "National Bank of Belgium"
   },
@@ -290,7 +282,6 @@
     "id": "SPC",
     "name": "Pacific Data Hub DotStat by The Pacific Community (SPC)",
     "url": "https://stats-nsi-stable.pacificdata.org/rest",
-    "documentation": "https://docs.pacificdata.org/dotstat",
     "supports": {
       "dataconsumerscheme": false,
       "dataproviderscheme": false,
@@ -303,7 +294,6 @@
   {
     "id": "STAT_EE",
     "data_content_type": "JSON",
-    "documentation": "https://www.stat.ee/sites/default/files/2020-09/API-instructions.pdf",
     "url": "http://andmebaas.stat.ee/sdmx-json",
     "name": "Statistics Estonia"
   },
@@ -311,9 +301,6 @@
     "id": "UNESCO",
     "name": "UN Educational, Scientific and Cultural Organization",
     "url": "http://api.uis.unesco.org/sdmx",
-    "headers": {
-      "accept": "application/vnd.sdmx.structure+xml;version=2.1"
-    },
     "supports": {
       "actualconstraint": false,
       "agencyscheme": false,

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -69,6 +69,11 @@
     }
   },
   {
+    "id": "COMP",
+    "name": "European Commission Directorate General for Competition",
+    "url": "https://webgate.ec.europa.eu/comp/redisstat/api/dissemination/sdmx/2.1"
+  },
+  {
     "id": "ECB",
     "resources": {
       "data": {
@@ -90,6 +95,11 @@
     }
   },
   {
+    "id": "EMPL",
+    "name": "European Commission Directorate General for Employment, Social Affairs, and Inclusion",
+    "url": "https://webgate.ec.europa.eu/empl/redisstat/api/dissemination/sdmx/2.1"
+  },
+  {
     "id": "ESTAT",
     "documentation": "https://wikis.ec.europa.eu/pages/viewpage.action?pageId=44165555",
     "url": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1",
@@ -109,6 +119,16 @@
       "structure": false,
       "structureset": false
     }
+  },
+  {
+    "id": "ESTAT_COMEXT",
+    "name": "Eurostat (Comext and Prodcom datasets)",
+    "url": "https://ec.europa.eu/eurostat/api/comext/dissemination/sdmx/2.1"
+  },
+  {
+    "id": "GROW",
+    "name": "European Commission Directorate General for Internal Market, Industry, Entrepreneurship and SMEs",
+    "url": "https://webgate.ec.europa.eu/grow/redisstat/api/dissemination/sdmx/2.1"
   },
   {
     "id": "ILO",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -6,7 +6,7 @@ from sdmx.source import Source, add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 23
+    assert len(source_ids) == 27
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -256,6 +256,41 @@ class TestESTAT(DataSourceTest):
         assert cl4.is_partial and 0 < len(cl4) < len(cl3)
 
 
+class TestESTAT_COMEXT(DataSourceTest):
+    source_id = "ESTAT_COMEXT"
+
+    endpoint_args = {
+        "data": dict(
+            resource_id="DS-059271",
+            params=dict(startPeriod="2023"),
+        ),
+    }
+
+
+class TestCOMP(DataSourceTest):
+    source_id = "COMP"
+
+    endpoint_args = {
+        "data": dict(resource_id="AID_RAIL"),
+    }
+
+
+class TestEMPL(DataSourceTest):
+    source_id = "EMPL"
+
+    endpoint_args = {
+        "data": dict(resource_id="LMP_IND_EXP"),
+    }
+
+
+class TestGROW(DataSourceTest):
+    source_id = "GROW"
+
+    endpoint_args = {
+        "data": dict(resource_id="POST_CUBE1_X"),
+    }
+
+
 class TestILO(DataSourceTest):
     source_id = "ILO"
     xfail = {

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -77,7 +77,7 @@ class DataSourceTest:
     #     )
 
     @pytest.mark.network
-    def test_endpoint(self, cache_path, client, endpoint, args):
+    def test_endpoint(self, pytestconfig, cache_path, client, endpoint, args):
         # See sdmx.testing._generate_endpoint_tests() for values of `endpoint`
         cache = cache_path.with_suffix(f".{endpoint}.xml")
 
@@ -87,8 +87,14 @@ class DataSourceTest:
             print(e)
             raise
 
+        if pytestconfig.getoption("verbose") and endpoint == "dataflow":
+            # Display the IDs of data flows; this can be used to identify targets for
+            # tests of the data endpoint for a particular source
+            for dfd in result.dataflow:
+                print(repr(dfd))
+
         # For debugging
-        # print(cache, cache.read_text(), result, sep='\n\n')
+        # print(cache, cache.read_text(), result, sep="\n\n")
         # assert False
 
         sdmx.to_pandas(result)


### PR DESCRIPTION
- Inherit from abs.Source in abs_json.Source.
  Correct an error introduced in #129. Re-using just one method, instead of subclassing, prevented `super()` from working in the `handle_response()` hook.
- Use https://validator.w3.org/checklink to check broken links in doc/sources.rst
- Add 4 new sources operated by Eurostat: ``ESTAT_COMEXT``, ``COMP``, ``EMPL``, and ``GROW``.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation.
- [x] Update doc/whatsnew.rst.
