### PR TITLE
Update doc/example and associated tests

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -85,4 +85,4 @@ jobs:
       run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
       env: { GH_TOKEN: "${{ github.token }}" }
 
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: mypy
     additional_dependencies:
@@ -15,7 +15,7 @@ repos:
     - types-requests
     args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.1
+  rev: v0.3.3
   hooks:
   - id: ruff
   - id: ruff-format

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -2,58 +2,60 @@ Ten-line usage example
 ======================
 
 Suppose we want to analyze annual unemployment data for some European countries.
+
 All we need to know in advance is the data provider: Eurostat.
+:mod:`sdmx` makes it easy to inspect all **data flows** available from this provider. [1]_
+The data we want is in a data flow with the identifier ‘UNE_RT_A’.
+The description of this data flow references a **data structure definition** (**DSD**) that happens to also have the ID ‘UNE_RT_A’. [2]_
 
-:mod:`sdmx` makes it easy to search the directory of data flows, and the complete structural metadata about the datasets available through the selected dataflow.
-(This example skips these steps; see :doc:`the walkthrough <walkthrough>`.)
-
-The data we want is in a **data flow** with the identifier ‘UNE_RT_A’.
-This dataflow references a **data structure definition** (**DSD**) that also has an ID ‘UNE_RT_A’.
-The DSD, in turn, contains or references all the metadata describing data sets available through this dataflow: the concepts, things measured, dimensions, and lists of codes used to label each dimension.
+First we create a :class:`.Client` that we will use to make multiple queries to this provider's SDMX-REST web service:
 
 .. ipython:: python
 
     import sdmx
     estat = sdmx.Client("ESTAT")
 
-Download the metadata and expose:
+Next, we download a **structure message**  containing the DSD and other structural information that it references.
+These include *structural metadata* that together completely describe the data available through this dataflow: the concepts, things measured, dimensions, lists of codes used to label each dimension, attributes, and so on:
 
 .. ipython:: python
 
-    metadata = estat.datastructure("UNE_RT_A", params=dict(references="descendants"))
-    metadata
+    sm = estat.datastructure("UNE_RT_A", params=dict(references="descendants"))
+    sm
 
