### PR TITLE
Update data source tests for Python 3.12

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,4 +77,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with: { python-version: 3.x }
+
+    - name: Force recreation of pre-commit virtual environment for mypy
+      if: github.event_name == 'schedule'  # Comment this line to run on a PR
+      run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
+      env: { GH_TOKEN: "${{ github.token }}" }
+
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,9 +25,10 @@ jobs:
         - "3.8"  # Earliest supported version
         - "3.9"
         - "3.10"
-        - "3.11"  # Latest supported version
+        - "3.11"
+        - "3.12"  # Latest supported version
         # commented: only enable once next Python version enters RC
-        # - "3.12.0-rc.1"  # Development version
+        # - "3.13.0-rc.1"  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -54,7 +54,7 @@ jobs:
       run: python -m pip install --upgrade pip wheel
 
     - name: Install the Python package and dependencies
-      run: pip install .[cache,docs,tests]
+      run: pip install .[cache,tests]
 
     - name: Run pytest
       env:
@@ -68,10 +68,6 @@ jobs:
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v3
-
-    - name: Test documentation build using Sphinx
-      if: contains(matrix.os, 'ubuntu')
-      run: make --directory=doc html
 
   pre-commit:
     name: Code quality

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.4.1
+  rev: v1.6.1
   hooks:
   - id: mypy
     additional_dependencies:
@@ -14,11 +14,9 @@ repos:
     - types-PyYAML
     - types-requests
     args: []
-- repo: https://github.com/psf/black
-  rev: 23.7.0
-  hooks:
-  - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.287
+  rev: v0.1.2
   hooks:
   - id: ruff
+  - id: ruff-format
+    args: [ --check ]

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Python 3.12 (released 2023-10-02) is fully supported (:pull:`145`).
 
 v2.12.0 (2023-10-11)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ markers = [
 
 [tool.ruff]
 select = ["C9", "E", "F", "I", "W"]
+ignore = ["E501", "W191"]
 
 [tool.ruff.mccabe]
 # Exceptions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]

--- a/sdmx/tests/__init__.py
+++ b/sdmx/tests/__init__.py
@@ -12,7 +12,7 @@ def _importorskip(
     try:
         mod = importlib.import_module(modname)
         has = True
-        if minversion is not None:
+        if minversion is not None:  # pragma: no cover
             if Version(mod.__version__) < Version(minversion):
                 raise ImportError("Minimum version not satisfied")
     except ImportError:

--- a/sdmx/tests/__init__.py
+++ b/sdmx/tests/__init__.py
@@ -1,28 +1,24 @@
 import importlib
-from distutils import version
+from typing import Optional, Tuple
 
 import pytest
+from packaging.version import Version
 
 
 # thanks to xarray
-def _importorskip(modname, minversion=None):
+def _importorskip(
+    modname: str, minversion: Optional[str] = None
+) -> Tuple[bool, pytest.MarkDecorator]:
     try:
         mod = importlib.import_module(modname)
         has = True
         if minversion is not None:
-            if LooseVersion(mod.__version__) < LooseVersion(minversion):
+            if Version(mod.__version__) < Version(minversion):
                 raise ImportError("Minimum version not satisfied")
     except ImportError:
         has = False
-    func = pytest.mark.skipif(not has, reason="requires {}".format(modname))
+    func = pytest.mark.skipif(not has, reason=f"requires {modname}")
     return has, func
-
-
-def LooseVersion(vstring):
-    # When the development version is something like '0.10.9+aac7bfc', this
-    # function will just discard the git commit id.
-    vstring = vstring.split("+")[0]
-    return version.LooseVersion(vstring)
 
 
 has_requests_cache, requires_requests_cache = _importorskip("requests_cache")

--- a/sdmx/tests/test_session.py
+++ b/sdmx/tests/test_session.py
@@ -7,8 +7,7 @@ from . import has_requests_cache
 
 @pytest.mark.skipif(has_requests_cache, reason="test without requests_cache")
 def test_session_without_requests_cache():  # pragma: no cover
-    # Passing cache= arguments when requests_cache is not installed triggers a
-    # warning
+    # Passing cache= arguments when requests_cache is not installed triggers a warning
     with pytest.warns(RuntimeWarning):
         Session(cache_name="test")
 

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -313,7 +313,8 @@ def write_dataset(
 
     # NB mypy errors here on CI, but not locally
     result: Union[pd.Series, pd.DataFrame] = pd.DataFrame.from_dict(
-        data, orient="index"  # type: ignore [arg-type]
+        data,
+        orient="index",  # type: ignore [arg-type]
     )
 
     if len(result):


### PR DESCRIPTION
Remove distutils, which is no longer available/installed by default in Python 3.12. This was causing failures of scheduled runs of the sources.yaml workflow.

Housekeeping:
- Explicitly note Python 3.12 is supported and tested.
- Update pre-commit configuration:
  - Update ruff 0.0.287 → 0.1.2.
  - Replace black with ruff-format --check.
  - Update mypy 1.4.1 → 1.6.1.
- Force a daily refresh of the cached environment for mypy via pre-commit.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
