### PR TITLE
Preserve IdentifiableArtefact(id="")

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bugfix: in v2.19.0 (only), :py:`IdentifableArtefact(id="")` resulted in the given ID (an empty :class:`str`) being incorrectly replaced with :data:`~.common.MissingID` (:pull:`203`).
 
 v2.19.0 (2024-10-23)
 ====================

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -245,7 +245,8 @@ class IdentifiableArtefact(AnnotableArtefact):
         # Validate URN, if any
         self._urn = URN(self.urn)
 
-        if not self.id:
+        if self.id is MissingID:
+            # Try to retrieve an item ID from the URN, if any
             self.id = self._urn.item_id or self._urn.id or MissingID
         elif self.urn and self.id not in (self._urn.item_id or self._urn.id):
             # Ensure explicit ID is consistent with URN

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -146,6 +146,7 @@ class _MissingID(str):
         return isinstance(other, self.__class__)
 
 
+#: Singleton used for :attr:`.IdentifiableArtefact.id` if none given.
 MissingID = _MissingID()
 
 

--- a/sdmx/tests/model/test_common.py
+++ b/sdmx/tests/model/test_common.py
@@ -93,6 +93,17 @@ URN = "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=IT1:VARIAB_ALL(9.
 
 
 class TestIdentifiableArtefact:
+    def test_init_empty_id(self):
+        """IdentifiableArtefact can be initialized with an empty :class:`str` as ID."""
+        # No id= parameter → id attribute is MissingID
+        ia0 = IdentifiableArtefact()
+        assert common.MissingID == ia0.id
+        assert common.MissingID is ia0.id
+
+        # Empty string parameter → id attribute is empty string
+        ia1 = IdentifiableArtefact(id="")
+        assert "" == ia1.id
+
     def test_init_urn(self):
         """IdentifiableArtefact can be initialized with URN."""
         ia = IdentifiableArtefact(urn=URN)


### PR DESCRIPTION
@glatterf42 reports that [here](https://github.com/iiasa/message-ix-models/actions/runs/11480171837/job/31948029245?pr=242) downstream tests fail with sdmx 2.19.0, but not sdmx 2.18.0.

This happens when an IdentifiableArtefact is initialized with an empty string (`""`) as its ID. Previously, this value was preserved. As a consequence of changes in #198, empty string was replaced with `MissingID`. There was no test covering this case.

This PR adds the missing test and a fix.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, bugfix
- [x] Update doc/whatsnew.rst
