### PR TITLE
Don't write invalid ref in <str:Categorisation>

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,10 +3,14 @@
 What's new?
 ***********
 
-.. _2.21.0:
+.. _2.21.1:
 
-.. Next release
-.. ============
+Next release
+============
+
+- Bug fix for writing :xml:`<str:Categorisation>` to SDMX-ML: invalid input SDMX-ML with non-standard classes tolerated in v2.21.0 (:pull:`218`) could not be round-tripped back to file (:pull:`221`).
+
+.. _2.21.0:
 
 v2.21.0 (2025-01-13)
 ====================

--- a/sdmx/tests/writer/test_writer_xml.py
+++ b/sdmx/tests/writer/test_writer_xml.py
@@ -318,6 +318,7 @@ def test_data_roundtrip(pytestconfig, specimen, data_id, structure_id, tmp_path)
 @pytest.mark.parametrize(
     "specimen_id, strict",
     [
+        ("BIS/gh-180.xml", False),
         ("ECB/orgscheme.xml", True),
         ("ECB_EXR/1/structure-full.xml", False),
         ("ESTAT/apro_mk_cola-structure.xml", True),

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -480,11 +480,14 @@ def _cl(obj: model.ComponentList, *args):
 
 @writer
 def _cat(obj: model.Categorisation):
-    return maintainable(
-        obj,
-        reference(obj.artefact, tag="str:Source", style="Ref"),
-        reference(obj.category, tag="str:Target", style="Ref"),
-    )
+    elem = maintainable(obj)
+    # If .reader.xml.v21._ref did not resolve a ref while reading (e.g. ref to a non-
+    # standard class like PublicationTable), this may be a dict → don't write. Generates
+    # XSD-invalid SDMX-ML; but occurs only when the input SDMX-ML was invalid anyway.
+    if isinstance(obj.artefact, common.IdentifiableArtefact):
+        elem.append(reference(obj.artefact, tag="str:Source", style="Ref"))
+    elem.append(reference(obj.category, tag="str:Target", style="Ref"))
+    return elem
 
 
 # §10.3: Constraints


### PR DESCRIPTION
Follows fix for #180 in #218. Without this, errors occur like:
```
  File "/home/runner/work/dsss/dsss/.venv/lib/python3.13/site-packages/sdmx/writer/xml.py", line 485, in _cat
    reference(obj.artefact, tag="str:Source", style="Ref"),
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/dsss/dsss/.venv/lib/python3.13/site-packages/sdmx/writer/xml.py", line 74, in reference
    attrib = dict(id=obj.id)
                     ^^^^^^
AttributeError: 'dict' object has no attribute 'id'
```

Also:
- Add a test, since this was only picked up in [`dsss` CI runs](https://github.com/khaeru/dsss/actions/runs/12761441370/job/35568456113).
- Following on #217, do not actually `_extract_zipball()` if the destination directory already exists. This avoids collisions that occur sporadically on GitHub Actions Windows runners with `pytest-xdist`.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A; bug fix.
- [x] Update doc/whatsnew.rst
