### PR TITLE
pyproject: Ensure sources.json is installed by setuptools.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,6 @@ find = {}
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+
+[tool.setuptools.data-files]
+sdmx = ["sdmx/sources.json"]


### PR DESCRIPTION
I couldn't build the package from source on Gnu Guix without ensuring the sources.json file is there.