### PR TITLE
Update OECD with SDMX-ML support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ doc/*.xml
 prof/
 htmlcov
 ref
-service-endpoints/
+source-tests/
 
 # Editors
 .vscode/

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -359,6 +359,8 @@ SDMX-ML —
 
 .. _OECD_JSON:
 
+.. currentmodule:: sdmx.source.oecd_json
+
 ``OECD_JSON``: Organisation for Economic Cooperation and Development (SDMX-JSON)
 --------------------------------------------------------------------------------
 
@@ -370,6 +372,10 @@ SDMX-JSON —
 .. versionchanged:: 2.12.0
 
    Renamed from ``OECD``.
+
+.. autofunction:: sdmx.source.oecd_json.Client
+
+.. autoclass:: sdmx.source.oecd_json.HTTPSAdapter
 
 
 .. _SGR:

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -340,13 +340,36 @@ API documentation `(en) <https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_sta
 
 .. _OECD:
 
-``OECD``: Organisation for Economic Cooperation and Development
----------------------------------------------------------------
+.. currentmodule:: sdmx.source.oecd
+
+``OECD``: Organisation for Economic Cooperation and Development (SDMX-ML)
+-------------------------------------------------------------------------
+
+SDMX-ML —
+`Website <https://data-explorer.oecd.org/>`__,
+`documentation <https://gitlab.algobank.oecd.org/public-documentation/dotstat-migration/-/raw/main/OECD_Data_API_documentation.pdf>`__
+
+- As of 2023-08-14, the site includes a disclaimer that “This is a public beta release. Not all data is available on this platform yet, as it is being progressively migrated from https://stats.oecd.org.”
+- The OECD website `describes an older SDMX-ML API <https://data.oecd.org/api/sdmx-ml-documentation/>`__, but this is an implementation of SDMX 2.0, which is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
+
+.. autoclass:: sdmx.source.oecd.Source
+   :members:
+
+.. versionadded:: 2.12.0
+
+.. _OECD_JSON:
+
+``OECD_JSON``: Organisation for Economic Cooperation and Development (SDMX-JSON)
+--------------------------------------------------------------------------------
 
 SDMX-JSON —
 `Website <https://data.oecd.org/api/sdmx-json-documentation/>`__
 
-The OECD website `describes an SDMX-ML API <https://data.oecd.org/api/sdmx-ml-documentation/>`__, but this is an implementation of SDMX 2.0, which is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
+- Only :ref:`SDMX-JSON version 1.0 <sdmx-json>` is supported.
+
+.. versionchanged:: 2.12.0
+
+   Renamed from ``OECD``.
 
 
 .. _SGR:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,8 +7,7 @@ Next release
 ============
 
 - Update :ref:`OECD <OECD>` to support the provider's recently-added SDMX-ML API (:pull:`140`).
-  Rename the corresponding, older SDMX-JSON source :ref:`OECD_JSON <OECD_JSON>`.
-
+  Rename the corresponding, older SDMX-JSON source :ref:`OECD_JSON <OECD_JSON>`; work around a known issue with its SSL configuration (see :func:`.oecd_json.Client`).
 
 v2.11.0 (2023-08-04)
 ====================
@@ -23,7 +22,6 @@ Migration notes
   the new standards delete some classes, change the name or behaviour of others, and add entirely new classes.
   (The `“Standards” page of the SDMX website <https://sdmx.org/?page_id=5008>`_ includes a link to a document with a “Summary of Changes and New Functionalities”.)
   User code that functions against :mod:`.model.v21` **must** be updated if it uses deleted or renamed classes; it **may** need updating if it depends on behaviour that changes in SDMX 3.0.
-
 
 All changes
 -----------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,12 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Update :ref:`OECD <OECD>` to support the provider's recently-added SDMX-ML API (:pull:`140`).
+  Rename the corresponding, older SDMX-JSON source :ref:`OECD_JSON <OECD_JSON>`.
+
 
 v2.11.0 (2023-08-04)
 ====================

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -55,7 +55,7 @@ class Client:
     source = None
 
     #: :class:`.Session` for queries sent from the instance.
-    session = None
+    session: requests.Session
 
     # Stored keyword arguments "allow_redirects" and "timeout" for pre-requests.
     _send_kwargs: Dict[str, Any] = {}

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -819,8 +819,6 @@ class Representation:
 class Code(Item["Code"]):
     """SDMX Code."""
 
-    __post_init__ = Item.__post_init__
-
 
 class Codelist(ItemScheme[IT]):
     """SDMX Codelist."""

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -213,7 +213,7 @@ def add_source(
     except ImportError:
         pass
     else:
-        SourceClass = getattr(mod, "Source")
+        SourceClass = getattr(mod, "Source", None) or SourceClass
 
     sources[id] = SourceClass(**_info)
 

--- a/sdmx/source/oecd.py
+++ b/sdmx/source/oecd.py
@@ -1,0 +1,24 @@
+from . import Source as BaseSource
+
+
+class Source(BaseSource):
+    _id = "OECD"
+
+    def modify_request_args(self, kwargs):
+        """Supply explicit provider agency ID for OECD.
+
+        The structures and data flows from this provider use a variety of agency IDs—
+        for example ``OECD.SDD.TPS``—to identify a specific the organizational unit
+        within the ``OECD`` that is responsible for each object. Queries requesting
+        structures or data with agency ID ``OECD`` (strictly) may return few or zero
+        results.
+
+        This hook sets the provider to "ALL" for structure queries if it is not given
+        explicitly.
+        """
+        super().modify_request_args(kwargs)
+
+        # NB this is an indirect test for resource_type != 'data'; because of the way
+        #    the hook is called, resource_type is not available directly.
+        if "key" not in kwargs:
+            kwargs.setdefault("provider", "ALL")

--- a/sdmx/source/oecd.py
+++ b/sdmx/source/oecd.py
@@ -7,13 +7,12 @@ class Source(BaseSource):
     def modify_request_args(self, kwargs):
         """Supply explicit provider agency ID for OECD.
 
-        The structures and data flows from this provider use a variety of agency IDs—
-        for example ``OECD.SDD.TPS``—to identify a specific the organizational unit
-        within the ``OECD`` that is responsible for each object. Queries requesting
-        structures or data with agency ID ``OECD`` (strictly) may return few or zero
-        results.
+        The structures and data flows from this provider use a variety of agency IDs—for
+        example “OECD.SDD.TPS”—to identify a specific the organizational unit within the
+        OECD that is responsible for each object. Queries requesting structures or data
+        with agency ID “OECD” (strictly) may return few or zero results.
 
-        This hook sets the provider to "ALL" for structure queries if it is not given
+        This hook sets the provider to “ALL” for structure queries if it is not given
         explicitly.
         """
         super().modify_request_args(kwargs)

--- a/sdmx/source/oecd_json.py
+++ b/sdmx/source/oecd_json.py
@@ -1,0 +1,57 @@
+import ssl
+from typing import TYPE_CHECKING
+
+import requests.adapters
+
+if TYPE_CHECKING:
+    import sdmx.client
+
+
+class HTTPSAdapter(requests.adapters.HTTPAdapter):
+    """:class:`~requests.adapters.HTTPAdapter` with custom :class:`~.ssl.SSLContext`."""
+
+    def __init__(self, ssl_context=None, **kwargs):
+        # Per https://stackoverflow.com/a/71646353/: create a context with the flag
+        # OP_LEGACY_SERVER_CONNECT set
+        self.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        self.ssl_context.options |= 0x4
+
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        import urllib3.poolmanager
+
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def Client(*args, **kwargs) -> "sdmx.client.Client":
+    """Work around OECD_JSON legacy SSL issues.
+
+    As of 2023-08-16 the OECD_JSON data source uses an old, insecure version of SSL/TLS
+    that—with default SSL configuration on properly patched systems—raises a
+    :class:`~requests.exceptions.SSLError` “UNSAFE_LEGACY_RENEGOTIATION_DISABLED”.
+
+    This function creates a :class:`.Client` using the workaround described at
+    https://stackoverflow.com/a/71646353/ to allow connecting to this data source.
+
+    .. warning::
+
+       Using this workaround disables SSL configuration that is intended to mitigate
+       against man-in-the-middle attacks as described in `CVE-2009-3555
+       <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2009-3555>`__. Use with
+       caution: in particular, do not change the :attr:`.Source.url` to use with data
+       sources other than OECD_JSON.
+    """
+    import sdmx.client
+
+    # Create a client
+    client = sdmx.client.Client(*args, **kwargs)
+    # Mount the adapter on the client's Session object
+    client.session.mount("https://", HTTPSAdapter())
+
+    return client

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -264,6 +264,20 @@
   },
   {
     "id": "OECD",
+    "url": "https://sdmx.oecd.org/public/rest",
+    "name": "Organisation for Economic Co-operation and Development",
+    "supports": {
+      "dataconsumerscheme": false,
+      "dataproviderscheme": false,
+      "metadataflow": false,
+      "organisationscheme": false,
+      "provisionagreement": false,
+      "structure": false,
+      "structureset": false
+    }
+  },
+  {
+    "id": "OECD_JSON",
     "data_content_type": "JSON",
     "url": "https://stats.oecd.org/SDMX-JSON",
     "name": "Organisation for Economic Co-operation and Development"

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -126,8 +126,9 @@ class TestClient:
             client._request_from_args(kwargs)
 
         # Raises for not implemented endpoint
-        with pytest.raises(NotImplementedError, match="OECD does not implement"):
-            sdmx.Client("OECD").get("datastructure")
+        _id = "OECD_JSON"
+        with pytest.raises(NotImplementedError, match=f"{_id} does not implement"):
+            sdmx.Client(_id).get("datastructure")
 
         # Raises for invalid key type
         with pytest.raises(TypeError, match="must be str or dict; got int"):

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -6,7 +6,7 @@ from sdmx.source import Source, add_source, list_sources, sources
 
 def test_list_sources():
     source_ids = list_sources()
-    assert len(source_ids) == 27
+    assert len(source_ids) == 28
 
     # Listed alphabetically
     assert source_ids[0] == "ABS"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -13,7 +13,7 @@ import requests_mock
 
 import sdmx
 from sdmx import Client
-from sdmx.exceptions import HTTPError, SSLError, XMLParseError
+from sdmx.exceptions import HTTPError, XMLParseError
 
 # Mark the whole file so the tests can be excluded/included
 pytestmark = pytest.mark.source
@@ -490,10 +490,6 @@ class TestOECD(DataSourceTest):
 class TestOECD_JSON(DataSourceTest):
     source_id = "OECD_JSON"
 
-    xfail = {
-        "data": (SSLError, "SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED"),
-    }
-
     endpoint_args = {
         "data": dict(
             resource_id="ITF_GOODS_TRANSPORT",
@@ -503,6 +499,13 @@ class TestOECD_JSON(DataSourceTest):
             # resource_id="PART2",
         )
     }
+
+    @pytest.fixture
+    def client(self, cache_path):
+        # Same as the default implementation, only using oecd_json.Client
+        from sdmx.source.oecd_json import Client
+
+        return Client(self.source_id, cache_name=str(cache_path), backend="sqlite")
 
 
 class TestSGR(DataSourceTest):

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -479,6 +479,16 @@ class TestNBB(DataSourceTest):
 
 class TestOECD(DataSourceTest):
     source_id = "OECD"
+    endpoint_args = {
+        "data": dict(
+            resource_id="DSD_MSTI@DF_MSTI",
+            headers={"Accept-Encoding": "compress, gzip"},
+        )
+    }
+
+
+class TestOECD_JSON(DataSourceTest):
+    source_id = "OECD_JSON"
 
     xfail = {
         "data": (SSLError, "SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED"),


### PR DESCRIPTION
OECD has added a SDMX 2.1-compliant REST API providing SDMX-ML.

- Add support, tests.
- Rename the former SDMX-JSON 1.0 endpoint to `OECD_JSON`.

### PR checklist
- [x] Checks all ✅ —excepting codecov/patch, which is due to modified data source tests; these will be picked up by the next sources.yaml run on main.
- [x] Update documentation
- [x] Update doc/whatsnew.rst
