### PR TITLE
Use supplied DSD for structure-specific messages

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,7 @@ Next release
 ============
 
 - Python 3.12 (released 2023-10-02) is fully supported (:pull:`145`).
+- Bugfix: :py:`dsd=...` argument supplied to the SDMX-ML reader ignored in v2.11.0 and later, causing a warning (:pull:`147`; thanks :gh-user:`miccoli` for :issue:`146`).
 
 v2.12.0 (2023-10-11)
 ====================

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -680,7 +680,7 @@ def _message(reader: Reader, elem):
     # With 'dsd' argument, the message should be structure-specific
     if (
         "StructureSpecific" in elem.tag
-        and reader.get_single(common.BaseDataStructureDefinition) is None
+        and reader.get_single(common.BaseDataStructureDefinition, subclass=True) is None
     ):
         log.warning(f"xml.Reader got no dsd=… argument for {QName(elem).localname}")
         ss_without_dsd = True

--- a/sdmx/tests/test_dataset_ss.py
+++ b/sdmx/tests/test_dataset_ss.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 
 import pandas as pd
@@ -26,9 +27,13 @@ class StructuredMessageTest(MessageTest):
         yield sdmx.read_sdmx(path / self.filename, dsd=dsd)
 
     # Tests for every class
-    def test_msg(self, path, dsd):
+    def test_msg(self, caplog, path, dsd):
         # The message can be parsed
-        sdmx.read_sdmx(path / self.filename, dsd=dsd)
+        with caplog.at_level(logging.WARNING):
+            sdmx.read_sdmx(path / self.filename, dsd=dsd)
+
+        # No warnings are emitted per missing dsd= argument (khaeru/sdmx#146)
+        assert [] == caplog.messages
 
     def test_structured_by(self, dsd, msg):
         # The DSD was used to parse the message


### PR DESCRIPTION
#135 updated this line:
https://github.com/khaeru/sdmx/blob/c28f50af506db86da6a35b7df13d8739362eb0df/sdmx/reader/xml/v21.py#L683
…to refer to BaseDataStructureDefinition, the base class for {v21,v30}.DataStructureDefinition.

However, `Reader.get_single()` does not match on subclasses unless `subclass=True` is given explicitly. The method would thus always return None, resulting in a warning, also perhaps other failures to use the provided DSD wherever code refers to the `ss_without_dsd` variable.

This PR corrects, closing #146.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, bugfix
- [x] Update doc/whatsnew.rst