-Explore the contents of some code lists:
-
-.. ipython:: python
-
-    for cl in "AGE", "UNIT":
-        print(sdmx.to_pandas(metadata.codelist[cl]))
-
-Next we download a **data set** containing a subset of the data from this data flow, structured by this DSD.
-To obtain data on Greece, Ireland and Spain only, we use codes from the code list with the ID ‘GEO’ to specify a **key** for the dimension with the ID ‘geo’ (note the difference: SDMX IDs are case-sensitive).
-We also use a **query parameter**, ‘startPeriod’, to limit the scope of the data returned:
+:py:`sm` is a Python object of class :class:`.StructureMessage`.
+We can explore some of the specific artifacts—for example, two **code lists**—using :meth:`.StructureMessage.get` to retrieve them and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    resp = estat.data(
+    for cl in "AGE", "SEX":
+        print(sdmx.to_pandas(sm.get(cl)))
+
+Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.
+To obtain data only for Greece, Ireland and Spain, we use codes from the code list with the ID ‘GEO’ to specify a **key** for the dimension with the ID ‘geo’. [3]_
+We also use a **query parameter**, ‘startPeriod’, to limit the scope of the data returned along the ‘TIME_PERIOD’ dimension.
+The query returns a **data message** (Python object of :class:`.DataMessage`) containing the data set:
+
+.. ipython:: python
+
+    dm = estat.data(
         "UNE_RT_A",
         key={"geo": "EL+ES+IE"},
-        params={"startPeriod": "2007"},
+        params={"startPeriod": "2014"},
     )
 
-``resp`` is now a :class:`.DataMessage` object.
-We use the :func:`sdmx.to_pandas` function to convert it to a :class:`pandas.Series`, then select on the ‘age’ dimension:
+We again use :func:`.to_pandas` to convert the entire :py:`dm` to a :class:`pandas.Series` with a multi-level index (one level per dimension of the DSD).
+Then we can use pandas' built-in methods, like :meth:`pandas.Series.xs` to take a cross-section, selecting on the ‘age’ index level (=SDMX dimension):
 
 .. ipython:: python
 
     data = (
-        sdmx.to_pandas(resp)
+        sdmx.to_pandas(dm)
         .xs("Y15-74", level="age", drop_level=False)
     )
 
-We can now explore the data set as expressed in a familiar pandas object.
-First, show dimension names:
+We further examine the retrieved data set in the familiar form of a :class:`.pandas.Series`.
+For one example, show dimension names:
 
 .. ipython:: python
 
@@ -71,3 +73,9 @@ Select some data of interest: show aggregate unemployment rates across ages ("Y1
 .. ipython:: python
 
     data.loc[("A", "Y15-74", "PC_ACT", "T")]
+
+.. [1] This example skips these steps.
+   For a longer explanation, see :ref:`the walkthrough <walkthrough-dataflow>`.
+.. [2] The standard does not require that these IDs are the same, but it is a practice used by some data providers.
+.. [3] Again, note the difference between the ID of a dimension and the ID of the code list used to enumerate that dimension.
+   SDMX IDs are case-sensitive.

--- a/doc/walkthrough.rst
+++ b/doc/walkthrough.rst
@@ -100,6 +100,9 @@ Suppose we are looking for time-series on exchange rates, and we know that the E
 We *could* search the Internet for the dataflow ID or browse the ECB's website.
 However, we can also use :mod:`sdmx` to retrieve metadata and get a complete overview of the data flows the ECB provides.
 
+
+.. _walkthrough-dataflow:
+
 Get information about the source's data flows
 ---------------------------------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,13 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Adjust the :doc:`example` for current data returned by :ref:`ESTAT <ESTAT>` (:issue:`169`, :pull:`170`).
+- :meth:`.StructureMessage.get` can match on :meth:`.IdentifiableArtefact.urn` (:pull:`170`).
+  This makes the method more useful in the case that a message includes artefacts with the same ID but different :attr:`~.MaintainableArtefact.maintainer` and/or :attr:`~.VersionableArtefact.version`.
+- Bugfix: :class:`.ItemScheme` could not be :func:`copy.deepcopy` 'd (:pull:`170`).
 
 v2.14.0 (2024-02-20)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,8 @@ select = ["C9", "E", "F", "I", "W"]
 ignore = ["E501", "W191"]
 # Exceptions:
 # - .client._handle_get_kwargs: 12
-# - .reader.xml.v21.read_message: 12
-# - .writer.pandas._maybe_convert_datetime: 27
+# - .reader.xml.v21.read_message: 15
+# - .writer.pandas._maybe_convert_datetime: 23
 # - .writer.pandas.write_dataset: 12
 mccabe.max-complexity = 11
 

--- a/sdmx/experimental.py
+++ b/sdmx/experimental.py
@@ -12,6 +12,7 @@ are stored internally as a pd.DataFrame. test_experimental.py verifies that
 this implementation exposes the same API as the default DataSet.
 
 """
+
 from typing import Optional, Text
 
 import pandas as pd

--- a/sdmx/format/xml/v21.py
+++ b/sdmx/format/xml/v21.py
@@ -1,4 +1,5 @@
 """Information about the SDMX-ML 2.1 file format."""
+
 from sdmx.model import v21
 
 from .common import XMLFormat

--- a/sdmx/format/xml/v30.py
+++ b/sdmx/format/xml/v30.py
@@ -1,4 +1,5 @@
 """Information about the SDMX-ML 3.0 file format."""
+
 from sdmx.model import v30
 
 from .common import XMLFormat

--- a/sdmx/message.py
+++ b/sdmx/message.py
@@ -6,6 +6,7 @@
 :mod:`sdmx` also uses :class:`DataMessage` to encapsulate SDMX-JSON data returned by
 data sources.
 """
+
 import logging
 from dataclasses import dataclass, field, fields
 from datetime import datetime
@@ -13,7 +14,8 @@ from operator import attrgetter
 from typing import TYPE_CHECKING, List, Optional, Text, Type, Union, get_args
 
 from sdmx import model
-from sdmx.dictlike import DictLike, DictLikeDescriptor, summarize_dictlike
+from sdmx.dictlike import DictLike, summarize_dictlike
+from sdmx.dictlike import DictLikeDescriptor as DLD
 from sdmx.format import Version
 from sdmx.model import common, v21, v30
 from sdmx.model.internationalstring import (
@@ -185,73 +187,57 @@ class ErrorMessage(Message):
 
 @dataclass
 class StructureMessage(Message):
+    """SDMX StructureMessage."""
+
     #: Collection of :class:`.Categorisation`.
-    categorisation: DictLikeDescriptor[str, model.Categorisation] = DictLikeDescriptor()
+    categorisation: DLD[str, model.Categorisation] = DLD()
     #: Collection of :class:`.CategoryScheme`.
-    category_scheme: DictLikeDescriptor[
-        str, model.CategoryScheme
-    ] = DictLikeDescriptor()
+    category_scheme: DLD[str, model.CategoryScheme] = DLD()
     #: Collection of :class:`.Codelist`.
-    codelist: DictLikeDescriptor[str, model.Codelist] = DictLikeDescriptor()
-    #: Collection of :class:`.HierarchicalCodelist`.
-    hierarchical_codelist: DictLikeDescriptor[
-        str, v21.HierarchicalCodelist
-    ] = DictLikeDescriptor()
-    #: Collection of :class:`.v30.Hierarchy`.
-    hierarchy: DictLikeDescriptor[str, v30.Hierarchy] = DictLikeDescriptor()
+    codelist: DLD[str, model.Codelist] = DLD()
     #: Collection of :class:`.ConceptScheme`.
-    concept_scheme: DictLikeDescriptor[str, model.ConceptScheme] = DictLikeDescriptor()
+    concept_scheme: DLD[str, model.ConceptScheme] = DLD()
     #: Collection of :class:`.ContentConstraint`.
-    constraint: DictLikeDescriptor[str, model.BaseConstraint] = DictLikeDescriptor()
+    constraint: DLD[str, model.BaseConstraint] = DLD()
+    #: Collection of :class:`.CustomTypeScheme`.
+    custom_type_scheme: DLD[str, model.CustomTypeScheme] = DLD()
     #: Collection of :class:`Dataflow(Definition) <.BaseDataflow>`.
-    dataflow: DictLikeDescriptor[str, model.BaseDataflow] = DictLikeDescriptor()
+    dataflow: DLD[str, model.BaseDataflow] = DLD()
+    #: Collection of :class:`.HierarchicalCodelist`.
+    hierarchical_codelist: DLD[str, v21.HierarchicalCodelist] = DLD()
+    #: Collection of :class:`.v30.Hierarchy`.
+    hierarchy: DLD[str, v30.Hierarchy] = DLD()
+    #: Collection of :class:`Metadataflow(Definition) <.BaseMetadataflow>`.
+    metadataflow: DLD[str, model.BaseMetadataflow] = DLD()
     #: Collection of :class:`MetadataStructureDefinition
     #: <.BaseMetadataStructureDefinition>`.
-    metadatastructure: DictLikeDescriptor[
-        str, model.BaseMetadataStructureDefinition
-    ] = DictLikeDescriptor()
-    #: Collection of :class:`Metadataflow(Definition) <.BaseMetadataflow>`.
-    metadataflow: DictLikeDescriptor[str, model.BaseMetadataflow] = DictLikeDescriptor()
-    #: Collection of :class:`DataStructureDefinition <.BaseDataStructureDefinition>`.
-    structure: DictLikeDescriptor[
-        str, model.BaseDataStructureDefinition
-    ] = DictLikeDescriptor()
-    #: Collection of :class:`.StructureSet`.
-    structureset: DictLikeDescriptor[str, v21.StructureSet] = DictLikeDescriptor()
-    #: Collection of :class:`.OrganisationScheme`.
-    organisation_scheme: DictLikeDescriptor[
-        str, model.OrganisationScheme
-    ] = DictLikeDescriptor()
-    #: Collection of :class:`.ProvisionAgreement`.
-    provisionagreement: DictLikeDescriptor[
-        str, model.ProvisionAgreement
-    ] = DictLikeDescriptor()
-
-    #: Collection of :class:`.CustomTypeScheme`.
-    custom_type_scheme: DictLikeDescriptor[
-        str, model.CustomTypeScheme
-    ] = DictLikeDescriptor()
+    metadatastructure: DLD[str, model.BaseMetadataStructureDefinition] = DLD()
     #: Collection of :class:`.NamePersonalisationScheme`.
-    name_personalisation_scheme: DictLikeDescriptor[
-        str, model.NamePersonalisationScheme
-    ] = DictLikeDescriptor()
+    name_personalisation_scheme: DLD[str, model.NamePersonalisationScheme] = DLD()
+    #: Collection of :class:`.OrganisationScheme`.
+    organisation_scheme: DLD[str, model.OrganisationScheme] = DLD()
+    #: Collection of :class:`.ProvisionAgreement`.
+    provisionagreement: DLD[str, model.ProvisionAgreement] = DLD()
     #: Collection of :class:`.RulesetScheme`.
-    ruleset_scheme: DictLikeDescriptor[str, model.RulesetScheme] = DictLikeDescriptor()
-    #: Collection of :class:`.VTLMappingScheme`.
-    vtl_mapping_scheme: DictLikeDescriptor[
-        str, model.VTLMappingScheme
-    ] = DictLikeDescriptor()
+    ruleset_scheme: DLD[str, model.RulesetScheme] = DLD()
+    #: Collection of :class:`DataStructureDefinition <.BaseDataStructureDefinition>`.
+    structure: DLD[str, model.BaseDataStructureDefinition] = DLD()
+    #: Collection of :class:`.StructureSet`.
+    structureset: DLD[str, v21.StructureSet] = DLD()
     #: Collection of :class:`.TransformationScheme`.
-    transformation_scheme: DictLikeDescriptor[
-        str, model.TransformationScheme
-    ] = DictLikeDescriptor()
+    transformation_scheme: DLD[str, model.TransformationScheme] = DLD()
     #: Collection of :class:`.UserDefinedOperatorScheme`.
-    user_defined_operator_scheme: DictLikeDescriptor[
-        str, model.UserDefinedOperatorScheme
-    ] = DictLikeDescriptor()
-
+    user_defined_operator_scheme: DLD[str, model.UserDefinedOperatorScheme] = DLD()
     #: Collection of :class:`.ValueList` (SDMX 3.0 only).
-    valuelist: DictLikeDescriptor[str, v30.ValueList] = DictLikeDescriptor()
+    valuelist: DLD[str, v30.ValueList] = DLD()
+    #: Collection of :class:`.VTLMappingScheme`.
+    vtl_mapping_scheme: DLD[str, model.VTLMappingScheme] = DLD()
+
+    def __post_init__(self):
+        # Construct a list referencing all of the collections
+        self._collections = [
+            getattr(self, f.name) for f in direct_fields(self.__class__)
+        ]
 
     def compare(self, other, strict=True):
         """Return :obj:`True` if `self` is the same as `other`.

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -465,8 +465,7 @@ class BaseConstraint(ABC, MaintainableArtefact):
     """ABC for SDMX 2.1 and 3.0 Constraint."""
 
     @abstractmethod
-    def __contains__(self, name):
-        ...
+    def __contains__(self, name): ...
 
 
 # §3.4: Data Types
@@ -1296,9 +1295,9 @@ class BaseDataStructureDefinition(Structure, ConstrainableArtefact):
     dimensions: DimensionDescriptor = field(default_factory=DimensionDescriptor)
     #: Mapping from  :attr:`.GroupDimensionDescriptor.id` to
     #: :class:`.GroupDimensionDescriptor`.
-    group_dimensions: DictLikeDescriptor[
-        str, GroupDimensionDescriptor
-    ] = DictLikeDescriptor()
+    group_dimensions: DictLikeDescriptor[str, GroupDimensionDescriptor] = (
+        DictLikeDescriptor()
+    )
 
     # Specific types to be used in concrete subclasses
     MemberValue: ClassVar[Type["BaseMemberValue"]]
@@ -2181,9 +2180,9 @@ class HierarchicalCode(IdentifiableArtefact):
 
     level: Optional[Level] = None
 
-    parent: Optional[
-        Union["HierarchicalCode", Any]
-    ] = None  # NB second element is "Hierarchy"
+    parent: Optional[Union["HierarchicalCode", Any]] = (
+        None  # NB second element is "Hierarchy"
+    )
     child: List["HierarchicalCode"] = field(default_factory=list)
 
 

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -633,12 +633,12 @@ class ItemScheme(MaintainableArtefact, Generic[IT]):
     def __getattr__(self, name: str) -> IT:
         # Provided to pass test_dsd.py
         try:
-            return self.__getitem__(name)
+            return self.__dict__["items"][name]
         except KeyError:
             raise AttributeError(name)
 
     def __getitem__(self, name: str) -> IT:
-        return self.items[name]
+        return self.__dict__["items"][name]
 
     def get_hierarchical(self, id: str) -> IT:
         """Get an Item by its :attr:`~.Item.hierarchical_id`."""

--- a/sdmx/model/internationalstring.py
+++ b/sdmx/model/internationalstring.py
@@ -47,10 +47,12 @@ class InternationalString:
 
     """
 
+    __slots__ = ("localizations",)
+
     # Types that can be converted into InternationalString
     _CONVERTIBLE = Union[str, Sequence, Mapping, Iterable[Tuple[str, str]]]
 
-    localizations: Dict[str, str] = {}
+    localizations: Dict[str, str]
 
     def __init__(self, value: Optional[_CONVERTIBLE] = None, **kwargs):
         # Handle initial values according to type

--- a/sdmx/model/internationalstring.py
+++ b/sdmx/model/internationalstring.py
@@ -93,7 +93,7 @@ class InternationalString:
     # Duplicate of __getitem__, to pass existing tests in test_dsd.py
     def __getattr__(self, name):
         try:
-            return self.__dict__["localizations"][name]
+            return self.__getattribute__("localizations")[name]
         except KeyError:
             raise AttributeError(name) from None
 

--- a/sdmx/model/v21.py
+++ b/sdmx/model/v21.py
@@ -1,4 +1,5 @@
 """SDMX 2.1 Information Model."""
+
 import logging
 
 # TODO for complete implementation of the IM, enforce TimeKeyValue (instead of KeyValue)

--- a/sdmx/reader/json.py
+++ b/sdmx/reader/json.py
@@ -1,4 +1,5 @@
 """SDMX-JSON v2.1 reader"""
+
 import json
 import logging
 from typing import Mapping, MutableMapping
@@ -36,8 +37,7 @@ class Reader(BaseReader):
     def detect(cls, content):
         return content.startswith(b"{")
 
-    # FIXME Reduce complexity from 17 → 13
-    def read_message(self, source, dsd=None):  # noqa: C901
+    def read_message(self, source, dsd=None):  # noqa: C901  TODO reduce complexity 15 → ≤11
         # Initialize message instance
         msg = DataMessage()
 

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -1,4 +1,5 @@
 """SDMX-ML v2.1 reader."""
+
 # Contents of this file are organized in the order:
 #
 # - Utility methods and global variables.

--- a/sdmx/reader/xml/v30.py
+++ b/sdmx/reader/xml/v30.py
@@ -1,4 +1,5 @@
 """SDMX-ML 3.0.0 reader."""
+
 from typing import Any, Dict
 
 import sdmx.urn

--- a/sdmx/rest/common.py
+++ b/sdmx/rest/common.py
@@ -1,4 +1,5 @@
 """Information related to the SDMX-REST web service standard."""
+
 import abc
 import re
 from copy import copy

--- a/sdmx/rest/v21.py
+++ b/sdmx/rest/v21.py
@@ -7,6 +7,7 @@ specification
 <https://github.com/sdmx-twg/sdmx-rest/blob/v1.5.0/v2_1/ws/rest/src/sdmx-rest.yaml>`_
 for further details.
 """
+
 from collections import ChainMap
 from typing import Dict
 from warnings import warn

--- a/sdmx/rest/v30.py
+++ b/sdmx/rest/v30.py
@@ -6,6 +6,7 @@ SDMX standards. See the `documentation
 <https://github.com/sdmx-twg/sdmx-rest/blob/v2.1.0/api/sdmx-rest.yaml>`__ for further
 details.
 """
+
 from collections import ChainMap
 from typing import Dict
 

--- a/sdmx/tests/model/test_common.py
+++ b/sdmx/tests/model/test_common.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from dataclasses import dataclass
 
 import pytest
@@ -249,6 +250,12 @@ class TestItemScheme:
         is2.append(Item(id="bar"))
 
         assert is0.compare(is2) is False
+
+    def test_deepcopy(self) -> None:
+        """ItemScheme may be :func:`.deepcopy`'d."""
+        is0: ItemScheme = ItemScheme(id="is0")
+
+        deepcopy(is0)
 
     def test_get_hierarchical(self) -> None:
         is0: ItemScheme = ItemScheme(id="is0")

--- a/sdmx/tests/test_experimental.py
+++ b/sdmx/tests/test_experimental.py
@@ -2,6 +2,7 @@
 
 See sdmx.experimental for more information.
 """
+
 import pytest
 
 from sdmx.experimental import DataSet as PandasDataSet

--- a/sdmx/tests/test_performance.py
+++ b/sdmx/tests/test_performance.py
@@ -1,4 +1,5 @@
 """Speed and memory usage tests."""
+
 from sdmx.model.v21 import AttributeValue, DataAttribute, DataStructureDefinition
 
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -3,6 +3,7 @@
 HTTP responses from the data sources are cached in tests/data/cache.
 To force the data to be retrieved over the Internet, delete this directory.
 """
+
 # TODO add a pytest argument for clearing this cache in conftest.py
 import logging
 from pathlib import Path

--- a/sdmx/tests/writer/test_pandas.py
+++ b/sdmx/tests/writer/test_pandas.py
@@ -1,4 +1,5 @@
 """Tests for pandasdmx/writer.py."""
+
 import pandas as pd
 import pytest
 from pytest import raises

--- a/sdmx/util/item_structure.py
+++ b/sdmx/util/item_structure.py
@@ -1,4 +1,5 @@
 """Parse structure information from item description."""
+
 import logging
 import operator
 import re

--- a/sdmx/writer/csv.py
+++ b/sdmx/writer/csv.py
@@ -2,6 +2,7 @@
 
 See :ref:`sdmx-csv`.
 """
+
 from os import PathLike
 from typing import Literal, Optional, Type, Union
 

--- a/sdmx/writer/pandas.py
+++ b/sdmx/writer/pandas.py
@@ -377,7 +377,7 @@ def _dataset_compat(df, datetime, kwargs):
     return df, datetime, kwargs
 
 
-def _maybe_convert_datetime(df, arg, obj, dsd=None):  # noqa: C901
+def _maybe_convert_datetime(df, arg, obj, dsd=None):  # noqa: C901  TODO reduce complexity 23 → ≤11
     """Helper for :meth:`.write_dataset` to handle datetime indices.
 
     Parameters


### PR DESCRIPTION
- Close #169.
- Improve StructureMessage.get() to be more flexible when artefact IDs are duplicated.
- Bugfix: allow copy.deepcopy(ItemScheme()).
- Housekeeping: bump versions of mypy, ruff.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
