### PR TITLE
Add support for data availability queries

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,6 +8,7 @@ Next release
 
 - Automatically handle unsupported values of the ``?references=...`` query parameter for the :ref:`COMP` data sources (:issue:`162`, :pull:`163`).
 - Bug fix for reading SDMX-ML 2.1: some associations (particularly, :attr:`.core_representation`) not stored correctly if a message contained two :class:`.MaintainableArtefact` with the same ID but different maintainer/version (:pull:`165`, thanks :gh-user:`sychsergiy` for :issue:`164`).
+- :class:`.Resource` extended with the ``availableconstraint`` resource from the SDMX 2.1 standard (:pull:`161`).
 
 v2.13.1 (2024-01-24)
 ====================

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -140,7 +140,10 @@ class Client:
         string which becomes part of the URL. Otherwise, do nothing, as `key` must be a
         :class:`str` confirming to the REST API spec.
         """
-        if not (resource_type == Resource.data and isinstance(key, dict)):
+        if not (
+            resource_type in (Resource.data, Resource.availableconstraint)
+            and isinstance(key, dict)
+        ):
             return key, dsd
 
         # Select validation method based on agency capabilities

--- a/sdmx/rest.py
+++ b/sdmx/rest.py
@@ -43,6 +43,7 @@ class Resource(str, Enum):
     ``agencyscheme``              :class:`.AgencyScheme`
     ``allowedconstraint``         :class:`.ContentConstraint`
     ``attachementconstraint``     :class:`.AttachmentConstraint`
+    ``availableconstraint``       :class:`.ContentConstraint`
     ``categorisation``            :class:`.Categorisation`
     ``categoryscheme``            :class:`.CategoryScheme`
     ``codelist``                  :class:`.Codelist`
@@ -80,6 +81,7 @@ class Resource(str, Enum):
     agencyscheme = "agencyscheme"
     allowedconstraint = "allowedconstraint"
     attachementconstraint = "attachementconstraint"
+    availableconstraint = "availableconstraint"
     categorisation = "categorisation"
     categoryscheme = "categoryscheme"
     codelist = "codelist"
@@ -153,7 +155,7 @@ class URL:
     key: Optional[str] = None
 
     def __post_init__(self):
-        if self.resource_type == Resource.data:
+        if self.resource_type in (Resource.data, Resource.availableconstraint):
             # Requests for data do not specific an agency in the URL
             if self.provider is not None:
                 warn(f"'provider' argument is redundant for {self.resource_type!r}")
@@ -170,7 +172,7 @@ class URL:
 
         parts = [self.source.url, self.resource_type.name]
 
-        if self.resource_type == Resource.data:
+        if self.resource_type in (Resource.data, Resource.availableconstraint):
             parts.append(self.resource_id)
             if self.key:
                 parts.append(self.key)

--- a/sdmx/source/__init__.py
+++ b/sdmx/source/__init__.py
@@ -21,6 +21,7 @@ DataContentType = Enum("DataContentType", "CSV JSON XML")
 #: endpoints that are described in the standards but are not implemented by any source
 #: currently in :file:`sources.json`; these all return 404.
 SDMX_ML_SUPPORTS = {
+    Resource.availableconstraint: False,
     Resource.attachementconstraint: False,
     Resource.customtypescheme: False,
     Resource.data: True,

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -275,6 +275,7 @@ class SpecimenCollection:
                 ("IMF", "ECOFIN_DSD-structure.xml"),
                 ("IMF", "hierarchicalcodelist-0.xml"),
                 ("IMF", "structureset-0.xml"),
+                ("IMF_STA", "availableconstraint_CPI.xml"),  # khaeru/sdmx#161
                 ("IMF_STA", "DSD_GFS.xml"),  # khaeru/sdmx#164
                 ("INSEE", "CNA-2010-CONSO-SI-A17-structure.xml"),
                 ("INSEE", "dataflow.xml"),


### PR DESCRIPTION
Add support for data availability queries (availableconstraint) defined by the [SDMX 2.1 standard](https://github.com/sdmx-twg/sdmx-rest/blob/v1.5.0/v2_1/ws/rest/docs/4_6_1_other_queries.md)

