### PR TITLE
Strip XML element text

### DIFF
--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -69,7 +69,7 @@ class Reference(BaseReference):
             for k in ("class", "package"):
                 result[k] = elem.attrib.get(k, None)
         elif elem.tag == "URN":
-            result = sdmx.urn.match(elem.text)
+            result = sdmx.urn.match(elem.text.strip())
             # If the URN doesn't specify an item ID, it is probably a reference to a
             # MaintainableArtefact, so target_id and id are the same
             result.update(target_id=result["item_id"] or result["id"])
@@ -355,7 +355,7 @@ def _st(reader, elem):
 
 @end("mes:Extracted mes:Prepared mes:ReportingBegin mes:ReportingEnd")
 def _datetime(reader, elem):
-    text, n = re.subn(r"(.*\.)(\d{6})\d+(\+.*)", r"\1\2\3", elem.text)
+    text, n = re.subn(r"(.*\.)(\d{6})\d+(\+.*)", r"\1\2\3", elem.text.strip())
     if n > 0:
         log.debug(f"Truncate sub-microsecond time in <{QName(elem).localname}>")
 
@@ -371,7 +371,10 @@ def _datetime(reader, elem):
 def _localization(reader, elem):
     reader.push(
         elem,
-        (elem.attrib.get(reader.qname("xml:lang"), model.DEFAULT_LOCALE), elem.text),
+        (
+            elem.attrib.get(reader.qname("xml:lang"), model.DEFAULT_LOCALE),
+            elem.text.strip(),
+        ),
     )
 
 
@@ -753,7 +756,7 @@ def _key0(reader, elem):
             "ToVtlSubSpace": model.ToVTLSpaceKey,
         }[parent]
 
-        return cls(key=elem.text)
+        return cls(key=elem.text.strip())
 
 
 @end("str:DataKeySet")
@@ -769,7 +772,7 @@ def _p(reader, elem):
     reader.push(
         elem,
         model.Period(
-            is_inclusive=elem.attrib["isInclusive"], period=isoparse(elem.text)
+            is_inclusive=elem.attrib["isInclusive"], period=isoparse(elem.text.strip())
         ),
     )
 

--- a/sdmx/reader/xml/v30.py
+++ b/sdmx/reader/xml/v30.py
@@ -17,7 +17,7 @@ class Reference(BaseReference):
     @classmethod
     def info_from_element(cls, elem):
         try:
-            result = sdmx.urn.match(elem.text)
+            result = sdmx.urn.match(elem.text.strip())
             # If the URN doesn't specify an item ID, it is probably a reference to a
             # MaintainableArtefact, so target_id and id are the same
             result.update(target_id=result["item_id"] or result["id"])
@@ -84,13 +84,13 @@ end("str:Observation")(v21._ar_kind)
 @end("str:Codelist")
 def _cl(reader, elem):
     try:
-        sdmx.urn.match(elem.text)
+        sdmx.urn.match(elem.text.strip())
     except ValueError:
         result = v21._itemscheme(reader, elem)
         result.extends = reader.pop_all(model.CodelistExtension)
         return result
     else:
-        reader.push(elem, elem.text)
+        reader.push(elem, elem.text.strip())
 
 
 @end("str:CodelistExtension")
@@ -111,7 +111,7 @@ def _code_selection(reader, elem):
 
 @end("str:MemberValue")
 def _mv(reader, elem):
-    return reader.model.MemberValue(value=elem.text)
+    return reader.model.MemberValue(value=elem.text.strip())
 
 
 @end("str:GeoGridCodelist")


### PR DESCRIPTION
Hi,

I downloaded BIS SDMX files using their bulk download website (`https://data.bis.org/static/bulk/{dataset_id}_sdmx-compact-2.1.zip`, for example https://data.bis.org/static/bulk/WS_CBPOL_sdmx-compact-2.1.zip ).

Because those XML files are non-indented (they only have 1 line), I re-indented them using [xmlindent](https://github.com/penberg/xmlindent), and now `read_sdmx` does not work anymore, because of the `\n` inserted in `element.text`:

```

--- SS without structure ---
1 (140191632947744) False

--- <class 'sdmx.message.StructureMessage'> ---
2 (140189840089040) <sdmx.StructureMessage>
  <Header>
    source: 
    test: False

--- ID ---
3 (140189838191248) IDREFc71e5f8d-5182-411e-8910-40010bd38ab1
    

--- Test ---
4 (140191565313648) false
    


Ignore:
 {140191632913024}
<mes:Prepared xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">2024-06-10T14:35:22Z
    </mes:Prepared>
    

2024-06-11 01:06:47,774 CRITICAL root: Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/sdmx/reader/xml/common.py", line 204, in read_message
    result = func(self, element)
             ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sdmx/reader/xml/v21.py", line 362, in _datetime
    reader.push(elem, isoparse(text))
                      ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dateutil/parser/isoparser.py", line 37, in func
    return f(self, str_in, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dateutil/parser/isoparser.py", line 138, in isoparse
    components += self._parse_isotime(dt_str[pos + 1:])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dateutil/parser/isoparser.py", line 346, in _parse_isotime
    components[-1] = self._parse_tzstr(timestr[pos:])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dateutil/parser/isoparser.py", line 395, in _parse_tzstr
    raise ValueError('Time zone offset requires sign')
ValueError: Time zone offset requires sign

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/download.py", line 8, in <module>
    main()
  File "/app/src/bis_fetcher/download.py", line 12, in main
    Downloader(downloader_helper=downloader_helper).start()
  File "/app/src/bis_fetcher/downloader.py", line 92, in start
    for dataset_id, dataflow_definition in self._source_data_loader.load_dataflow().items():
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/bis_fetcher/source_data_loader.py", line 73, in load_dataflow
    dataflow_msg = self._parse_sdmx_structure_message(self.dataflow_file)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/bis_fetcher/source_data_loader.py", line 144, in _parse_sdmx_structure_message
    msg = sdmx.read_sdmx(input_file)  # type:ignore[no-untyped-call]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sdmx/reader/__init__.py", line 126, in read_sdmx
    return reader().read_message(obj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sdmx/reader/xml/__init__.py", line 45, in read_message
    import_module(f"sdmx.reader.xml.{version}")
  File "/usr/local/lib/python3.12/site-packages/sdmx/reader/xml/common.py", line 221, in read_message
    raise XMLParseError from exc
sdmx.exceptions.XMLParseError: ValueError: Time zone offset requires sign
```

To add tests, I have seen the sdmx-test-data repository, but did not want to modify those files directly. How would you proceed about tests?

### PR checklist
- [ ] Checks all ✅
- [ ] Update documentation
- [ ] Update doc/whatsnew.rst
