### PR TITLE
Convert pandas.DataFrame as if it were SDMX-CSV

### DIFF
--- a/doc/api/reader.rst
+++ b/doc/api/reader.rst
@@ -84,5 +84,8 @@ Reader API
 .. automodule:: sdmx.reader
    :members:
 
+.. autoclass:: sdmx.reader.base.Converter
+   :members:
+
 .. autoclass:: sdmx.reader.base.BaseReader
    :members:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,6 +8,12 @@ What's new?
 Next release
 ============
 
+- Add :func:`.to_sdmx` and :class:`.DataFrameConverter` to allow converting :class:`.pandas.DataFrame` as if it were SDMX-CSV (:pull:`212`).
+
+  - See also :class:`.Converter`, :data:`.CONVERTER`, :func:`.get_converter` for opportunities to extend this generic capability.
+  - Add :func:`.get_reader`; deprecate :func:`.detect_content_reader`, :func:`.get_reader_for_media_type`, :func:`.get_reader_for_path`.
+  - Add :meth:`.BaseReader.handles` and :attr:`.binary_content_startswith`; deprecate :meth:`~.BaseReader.detect`, :meth:`~.BaseReader.supports_suffix`, :meth:`~.BaseReader.handles_media_type`.
+
 - Improve tolerance of invalid references in SDMX-ML (:pull:`207`; thanks :gh-user:`nicolas-graves` for :issue:`205`).
   Where a file gives a reference for a :attr:`.Component.concept_identity` (such as for a :class:`.Dimension` or :class:`.PrimaryMeasure`) that is invalid—that is, the specified :class:`.Concept` does not exist in the referenced :class:`.ConceptScheme`—log on level :data:`logging.WARNING` and discard the reference.
   Previously such invalid references caused a :class:`KeyError`.

--- a/sdmx/__init__.py
+++ b/sdmx/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from sdmx.client import Client, Request, read_url
 from sdmx.format.xml.common import install_schemas, validate_xml
-from sdmx.reader import read_sdmx
+from sdmx.reader import read_sdmx, to_sdmx
 from sdmx.rest import Resource
 from sdmx.source import add_source, list_sources
 from sdmx.writer import to_csv, to_pandas, to_xml
@@ -21,6 +21,7 @@ __all__ = [
     "to_csv",
     "to_pandas",
     "to_xml",
+    "to_sdmx",
     "validate_xml",
 ]
 

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -7,7 +7,7 @@ import requests
 
 from sdmx.model import common
 from sdmx.model.v21 import DataStructureDefinition
-from sdmx.reader import get_reader_for_media_type
+from sdmx.reader import get_reader
 from sdmx.rest import Resource
 from sdmx.session import ResponseIO, Session
 from sdmx.source import NoSource, list_sources, sources
@@ -481,19 +481,19 @@ class Client:
         )
 
         # Select reader class
-        content_type = response.headers.get("content-type", None)
         try:
-            Reader = get_reader_for_media_type(content_type)
+            Reader = get_reader(response)
         except ValueError:
             raise ValueError(
-                f"can't determine a reader for response content type {content_type!r}"
+                "can't determine a reader for response content type "
+                + repr(response.headers.get("content-type", None))
             ) from None
 
         # Instantiate reader
         reader = Reader()
 
         # Parse the message, using any provided or auto-queried DSD
-        msg = reader.read_message(response_content, structure=kwargs.get("dsd", None))
+        msg = reader.convert(response_content, structure=kwargs.get("dsd", None))
 
         # Store the HTTP response with the message
         msg.response = response

--- a/sdmx/reader/__init__.py
+++ b/sdmx/reader/__init__.py
@@ -1,126 +1,200 @@
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Union
+from warnings import warn
 
 from . import csv, json, xml
 
-#: Reader classes
+if TYPE_CHECKING:
+    import io
+    from typing import TypeVar
+
+    import sdmx.message
+    import sdmx.reader.base
+
+    T = TypeVar("T", bound=sdmx.reader.base.Converter)
+
+
+#: All converters. Application code **may** extend this collection with custom
+#: sub-classes of :class:`.Converter`.
+CONVERTER = [csv.DataFrameConverter, csv.Reader, json.Reader, xml.Reader]
+
+#: Only Readers for standard SDMX formats.
 READERS = [csv.Reader, json.Reader, xml.Reader]
 
 
