### PR TITLE
Use `uv` in first-party "publish" CI workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,15 @@
 name: Build package / publish
 
 on:
-  pull_request:  # Check that package can be built even on PRs
+  # On PR commits, check build completes w/o error.
+  pull_request:
     branches: [ main ]
   push:
     branches: [ main ]
+    # Publish on any push of a new tag, including
+    # 'v*rc*' pushed to a PR branch.
     tags: [ "v*" ]
+  # Publish on new releases.
   release:
     types: [ published ]
 
@@ -15,7 +19,40 @@ concurrency:
 
 jobs:
   publish:
-    uses: iiasa/actions/.github/workflows/publish.yaml@main
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+    environment:
+      name: publish
+
+    permissions:
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      # On 'pull_request' and some 'push' events,
+      # setuptools-scm or versioningit will give
+      # '0.1.dev1'. To confirm that the build system
+      # generates the desired version string,
+      # uncomment these lines and adjust fetch-depth.
+      # with:
+      #   fetch-depth: 10
+      #   fetch-tags: true
+
+    - uses: astral-sh/setup-uv@v5
+      with:
+        cache-dependency-glob: "**/pyproject.toml"
+        python-version: "3.13"
+
+    - name: Build
+      run: uv build
+
+    - name: Publish
+      if: >-
+        github.event_name == 'release' || (
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+        )
+      # Uncomment for testing
+      # env:
+      #   UV_PUBLISH_URL: https://test.pypi.org/legacy/
+      run: uv publish --trusted-publishing=always

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["build", "setuptools-scm"]
+requires = ["hatchling", "versioningit"]
+build-backend = "hatchling.build"
 
 [project]
 name = "sdmx1"
@@ -69,6 +70,10 @@ exclude_also = [
   "if TYPE_CHECKING:",
 ]
 
+[tool.hatch]
+build.targets.wheel.packages = ["sdmx"]
+version.source = "versioningit"
+
 [tool.mypy]
 files = [
   "conftest.py",
@@ -108,8 +113,5 @@ ignore = ["E501", "W191"]
 # - .writer.pandas.write_dataset: 12
 mccabe.max-complexity = 10
 
-[tool.setuptools.packages]
-find = {}
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"
+[tool.versioningit]
+default-version = "0.1.dev1"  # Match setuptools-scm


### PR DESCRIPTION
Drop use of reusable workflow from iiasa/actions. Reusable workflows are not supported by pypa/gh-action-pypi-publish, and it does not seem likely that support is coming.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, CI changes only
- ~Update doc/whatsnew.rst~
