### PR TITLE
Update ECB source URL

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -153,12 +153,15 @@ SDMX-ML —
 ------------------------------
 
 SDMX-ML —
-`Website <https://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__
+`Website <https://data.ecb.europa.eu/help/api/overview>`__
 
 - Supports categorisations of data-flows.
 - Supports preview_data and series-key based key validation.
-- In general short response times.
 
+.. versionchanged:: 2.10.1
+   `As of 2023-06-23 <https://data.ecb.europa.eu/blog/blog-posts/ecb-data-portal-live-now>`__ the ECB source is part of an “ECB Data Portal” that replaces an earlier “ECB Statistical Data Warehouse (SDW)” (`documentation <https://www.ecb.europa.eu/stats/ecb_statistics/co-operation_and_standards/sdmx/html/index.en.html>`__ still available).
+   The URL in :mod:`sdmx` is updated.
+   Text on the ECB website (above) states that the previous URL (in :mod:`sdmx` ≤ 2.10.0) should continue to work until about 2024-06-23.
 
 .. _ESTAT:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Update the :ref:`ECB` data source URL per a recent change in the service (:pull:`134`).
 
 v2.10.0 (2023-05-20)
 ====================

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -73,7 +73,7 @@
   },
   {
     "id": "ECB",
-    "url": "https://sdw-wsrest.ecb.europa.eu/service",
+    "url": "https://data-api.ecb.europa.eu/service",
     "name": "European Central Bank",
     "supports": {
       "actualconstraint": false,

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -116,7 +116,7 @@ def test_doc_usage_structure():
     msg1 = ecb.categoryscheme(provider="all")
 
     assert msg1.response.url == (
-        "https://sdw-wsrest.ecb.europa.eu/service/categoryscheme/all/all/latest"
+        "https://data-api.ecb.europa.eu/service/categoryscheme/all/all/latest"
         "?references=parentsandsiblings"
     )
 


### PR DESCRIPTION
The ECB API documentation page at https://data.ecb.europa.eu/help/api/overview contains the text:

> Migrating SDW API queries to EDP API queries
>
> The SDW web services API will be repointed to the ECB Data Portal API as of the official go-live. User requests will be automatically redirected for at least a year from https://sdw-wrest.ecb.europa.eu/ to https://data-api.ecb.europa.eu/. API request syntax will remain unchanged, as data structures and codifications remain the same.

There's no reference to indicate _what_ the actual "official go-live [date]" is (EDIT: appears to be https://data.ecb.europa.eu/blog/blog-posts/ecb-data-portal-live-now) but one test that checks the exact URL of a response began to fail as of 2023-06-27.

This PR adjusts.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst