### PR TITLE
Address CI failures

### DIFF
--- a/.github/workflows/sources.yaml
+++ b/.github/workflows/sources.yaml
@@ -81,7 +81,7 @@ jobs:
       env:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: |
-        uv run \
+        uv run --no-sync \
           pytest -m network --regex '.*Test${{ matrix.source }}:' \
           --color=yes --durations=30 -rA --verbose \
           --cov-report=xml \
@@ -124,7 +124,9 @@ jobs:
         merge-multiple: true
 
     - name: Compile report
-      run: python -m sdmx.testing.report
+      run: |
+        uv run --no-sync \
+          python -m sdmx.testing.report
 
     - name: Upload report as a pages artifact
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/sources.yaml
+++ b/.github/workflows/sources.yaml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  python-version: 3.13
+
 jobs:
   source:
     runs-on: ubuntu-latest
@@ -70,7 +73,7 @@ jobs:
 
     - name: Install Python, the package, and dependencies
       run: |
-        uv venv --python=${{ matrix.python-version }}
+        uv venv --python=${{ env.python-version }}
         uv pip install .[tests] pytest-regex
 
     - name: Tests of ${{ matrix.source }} data source
@@ -110,7 +113,7 @@ jobs:
 
     - name: Install Python, the package, and dependencies
       run: |
-        uv venv --python=${{ matrix.python-version }}
+        uv venv --python=${{ env.python-version }}
         uv pip install .[tests] pytest-regex
 
     - name: Download artifacts

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -472,6 +472,13 @@ class TestISTAT(DataSourceTest):
             log.info(f"Known, sporadic {e!r}")
             pass
 
+    @pytest.mark.xfail(
+        raises=HTTPError,
+        reason="""As of 2024-12-23, returns a 404 but also a text/plain message: «Error
+        while retrieving Mappings from "Mapping Store"! Cause:Dataflow
+        'urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=IT1:22_289(1.0)' doesn't
+        contain a mapping set»""",
+    )
     @pytest.mark.network
     def test_gh_104(self, client):
         """Test of https://github.com/khaeru/sdmx/issues/104.


### PR DESCRIPTION
1. In the "pytest" workflow, `TestISTAT.test_gh_104()`: the query of https://esploradati.istat.it/SDMXWS/rest/data/22_289/.IT..1+2.TOTAL.99 is returning a 404 error with the text/plain content:

   > Error while retrieving Mappings from "Mapping Store"! Cause:Dataflow 'urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=IT1:22_289(1.0)' doesn't contain a mapping set

   Despite the response code, this appears to be more of a 500 Internal Server Error → **mark as Xfail**
2. In the "sources" CI workflow, the "collect" job was not correctly updated in #215 to use `uv run python …`.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, CI changes only
- ~Update doc/whatsnew.rst~