-def _readers():
-    return ", ".join(map(lambda cls: cls.__name__, READERS))
+def detect_content_reader(content) -> type["sdmx.reader.base.BaseReader"]:
+    """Return a reader class for :class:`bytes` `content`.
+
+    .. deprecated:: 2.20.0
+       Use :func:`get_reader` instead.
+    """
+    warn(
+        "detect_content_reader(bytes); use get_reader() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_reader(content)
 
 
-def detect_content_reader(content):
-    """Return a reader class for `content`.
+def _get(data: Any, kwargs: Optional[dict], _classes: list[type["T"]]) -> type["T"]:
+    for c in _classes:
+        if c.handles(data, kwargs or {}):
+            return c
 
-    The :meth:`.BaseReader.detect` method for each class in :data:`READERS` is called;
-    if a reader signals that it is compatible with `content`, then that class is
-    returned.
+    raise ValueError(
+        f"{data!r} not recognized by any of "
+        + ", ".join(map(lambda c: c.__name__, _classes))
+    )
+
+
+def get_converter(
+    data: Any, kwargs: Optional[dict] = None
+) -> type["sdmx.reader.base.Converter"]:
+    """Identify a :class:`Converter` or :class:`.Reader` for `data`.
+
+    For each class in :data:`CONVERTER`, the :meth:`.Converter.handles` or
+    :meth:`.BaseReader.handles` method is called with `data` and `kwargs`.
+
+    `data` may include:
+
+    - :class:`bytes` —same behaviour as deprecated :func:`.detect_content_reader`.
+    - :class:`requests.Response` —same behaviour as deprecated
+      :func:`.get_reader_for_media_type`.
+    - :class:`pathlib.Path` —same behaviour as deprecated :func:`.get_reader_for_path`.
+
+    …or, anything else that is handled by a class listed in :data:`CONVERTER`.
 
     Raises
     ------
     ValueError
-        If no reader class matches.
+        if none of the Converter classes can convert `data` and `kwargs` to SDMX.
     """
-    for cls in READERS:
-        if cls.detect(content):
-            return cls
-
-    raise ValueError(f"{repr(content)} not recognized by any of {_readers()}")
+    return _get(data, kwargs, CONVERTER)
 
 
-def get_reader_for_media_type(value):
+def get_reader(
+    data: Any,
+    kwargs: Optional[dict] = None,
+    _classes: list[type["sdmx.reader.base.BaseReader"]] = READERS,
+) -> type["sdmx.reader.base.BaseReader"]:
+    """Identify a :class:`.Reader` for `data`.
+
+    Identical to :func:`.get_converter`, except only :data:`READERS` for SDMX standard
+    formats are returned.
+    """
+    return _get(data, kwargs, READERS)
+
+
+def get_reader_for_media_type(value) -> type["sdmx.reader.base.BaseReader"]:
     """Return a reader class for HTTP content/media type `value`.
 
-    Raises
-    ------
-    ValueError
-        If no reader class matches.
-
-    See also
-    --------
-    BaseReader.media_type
+    .. deprecated:: 2.20.0
+       Use :func:`get_reader` instead.
     """
-    for cls in READERS:
-        if cls.handles_media_type(value):
-            return cls
+    from requests import Response
 
-    raise ValueError(f"Media type {value!r} not supported by any of {_readers()}")
+    warn(
+        "get_reader_for_media_type(str); use get_reader(requests.Response) instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Use `value` as Content-Type header for an otherwise-empty Response
+    resp = Response()
+    resp.headers["content-type"] = value
+
+    try:
+        return get_reader(resp)
+    except ValueError as e:
+        *_, names = e.args[0].partition(" any of ")
+        raise ValueError(f"Media type {value!r} not supported by any of {names}")
 
 
-def get_reader_for_path(path):
+def get_reader_for_path(path) -> type["sdmx.reader.base.BaseReader"]:
     """Return a reader class for file `path`.
 
-    Raises
-    ------
-    ValueError
-        If no reader class matches.
-
-    See also
-    --------
-    BaseReader.suffixes
+    .. deprecated:: 2.20.0
+       Use :func:`get_reader` instead.
     """
-    suffix = Path(path).suffix
-    for cls in READERS:
-        if cls.supports_suffix(suffix):
-            return cls
+    warn(
+        "get_reader_for_path(…); use get_reader() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    raise ValueError(f"File suffix {repr(suffix)} not supported by any of {_readers()}")
+    p = Path(path)
+    try:
+        return get_reader(p)
+    except ValueError as e:
+        *_, names = e.args[0].partition(" any of ")
+        raise ValueError(f"File suffix {p.suffix!r} not supported by any of {names}")
 
 
-def read_sdmx(filename_or_obj, format=None, **kwargs):
-    """Load a SDMX-ML or SDMX-JSON message from a file or file-like object.
+def read_sdmx(
+    filename_or_obj: Union[bytes, str, Path, "io.IOBase", "io.BufferedReader"],
+    format: Optional[str] = None,
+    **kwargs,
+) -> "sdmx.message.Message":
+    """Read a :class:`.Message` from a path, file, or stream in an SDMX standard format.
+
+    To identify whether `filename_or_obj` contains SDMX-CSV, SDMX-JSON, or SDMX-ML,
+    :meth:`.BaseReader.handles` is called.
 
     Parameters
     ----------
-    filename_or_obj : str or :class:`~os.PathLike` or file
-    format : 'XML' or 'JSON', optional
+    filename_or_obj :
+        may include:
+
+        - :class:`str` or :class:`pathlib.Path`: path to a particular file.
+        - :class:`bytes`: raw/binary SDMX content.
+        - :class:`io.IOBase`: a buffer, opened file, or other I/O object containing
+          binary SDMX content.
+    format : 'CSV', 'XML', or 'JSON', optional
+        force handling `filename_or_obj` as if it had the given extension, even if
+        :meth:`~.BaseReader.handles` fails to match.
 
     Other Parameters
     ----------------
-    dsd : :class:`DataStructureDefinition <.BaseDataStructureDefinition>`
-        For “structure-specific” `format`=``XML`` messages only.
+    structure :
+        :class:`.Structure`, :class:`.StructureUsage`, or other information used by a
+        :class:`.BaseReader` to interpret the content of `filename_or_obj`. For example,
+        the :class:`DataStructureDefinition <.BaseDataStructureDefinition>` for a
+        structure-specific SDMX-ML message.
     """
-    reader = None
+    if isinstance(filename_or_obj, (str, Path)):
+        path = Path(filename_or_obj)  # Ensure Path type
+        obj: Union[bytes, "io.IOBase"] = open(path, "rb")  # Open the file
+    else:
+        path, obj = None, filename_or_obj
 
-    try:
-        path = Path(filename_or_obj)
-
-        # Open the file
-        obj = open(path, "rb")
-    except TypeError:
-        # Not path-like → opened file
-        path = None
-        obj = filename_or_obj
-
-    if path:
+    # Try to identify a reader by first the path, then by the `obj` content
+    for candidate in path, obj, Path(f"_.{(format or 'MISSING').lower()}"):
         try:
-            # Use the file extension to guess the reader
-            reader = get_reader_for_path(filename_or_obj)
+            reader = get_reader(candidate, kwargs)
         except ValueError:
-            pass
-
-    if not reader:
-        try:
-            reader = get_reader_for_path(Path(f"dummy.{format.lower()}"))
-        except (AttributeError, ValueError):
-            pass
-
-    if not reader:
-        # Read a line and then return the cursor to the initial position
-        pos = obj.tell()
-        first_line = obj.readline().strip()
-        obj.seek(pos)
-
-        try:
-            reader = detect_content_reader(first_line)
-        except ValueError:
-            pass
+            reader = None
+        else:
+            break
 
     if not reader:
         raise RuntimeError(
-            f"cannot infer SDMX message format from path {repr(path)}, "
-            f"format={format}, or content '{first_line[:5].decode()}..'"
+            f"cannot infer SDMX message format from path {path!r}, format "
+            f"hint={format}, or content"
         )
 
-    return reader().read_message(obj, **kwargs)
+    return reader().convert(obj, **kwargs)
+
+
+def to_sdmx(data, **kwargs) -> "sdmx.message.Message":
+    """Convert `data` in non-SDMX formats and data structures to SDMX :class:`.Message`.
+
+    Unlike :func:`.read_sdmx`, which handles only the standard SDMX formats SDMX-CSV,
+    SDMX-JSON, and SDMX-ML, this method can will process any Python data structure
+    handled by a known :data:`CONVERTER`.
+    """
+    try:
+        converter = get_converter(data, kwargs)
+    except ValueError:
+        raise NotImplementedError(f"Convert {type(data)} {data!r} to SDMX")
+
+    return converter().convert(data, **kwargs)

--- a/sdmx/reader/base.py
+++ b/sdmx/reader/base.py
@@ -32,7 +32,8 @@ class Converter:
 class BaseReader(Converter):
     """Converter of file or binary data in standard SDMX formats."""
 
-    #: First byte(s) of file or response body content, used by :meth:`.handles`.
+    #: First byte(s) of file or response body content, used by
+    #: :meth:`~.BaseReader.handles`.
     binary_content_startswith: ClassVar[Optional[bytes]] = None
 
     #: List of media types, used by :meth:`.handles`.
@@ -45,13 +46,16 @@ class BaseReader(Converter):
     def detect(cls, content: bytes) -> bool:
         """Detect whether the reader can handle `content`.
 
+        .. deprecated:: 2.20.0
+           Use :meth:`~.BaseReader.handles` instead.
+
         Returns
         -------
         bool
             :obj:`True` if the reader can handle the content.
         """
         warn(
-            "BaseReader.detect(); use Converter.handles(bytes(…)) instead",
+            "BaseReader.detect(bytes); use Converter.handles() instead",
             DeprecationWarning,
         )
         return False
@@ -59,9 +63,13 @@ class BaseReader(Converter):
     @classmethod
     @lru_cache()
     def handles_media_type(cls, value: str) -> bool:
-        """:obj:`True` if the reader can handle content/media type `value`."""
+        """:obj:`True` if the reader can handle content/media type `value`.
+
+        .. deprecated:: 2.20.0
+           Use :meth:`~.BaseReader.handles` instead.
+        """
         warn(
-            "BaseReader.handles_media_type(); use Converter.handles(requests.Response(…)) instead",
+            "BaseReader.handles_media_type(str); use Converter.handles(requests.Response) instead",
             DeprecationWarning,
         )
         for mt in cls.media_types:
@@ -71,9 +79,13 @@ class BaseReader(Converter):
 
     @classmethod
     def supports_suffix(cls, value: str) -> bool:
-        """:obj:`True` if the reader can handle files with suffix `value`."""
+        """:obj:`True` if the reader can handle files with suffix `value`.
+
+        .. deprecated:: 2.20.0
+           Use :meth:`~.BaseReader.handles` instead.
+        """
         warn(
-            "BaseReader.supports_suffix(); use Converter.handles(pathlib.Path(…)) instead",
+            "BaseReader.supports_suffix(str); use Converter.handles(pathlib.Path) instead",
             DeprecationWarning,
         )
         return cls.handles(pathlib.Path(f"_.{value.lower()}"), {})

--- a/sdmx/reader/base.py
+++ b/sdmx/reader/base.py
@@ -1,22 +1,44 @@
+import io
 import logging
-from abc import ABC, abstractmethod
+import pathlib
 from functools import lru_cache
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 from warnings import warn
+
+import requests
 
 from sdmx.format import MediaType
 
 if TYPE_CHECKING:
+    import sdmx.message
     import sdmx.model.common
 
 log = logging.getLogger(__name__)
 
 
-class BaseReader(ABC):
-    #: List of media types handled by the reader.
+class Converter:
+    """Base class for conversion to :mod:`sdmx` objects."""
+
+    @classmethod
+    def handles(cls, data: Any, kwargs: dict) -> bool:
+        """Return :any:`True` if the class can convert `data` using `kwargs`."""
+        return False
+
+    def convert(self, data: Any, **kwargs) -> "sdmx.message.Message":
+        """Convert `data` to an instance of an SDMX Message subclass."""
+        raise NotImplementedError
+
+
+class BaseReader(Converter):
+    """Converter of file or binary data in standard SDMX formats."""
+
+    #: First byte(s) of file or response body content, used by :meth:`.handles`.
+    binary_content_startswith: ClassVar[Optional[bytes]] = None
+
+    #: List of media types, used by :meth:`.handles`.
     media_types: ClassVar[list[MediaType]] = []
 
-    #: List of file name suffixes handled by the reader.
+    #: List of file name suffixes, used by :meth:`.handles`.
     suffixes: ClassVar[list[str]] = []
 
     @classmethod
@@ -28,12 +50,20 @@ class BaseReader(ABC):
         bool
             :obj:`True` if the reader can handle the content.
         """
+        warn(
+            "BaseReader.detect(); use Converter.handles(bytes(…)) instead",
+            DeprecationWarning,
+        )
         return False
 
     @classmethod
     @lru_cache()
     def handles_media_type(cls, value: str) -> bool:
         """:obj:`True` if the reader can handle content/media type `value`."""
+        warn(
+            "BaseReader.handles_media_type(); use Converter.handles(requests.Response(…)) instead",
+            DeprecationWarning,
+        )
         for mt in cls.media_types:
             if mt.match(value):
                 return True
@@ -42,20 +72,67 @@ class BaseReader(ABC):
     @classmethod
     def supports_suffix(cls, value: str) -> bool:
         """:obj:`True` if the reader can handle files with suffix `value`."""
-        return value.lower() in cls.suffixes
+        warn(
+            "BaseReader.supports_suffix(); use Converter.handles(pathlib.Path(…)) instead",
+            DeprecationWarning,
+        )
+        return cls.handles(pathlib.Path(f"_.{value.lower()}"), {})
 
-    @abstractmethod
-    def read_message(
-        self,
-        source,
-        structure: Optional["sdmx.model.common.Structure"] = None,
-        **kwargs,
+    @classmethod
+    def handles(cls, data, kwargs):
+        """Return :any:`True` if the Reader can convert `data` using `kwargs`.
+
+        The default implementation checks for any of the following conditions:
+
+        1. `data` is :class:`pathlib.Path` and has one of the Reader's
+           :attr:`.suffixes`. The match is case-insensitive.
+        2. `data` is :class:`requests.Response` and its
+           :attr:`~requests.Response.headers` include a ``content-type`` that is matched
+           by one of the :class:`.MediaTypes` in the Reader' :attr:`.media_types`.
+        3. `data` is :class:`bytes`, :class:`io.IOBase`, or :class:`io.BufferedReader`
+           and starts with the class' :attr:`.binary_content_startswith` (if any). For
+           the :mod:`io` classes, this check is performed by 'peeking' at the content
+           without changing the position in the file for a later call to
+           :meth:`.convert`.
+        """
+        if isinstance(data, pathlib.Path):
+            # `data` is a Path with a known suffix
+            # Formerly supports_suffix()
+            return data.suffix.lower() in cls.suffixes
+        elif isinstance(data, requests.Response):
+            # `data` is a HTTP Response with given content-type headers
+            # Formerly handles_media_type()
+            value = data.headers.get("content-type", "")
+            return any(mt.match(value) for mt in cls.media_types)
+        elif bcsw := cls.binary_content_startswith:
+            if isinstance(data, bytes):
+                # `data` is raw bytes
+                # Formerly detect()
+                peek = data
+            elif isinstance(data, io.BufferedReader):
+                # `data` is a subtype of io.IOBase that supports peek()
+                peek = data.peek(len(bcsw))
+            elif isinstance(data, io.IOBase):
+                # `data` is a subtype of io.IOBase that supports tell()/seek()
+                # Formerly in read_sdmx()
+                pos = data.tell()
+                peek = data.readline().strip()
+                data.seek(pos)  # Return to original `pos`ition
+            else:
+                peek = b""
+
+            return peek.startswith(bcsw)
+
+        return False
+
+    def convert(
+        self, data, structure: Optional["sdmx.model.common.Structure"] = None, **kwargs
     ):
-        """Read message from *source*.
+        """Convert `data` to an instance of an SDMX Message subclass.
 
         Parameters
         ----------
-        source : file-like
+        data : file-like
             Message content.
         structure :
             :class:`DataStructure <.BaseDataStructureDefinition>` or
@@ -67,7 +144,16 @@ class BaseReader(ABC):
         :class:`.Message`
             An instance of a Message subclass.
         """
-        pass  # pragma: no cover
+        raise NotImplementedError
+
+    def read_message(self, *args, **kwargs):
+        """Deprecated. Use :meth:`.convert` instead."""
+        warn(
+            "Reader.read_message(); use Converter.convert() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.convert(*args, **kwargs)
 
     @classmethod
     def _handle_deprecated_kwarg(

--- a/sdmx/reader/xml/common.py
+++ b/sdmx/reader/xml/common.py
@@ -151,9 +151,9 @@ class XMLEventReader(BaseReader):
 
     # BaseReader methods
 
-    def read_message(
+    def convert(
         self,
-        source,
+        data,
         structure=None,
         _events=None,
         **kwargs,
@@ -175,7 +175,7 @@ class XMLEventReader(BaseReader):
         if _events is None:
             events = cast(
                 Iterator[tuple[str, etree._Element]],
-                etree.iterparse(source, events=("start", "end")),
+                etree.iterparse(data, events=("start", "end")),
             )
         else:
             events = _events

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -130,7 +130,7 @@ def _message(reader: Reader, elem):
 
     ss_without_structure = False
 
-    # Retrieve any {Metad,D}ataStructure definition given to Reader.read_message()
+    # Retrieve any {Metad,D}ataStructure definition given to Reader.convert()
     supplied_structure = reader.get_single(common.Structure, subclass=True)
 
     # Handle

--- a/sdmx/tests/model/test_v21.py
+++ b/sdmx/tests/model/test_v21.py
@@ -1,4 +1,5 @@
 from operator import attrgetter
+from typing import cast
 
 import pytest
 
@@ -589,7 +590,7 @@ class TestMetadataSet:
     @pytest.fixture(scope="class")
     def msg(self, specimen) -> sdmx.message.MetadataMessage:
         with specimen("esms_generic.xml") as f:
-            return sdmx.read_sdmx(f)
+            return cast(sdmx.message.MetadataMessage, sdmx.read_sdmx(f))
 
     def test_report_hierarchy(self, msg: sdmx.message.MetadataMessage) -> None:
         # Access message → metadata set → report

--- a/sdmx/tests/reader/test_base.py
+++ b/sdmx/tests/reader/test_base.py
@@ -16,7 +16,7 @@ class TestBaseReader:
                 MediaType("", "xml", "2.1", Flag.data, full="application/foo"),
             ]
 
-            def read_message(self, source, dsd=None):
+            def convert(self, source, dsd=None):
                 pass  # pragma: no cover
 
         return cls
@@ -32,14 +32,16 @@ class TestBaseReader:
             ),
             pytest.raises(ValueError, match="Mismatched structure=FOO, dsd=BAR"),
         ):
-            r.read_message(None, structure=dsd0, dsd=dsd1)
+            r.convert(None, structure=dsd0, dsd=dsd1)
 
     def test_detect(self, MinimalReader):
-        assert False is MinimalReader.detect(b"foo")
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert False is MinimalReader.detect(b"foo")
 
     def test_handles_media_type(self, caplog, MinimalReader):
         """:meth:`.handles_media_type` matches even when params differ, but logs."""
-        assert True is MinimalReader.handles_media_type("application/foo; bar=qux")
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert True is MinimalReader.handles_media_type("application/foo; bar=qux")
         assert (
             "Match application/foo with params {'bar': 'qux'}; "
             "expected {'version': '2.1'}" in caplog.messages

--- a/sdmx/tests/reader/test_reader_csv.py
+++ b/sdmx/tests/reader/test_reader_csv.py
@@ -1,9 +1,13 @@
 from functools import lru_cache
-from io import BytesIO
+from io import BytesIO, StringIO
 from typing import TYPE_CHECKING
 
+import pandas as pd
 import pytest
 
+import sdmx.message
+from sdmx import to_sdmx
+from sdmx.model import common
 from sdmx.reader.csv import Handler, NotHandled, Reader
 
 if TYPE_CHECKING:
@@ -17,6 +21,39 @@ class TestHandler:
 
     def test_repr(self):
         assert "<NotHandled>" == repr(NotHandled())
+
+
+class TestDataFrameConverter:
+    @pytest.fixture
+    def df(self) -> pd.DataFrame:
+        """Equivalent to the content of v21/csv/example-01.csv"""
+        buf = StringIO("""
+STRUCTURE,STRUCTURE_ID,ACTION,DIM_1,DIM_2,DIM_3,OBS_VALUE,ATTR_2,ATTR_3,ATTR_1,UPDATED
+dataflow,ESTAT:NA_MAIN(1.6.0),I,A,B,2014-01,12.4,Y,"Normal, special and other values",N,2021-01-22T13:15:41Z
+dataflow,ESTAT:NA_MAIN(1.6.0),I,A,B,2014-02,10.8,Y,"Normal, special and other values",Y,2021-01-22T13:15:41Z
+""")
+        return pd.read_csv(buf)
+
+    def test_to_sdmx(self, df) -> None:
+        """:class:`.DataFrameConverter` can be used through :func:`.to_sdmx`."""
+        dfd = get_dfd()
+
+        result = to_sdmx(df, structure=dfd)  # Function runs
+
+        assert isinstance(result, sdmx.message.DataMessage)  # Returns a data set
+        assert 1 == len(result.data)  # Message has 1 data set
+        ds = result.data[0]
+
+        assert 2 == len(ds)  # Data set has 2 observations
+        o0 = ds.obs[0]
+
+        assert 12.4 == o0.value  # Observation has an expected value
+        assert (  # Observation has the expected key
+            dfd.structure.make_key(
+                common.Key, dict(DIM_1="A", DIM_2="B", DIM_3="2014-01")
+            )
+            == o0.dimension
+        )
 
 
 class TestReader:

--- a/sdmx/tests/reader/test_reader_csv.py
+++ b/sdmx/tests/reader/test_reader_csv.py
@@ -66,7 +66,8 @@ class TestReader:
         ],
     )
     def test_handles_media_type(self, mt, expected) -> None:
-        assert expected is Reader.handles_media_type(mt)
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert expected is Reader.handles_media_type(mt)
 
     @pytest.mark.parametrize(
         "content, exc_text",
@@ -77,11 +78,12 @@ class TestReader:
     )
     def test_inspect_header0(self, content, exc_text) -> None:
         with pytest.raises(ValueError, match=f"Invalid SDMX-CSV 2.0.0: {exc_text}"):
-            Reader().read_message(BytesIO(content))
+            Reader().convert(BytesIO(content))
 
     @pytest.mark.parametrize("value, expected", [(".csv", True), (".xlsx", False)])
     def test_supports_suffix(self, value, expected) -> None:
-        assert expected is Reader.supports_suffix(value)
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert expected is Reader.supports_suffix(value)
 
 
 @lru_cache
@@ -110,7 +112,7 @@ def get_dfd(n_measure: int = 1) -> "v30.Dataflow":
 
 
 @pytest.mark.parametrize_specimens("path", format="csv")
-def test_read_specimen(path):
+def test_read_specimen(path) -> None:
     """Test that the samples from the SDMX-CSV spec can be read."""
     import sdmx
 
@@ -119,7 +121,7 @@ def test_read_specimen(path):
     else:
         dfd = get_dfd()
 
-    kwargs = dict(structure=dfd)
+    kwargs: dict = dict(structure=dfd)
 
     if path.stem == "example-04":
         kwargs.update(delimiter=";")

--- a/sdmx/tests/reader/test_reader_json.py
+++ b/sdmx/tests/reader/test_reader_json.py
@@ -1,6 +1,13 @@
 import pytest
 
 import sdmx
+from sdmx.reader.json import Reader
+
+
+class TestReader:
+    def test_deprecated_detect(self) -> None:
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert True is Reader.detect(b"{")
 
 
 @pytest.mark.parametrize_specimens("path", format="json")

--- a/sdmx/tests/reader/test_reader_xml.py
+++ b/sdmx/tests/reader/test_reader_xml.py
@@ -2,6 +2,13 @@ import pytest
 
 import sdmx
 from sdmx.message import Message
+from sdmx.reader import xml
+
+
+class TestReader:
+    def test_deprecated_detect(self) -> None:
+        with pytest.warns(DeprecationWarning, match="use Converter.handles"):
+            assert True is xml.Reader.detect(b"<")
 
 
 @pytest.mark.parametrize_specimens("path", format="xml")

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -34,11 +34,7 @@ def test_read_sdmx(tmp_path, specimen):
 
     # Exception raised when the file contents don't allow to guess the format
     bad_file = BytesIO(b"#! neither XML nor JSON")
-    exc = (
-        "cannot infer SDMX message format from path None, format={}, or content "
-        "'#! ne..'"
-    )
-    with pytest.raises(RuntimeError, match=exc.format("None")):
+    with pytest.raises(RuntimeError, match="cannot infer SDMX message format from "):
         sdmx.read_sdmx(bad_file)
 
     # Using the format= argument forces a certain reader to be used

--- a/sdmx/tests/test_reader.py
+++ b/sdmx/tests/test_reader.py
@@ -2,7 +2,37 @@ import re
 
 import pytest
 
-from sdmx.reader import get_reader_for_media_type
+from sdmx import to_sdmx
+from sdmx.reader import (
+    detect_content_reader,
+    get_reader_for_media_type,
+    get_reader_for_path,
+    json,
+)
+from sdmx.reader.base import BaseReader, Converter
+
+
+class TestConverter:
+    def test_handles(self) -> None:
+        assert False is Converter.handles({}, {})
+
+    def test_convert(self) -> None:
+        with pytest.raises(NotImplementedError):
+            Converter().convert({})
+
+
+class TestBaseReader:
+    def test_deprecated_read_message(self) -> None:
+        with (
+            pytest.raises(NotImplementedError),
+            pytest.warns(DeprecationWarning, match="use Converter.convert"),
+        ):
+            BaseReader().read_message({})
+
+
+def test_deprecated_detect_content_reader() -> None:
+    with pytest.warns(DeprecationWarning, match=r"use get_reader\(\) instead"):
+        assert json.Reader is detect_content_reader(b"{")
 
 
 @pytest.mark.parametrize(
@@ -11,9 +41,12 @@ from sdmx.reader import get_reader_for_media_type
         "application/x-pdf",
     ],
 )
