### PR TITLE
Handle quirks of ESTAT-operated sources COMP, EMPL, GROW

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  # Only update major versions
+  ignore:
+    - dependency-name: "*"
+      update-types:
+      - "version-update:semver-minor"
+      - "version-update:semver-patch"
+  # Below config mirrors the example at
+  # https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+    time: "16:00"
+  groups:
+    all-actions:
+      patterns: [ "*" ]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,10 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     uses: iiasa/actions/.github/workflows/publish.yaml@main

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -36,15 +36,15 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Checkout test data
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: khaeru/sdmx-test-data
         path: sdmx-test-data
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -75,8 +75,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with: { python-version: 3.x }
 
     - name: Force recreation of pre-commit virtual environment for mypy

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -67,7 +67,8 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env: { CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}" }
 
   pre-commit:
     name: Code quality

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - types-requests
     args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.9
+  rev: v0.1.15
   hooks:
   - id: ruff
   - id: ruff-format

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -20,7 +20,7 @@ Download the metadata and expose:
 
 .. ipython:: python
 
-    metadata = estat.datastructure("UNE_RT_A")
+    metadata = estat.datastructure("UNE_RT_A", params=dict(references="descendants"))
     metadata
 
 Explore the contents of some code lists:

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -181,8 +181,8 @@ Website `1 <https://wikis.ec.europa.eu/pages/viewpage.action?pageId=40708145>`__
 - In some cases, the service can have a long response time, so :mod:`sdmx` will time out.
   Increase the timeout attribute if necessary.
 
-.. autoclass:: sdmx.source.estat.Source()
-   :members:
+.. automodule:: sdmx.source.estat
+   :members: Source, handle_references_param
 
 .. _ESTAT_COMEXT:
 
@@ -213,6 +213,14 @@ In order to identify available data flows:
    sm = COMP.dataflow()
    print(sm.dataflow)
 
+.. automodule:: sdmx.source.comp
+   :members:
+
+.. automodule:: sdmx.source.empl
+   :members:
+
+.. automodule:: sdmx.source.grow
+   :members:
 
 .. _ILO:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Automatically handle unsupported values of the ``?references=...`` query parameter for the :ref:`COMP` data sources (:issue:`162`, :pull:`163`).
 
 v2.13.1 (2024-01-24)
 ====================

--- a/sdmx/source/comp.py
+++ b/sdmx/source/comp.py
@@ -1,0 +1,23 @@
+from sdmx.source import Source as BaseSource
+
+from .estat import handle_references_param
+
+
+class Source(BaseSource):
+    """Handle `COMP` quirks.
+
+    .. versionadded:: 2.13.2
+    """
+
+    _id = "COMP"
+
+    def modify_request_args(self, kwargs):
+        """Modify arguments used to build query URL.
+
+        See also
+        --------
+        :func:`.handle_references_param`, :issue:`162`
+        """
+        super().modify_request_args(kwargs)
+
+        handle_references_param(kwargs)

--- a/sdmx/source/empl.py
+++ b/sdmx/source/empl.py
@@ -1,0 +1,23 @@
+from sdmx.source import Source as BaseSource
+
+from .estat import handle_references_param
+
+
+class Source(BaseSource):
+    """Handle `EMPL` quirks.
+
+    .. versionadded:: 2.13.2
+    """
+
+    _id = "EMPL"
+
+    def modify_request_args(self, kwargs):
+        """Modify arguments used to build query URL.
+
+        See also
+        --------
+        :func:`.handle_references_param`, :issue:`162`
+        """
+        super().modify_request_args(kwargs)
+
+        handle_references_param(kwargs)

--- a/sdmx/source/estat.py
+++ b/sdmx/source/estat.py
@@ -1,6 +1,7 @@
 import logging
 from tempfile import NamedTemporaryFile
 from time import sleep
+from typing import Dict
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -10,6 +11,41 @@ from sdmx.rest import Resource
 from sdmx.source import Source as BaseSource
 
 log = logging.getLogger(__name__)
+
+
+def handle_references_param(kwargs: Dict) -> None:
+    """Handle the "references" query parameter for ESTAT and similar.
+
+    For this parameter, the server software behind ESTAT's data source only supports
+    (as of 2022-11-13) the values "children", "descendants", or "none". Other values—
+    including the "all" or parentsandsiblings" used as defaults by :class:`.Client`—
+    result in error messages.
+
+    This handler, used via :meth:`.Source.modify_request_args`:
+
+    - Replaces the defaults of "all" or "parentsandsiblings" set by :class:`.Client`
+      with "descendants".
+    - Replaces other, unsupported values with "none".
+    """
+    resource_type = kwargs.get("resource_type")
+    params = kwargs.setdefault("params", {})
+
+    # Preempt default values that would be set by Client._request_from_args()
+    if (
+        "references" not in params
+        and (
+            resource_type in {Resource.dataflow, Resource.datastructure}
+            and kwargs.get("resource_id")
+        )
+        or resource_type == Resource.categoryscheme
+    ):
+        params["references"] = "descendants"
+
+    # Replace unsupported values
+    references = params.get("references")
+    if references not in ("children", "descendants", "none", None):
+        log.info(f"Replace unsupported references={references!r} with 'none'")
+        params["references"] = "none"
 
 
 class Source(BaseSource):