-def test_get_reader_for_media_type0(value):
-    with pytest.raises(
-        ValueError, match=re.escape(f"Media type {value!r} not supported by any of")
+def test_deprecated_get_reader_for_media_type0(value):
+    with (
+        pytest.raises(
+            ValueError, match=re.escape(f"Media type {value!r} not supported by any of")
+        ),
+        pytest.warns(DeprecationWarning, match=r"use get_reader\(requests.Response"),
     ):
         get_reader_for_media_type(value)
 
@@ -26,6 +59,24 @@ def test_get_reader_for_media_type0(value):
         "draft-sdmx-json;charset=UTF-8",
     ],
 )
-def test_get_reader_for_media_type1(value):
-    # Does not raise
-    get_reader_for_media_type(value)
+def test_deprecated_get_reader_for_media_type1(value):
+    with pytest.warns(DeprecationWarning, match=r"use get_reader\(requests.Response"):
+        # Does not raise
+        get_reader_for_media_type(value)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "example.json",
+        pytest.param("example.badsuffix", marks=pytest.mark.xfail(raises=ValueError)),
+    ),
+)
+def test_deprecated_get_reader_for_path(path):
+    with pytest.warns(DeprecationWarning, match=r"use get_reader\(\) instead"):
+        assert json.Reader is get_reader_for_path(path)
+
+
+def test_to_sdmx():
+    with pytest.raises(NotImplementedError, match="Convert <class 'dict"):
+        to_sdmx(dict())


### PR DESCRIPTION
Additions in #201/v2.19.0 allowed to read SDMX-CSV from files or streams. This is strictly what is specified by the SDMX-CSV standard.This PR extends to allow converting SDMX-CSV-*like* content in a pandas data frame using the same core features.

This is **non-standard**: the SDMX standards don't say anything about in-memory representations, so a pd.DataFrame *per se* is not and can not be SDMX-CSV; only a file that conforms to the standard. However, pandas is widely used and we already have a [HOWTO for doing such conversion manually](https://sdmx1.readthedocs.io/en/latest/howto/create.html). This PR is one step towards making this process easier. 

Some internal changes:
- A new class `Converter` with a simple API of two methods.
- A new to-level to_sdmx() method that allows to invoke Converters.
- `BaseReader` is a sub-class of Converter: specifically, a Converter that can handle the SDMX standard formats.
- `BaseReader.handles()` absorbs content-matching logic that was previously spread across multiple functions, class methods, and class properties.
- `.reader` utility functions detect_content_reader(), get_reader_for_media_type(), and get_reader_for_path() are deprecated in favour of unified get_reader() and get_converter().

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