@@ -23,10 +59,6 @@ class Source(BaseSource):
     :meth:`.Client.get`.
 
     .. versionadded:: 0.2.1
-
-    See also
-    --------
-    :meth:`modify_request_args`
     """
 
     _id = "ESTAT"
@@ -34,10 +66,6 @@ class Source(BaseSource):
     def modify_request_args(self, kwargs):
         """Modify arguments used to build query URL.
 
-        For the "references" query parameter, ESTAT (as of 2022-11-13) only supports the
-        values "children", "descendants", or "none". Other values—including the "all" or
-        "parentsandsiblings" used as defaults by :class:`.Client` cause errors. Replace
-        unsupported values with "none", and use "descendants" as default.
 
         See also
         --------
@@ -47,23 +75,7 @@ class Source(BaseSource):
 
         kwargs.pop("get_footer_url", None)
 
-        resource_type = kwargs.get("resource_type")
-
-        # Handle the ?references= query parameter
-        params = kwargs.setdefault("params", {})
-        references = params.get("references")
-        if references is None:
-            # Client._request_from_args() sets "all" or "parentsandsiblings" by default.
-            # Neither of these values is supported by ESTAT; use "descendants" instead.
-            if (
-                resource_type
-                in (Resource.categoryscheme, Resource.dataflow, Resource.datastructure)
-                and kwargs.get("resource_id")
-            ) or kwargs.get("resource"):
-                params["references"] = "descendants"
-        elif references not in ("children", "descendants", "none"):
-            log.info(f"Replace unsupported references={references!r} with 'none'")
-            params["references"] = "none"
+        handle_references_param(kwargs)
 
     def finish_message(self, message, request, get_footer_url=(30, 3), **kwargs):
         """Handle the initial response.

--- a/sdmx/source/grow.py
+++ b/sdmx/source/grow.py
@@ -1,0 +1,23 @@
+from sdmx.source import Source as BaseSource
+
+from .estat import handle_references_param
+
+
+class Source(BaseSource):
+    """Handle `GROW` quirks.
+
+    .. versionadded:: 2.13.2
+    """
+
+    _id = "GROW"
+
+    def modify_request_args(self, kwargs):
+        """Modify arguments used to build query URL.
+
+        See also
+        --------
+        :func:`.handle_references_param`, :issue:`162`
+        """
+        super().modify_request_args(kwargs)
+
+        handle_references_param(kwargs)

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -71,7 +71,9 @@ def test_doc_index1():
 
     # Same effect
     structure_response = estat.get(
-        "datastructure", flow_response.dataflow.UNE_RT_A.structure.id
+        "datastructure",
+        flow_response.dataflow.UNE_RT_A.structure.id,
+        params=dict(references="descendants"),
     )
 
     # Even better: Client.get(…) should examine the class and ID of the object

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -284,6 +284,7 @@ class TestEMPL(DataSourceTest):
 
     endpoint_args = {
         "data": dict(resource_id="LMP_IND_EXP"),
+        "dataflow": dict(resource_id="LMP_IND_EXP"),
     }
 
 
@@ -292,6 +293,7 @@ class TestGROW(DataSourceTest):
 
     endpoint_args = {
         "data": dict(resource_id="POST_CUBE1_X"),
+        "dataflow": dict(resource_id="POST_CUBE1_X"),
     }
 
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -275,6 +275,7 @@ class TestCOMP(DataSourceTest):
 
     endpoint_args = {
         "data": dict(resource_id="AID_RAIL"),
+        "dataflow": dict(resource_id="AID_SCB_OBJ"),
     }
 
 


### PR DESCRIPTION
Closes #162.

Note that this PR does **not** address this TODO:
https://github.com/khaeru/sdmx/blob/7a2de97237860eac894399fd8c4cba9e09180234/sdmx/client.py#L279-L283
…as a consequence, some of the code in .source.estat.handle_references_param() is duplicative of existing code in Client._handle_get_kwargs(). The Source class will get a more extensive rework soon, in which this duplication can probably be removed.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
