### PR TITLE
Adjust expectation for test_request_preview_data()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.13.0
+  rev: v1.16.1
   hooks:
   - id: mypy
     pass_filenames: false
@@ -16,8 +16,8 @@ repos:
     - types-PyYAML
     - types-requests
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.11.13
   hooks:
-  - id: ruff
+  - id: ruff-check
   - id: ruff-format
     args: [ --check ]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3"
+    python: "3.13"
 
 python:
   install:

--- a/README.rst
+++ b/README.rst
@@ -21,15 +21,19 @@ sdmx: Statistical data and metadata exchange
 `Source code @ Github <https://github.com/khaeru/sdmx/>`_ —
 `Authors <https://github.com/khaeru/sdmx/graphs/contributors>`_
 
-``sdmx`` (`‘sdmx1’ on PyPI <https://pypi.org/project/sdmx1>`_) is a Python implementation of the `SDMX <http://www.sdmx.org>`_ 2.1 (`ISO 17369:2013 <https://www.iso.org/standard/52500.html>`_) and 3.0 standards for **statistical data and metadata exchange**.
+``sdmx`` (`‘sdmx1’ on PyPI <https://pypi.org/project/sdmx1>`_) is a Python implementation
+of the `SDMX <http://www.sdmx.org>`_ 2.1 (`ISO 17369:2013 <https://www.iso.org/standard/52500.html>`_) and 3.0 standards
+for **statistical data and metadata exchange**.
 The SDMX standards are developed and used by national statistical agencies, central banks, and international organisations.
 
 ``sdmx`` can be used to:
 
-- Explore and retrieve data available from SDMX-REST `web services <https://sdmx1.rtfd.io/en/latest/sources.html>`_ operated by providers including the World Bank, International Monetary Fund, Eurostat, OECD, and United Nations;
+- Explore and retrieve data available from SDMX-REST `web services <https://sdmx1.rtfd.io/en/latest/sources.html>`_
+  operated by providers including the World Bank, International Monetary Fund, Eurostat, OECD, and United Nations;
 - Read and write data and metadata in file formats including SDMX-ML (XML), SDMX-JSON, and SDMX-CSV;
-- Convert data and metadata into `pandas <https://pandas.pydata.org>`_ objects, for use with the analysis, plotting, and other tools in the Python data science ecosystem;
-- Apply the `SDMX information model <https://sdmx1.rtfd.io/en/latest/api.rst#api-model>`_ to structure and publish your own data;
+- Convert data and metadata into `pandas <https://pandas.pydata.org>`_ objects,
+  for use with the analysis, plotting, and other tools in the Python data science ecosystem;
+- Apply the `SDMX information model <https://sdmx1.rtfd.io/en/latest/implementation.html#im>`_ to structure and publish your own data;
 
 …and much more.
 
@@ -37,7 +41,8 @@ The SDMX standards are developed and used by national statistical agencies, cent
 Documentation
 -------------
 
-See https://sdmx1.readthedocs.io/en/latest/ for the latest docs per the ``main`` branch, or https://sdmx1.readthedocs.io/en/stable/ for the most recent release.
+See https://sdmx1.readthedocs.io/en/latest/ for the latest docs per the ``main`` branch,
+or https://sdmx1.readthedocs.io/en/stable/ for the most recent release.
 
 
 License
@@ -45,13 +50,16 @@ License
 
 Copyright 2014–2025, `sdmx1 developers <https://github.com/khaeru/sdmx/graphs/contributors>`_
 
-Licensed under the Apache License, Version 2.0 (the “License”); you may not use these files except in compliance with the License.
+Licensed under the Apache License, Version 2.0 (the “License”);
+you may not use these files except in compliance with the License.
 You may obtain a copy of the License:
 
 - from the file LICENSE included with the source code, or
 - at http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 
 

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -31,7 +31,7 @@ and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    for cl in "ESTAT:AGE(11.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(59.0)":
+    for cl in "ESTAT:AGE(11.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(61.0)":
         print(sdmx.to_pandas(sm.get(cl)))
 
 Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,10 +3,12 @@
 What's new?
 ***********
 
-.. _2.22.0:
+Next release
+============
 
-.. Next release
-.. ============
+- Correct a broken link to :ref:`im` in the README (:pull:`233`; thanks :gh-user:`econometricsfanboy` for :issue:`232`).
+
+.. _2.22.0:
 
 v2.22.0 (2025-03-25)
 ====================

--- a/sdmx/client.py
+++ b/sdmx/client.py
@@ -247,7 +247,7 @@ class Client:
             "get", url.join(with_query=False), params=url.query, headers=headers
         )
 
-    def _request_from_url(self, kwargs):
+    def _request_from_url(self, kwargs) -> "requests.Request":
         url = kwargs.pop("url")
         parameters = kwargs.pop("params", {})
         headers = kwargs.pop("headers", {})
@@ -455,26 +455,26 @@ class Client:
         else:
             req = self._request_from_args(kwargs)
 
-        req = self.session.prepare_request(req)
+        req_prepared = self.session.prepare_request(req)
 
         # Now get the SDMX message via HTTP
-        log.info(f"Request {req.url}")
-        log.info(f"with headers {req.headers}")
+        log.info(f"Request {req_prepared.url}")
+        log.info(f"with headers {req_prepared.headers}")
 
         # Try to get resource from memory cache if specified
-        if use_cache:
+        if use_cache and req_prepared.url:
             try:
-                return self.cache[req.url]
+                return self.cache[req_prepared.url]
             except KeyError:
                 log.info("Not found in cache")
                 pass
 
         if dry_run:
-            return req
+            return req_prepared  # type: ignore [return-value]
 
         try:
             # Send the request
-            response = self.session.send(req, **self._send_kwargs)
+            response = self.session.send(req_prepared, **self._send_kwargs)
             response.raise_for_status()
         except requests.exceptions.ConnectionError as e:
             raise e from None

--- a/sdmx/model/v30.py
+++ b/sdmx/model/v30.py
@@ -236,7 +236,8 @@ class SelectionValue(common.BaseSelectionValue):
     valid_to: Optional[str] = None
 
 
-class MemberValue(common.BaseMemberValue, SelectionValue):
+@dataclass
+class MemberValue(SelectionValue, common.BaseMemberValue):
     """SDMX 3.0 MemberValue."""
 
 
@@ -244,12 +245,14 @@ class TimeRangeValue(SelectionValue):
     """SDMX 3.0 TimeRangeValue."""
 
 
+@dataclass
 class BeforePeriod(TimeRangeValue, common.Period):
-    pass
+    """SDMX 3.0 BeforePeriod."""
 
 
+@dataclass
 class AfterPeriod(TimeRangeValue, common.Period):
-    pass
+    """SDMX 3.0 AfterPeriod."""
 
 
 @dataclass

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from collections import ChainMap
+from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
@@ -321,7 +322,7 @@ def test_data_path(pytestconfig):
 
 
 @pytest.fixture(scope="class")
-def testsource(pytestconfig):
+def testsource(pytestconfig) -> Generator[str, None, None]:
     """Fixture: the :attr:`.Source.id` of a temporary data source."""
     from sdmx.source import sources
 

--- a/sdmx/testing/data.py
+++ b/sdmx/testing/data.py
@@ -9,8 +9,7 @@ import platformdirs
 import pytest
 
 if TYPE_CHECKING:
-    from requests_cache import CachedSession
-
+    from sdmx.session import Session
     from sdmx.source import Source
 
 log = logging.getLogger(__name__)
@@ -203,9 +202,7 @@ class SpecimenCollection:
         metafunc.parametrize(mark.args[0], self.as_params(**mark.kwargs))
 
 
-def add_responses(
-    session: "CachedSession", file_cache_path: Path, source: "Source"
-) -> None:
+def add_responses(session: "Session", file_cache_path: Path, source: "Source") -> None:
     """Populate cached responses for `session`.
 
     Two sources are used:

--- a/sdmx/tests/model/test_v21.py
+++ b/sdmx/tests/model/test_v21.py
@@ -767,6 +767,7 @@ class TestHierarchicalCodelist:
         # The code has a child associated with a different code list
         c3 = c2.child[0]
         assert "6J" == c3.code
+        assert c3.code and c3.code.parent and c3.code.parent.urn
         assert c3.code.parent.urn.endswith("Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)")
 
     def test_repr(self, obj: model.HierarchicalCodelist):

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -2,16 +2,25 @@ import json
 import logging
 import re
 from io import BytesIO
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
-from requests import HTTPError
+from requests import HTTPError, PreparedRequest
 
 import sdmx
 from sdmx.util.requests import save_response
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def test_deprecated_request(caplog):
+    from requests import Session
+
+    from sdmx import Client
+    from sdmx.testing.data import SpecimenCollection
+
+
+def test_deprecated_request(caplog) -> None:
     message = "Request class will be removed in v3.0; use Client(…)"
     with pytest.warns(DeprecationWarning, match=re.escape(message)):
         sdmx.Request("ECB")
@@ -19,7 +28,7 @@ def test_deprecated_request(caplog):
     assert caplog.record_tuples == [("sdmx.client", logging.WARNING, message)]
 
 
-def test_read_sdmx(tmp_path, specimen):
+def test_read_sdmx(tmp_path: "Path", specimen: "SpecimenCollection") -> None:
     # Copy the file to a temporary file with an urecognizable suffix
     target = tmp_path / "foo.badsuffix"
     with specimen("flat.json", opened=False) as original:
@@ -44,11 +53,13 @@ def test_read_sdmx(tmp_path, specimen):
 
 class TestClient:
     @pytest.fixture
-    def client(self, testsource, session_with_stored_responses):
+    def client(
+        self, testsource: str, session_with_stored_responses: "Session"
+    ) -> "Client":
         """A :class:`Client` connected to a non-existent test source."""
         return sdmx.Client(testsource, session=session_with_stored_responses)
 
-    def test_init(self):
+    def test_init(self) -> None:
         with pytest.warns(
             DeprecationWarning, match=re.escape("Client(…, log_level=…) parameter")
         ):
@@ -59,10 +70,12 @@ class TestClient:
             sdmx.Client("noagency")
 
     # Regular methods
-    def test_clear_cache(self, client):
+    def test_clear_cache(self, client: "Client") -> None:
         client.clear_cache()
 
-    def test_session_attrs0(self, caplog, client):
+    def test_session_attrs0(
+        self, caplog: "pytest.LogCaptureFixture", client: "Client"
+    ) -> None:
         # Deprecated attributes
         with pytest.warns(DeprecationWarning, match="Setting Client.timeout"):
             client.timeout = 300
@@ -96,11 +109,13 @@ class TestClient:
             "{'allow_redirects': False}" in caplog.messages
         )
 
-    def test_session_attrs1(self, testsource, session_with_stored_responses):
+    def test_session_attrs1(
+        self, testsource: str, session_with_stored_responses: "Session"
+    ) -> None:
         with pytest.raises(ValueError):
             sdmx.Client(testsource, session=session_with_stored_responses, verify=False)
 
-    def test_dir(self, client):
+    def test_dir(self, client: "Client") -> None:
         """dir() includes convenience methods for resource endpoints."""
         expected = {
             "cache",
@@ -115,28 +130,91 @@ class TestClient:
         expected |= set(ep.name for ep in sdmx.Resource)
         assert set(filter(lambda s: not s.startswith("_"), dir(client))) == expected
 
-    def test_get0(self, client):
+    @pytest.mark.network
+    def test_request_get_args(self) -> None:
+        ESTAT = sdmx.Client("ESTAT")
+
+        # Client._make_key accepts '+'-separated values
+        args = dict(
+            resource_id="UNE_RT_A",
+            key={"geo": "EL+ES+IE"},
+            params={"startPeriod": "2007"},
+            dry_run=True,
+            use_cache=True,
+        )
+        # Store the URL
+        url = ESTAT.data(**args).url
+
+        # Using an iterable of key values gives the same URL
+        args["key"] = {"geo": ["EL", "ES", "IE"]}
+        assert ESTAT.data(**args).url == url
+
+        # Using a direct string for a key gives the same URL
+        args["key"] = "....EL+ES+IE"  # No specified values for first 4 dimensions
+        assert ESTAT.data(**args).url == url
+
+        # Giving 'provider' is redundant for a data request, causes a warning
+        with pytest.warns(UserWarning, match="'agency_id' argument is redundant"):
+            ESTAT.data(
+                "UNE_RT_A",
+                key={"geo": "EL+ES+IE"},
+                params={"startPeriod": "2007"},
+                agency_id="ESTAT",
+            )
+
+        # Using an unknown endpoint is an exception
+        with pytest.raises(KeyError):
+            ESTAT.get("badendpoint", "id")
+
+        # TODO test Client.get(obj) with IdentifiableArtefact subclasses
+
+    def test_get0(self, client: "Client") -> None:
         """:meth:`.get` handles mixed query parameters correctly."""
         req = client.get(
             "dataflow", detail="full", params={"references": "none"}, dry_run=True
         )
+        assert isinstance(req, PreparedRequest)
         assert (
             "https://example.com/sdmx-rest/dataflow/TEST/all/latest?detail=full&"
             "references=none" == req.url
         )
 
-    def test_get1(self, client):
+    def test_get1(self, client: "Client") -> None:
         """Exceptions are raised on invalid arguments."""
         # Exception is raised on unrecognized arguments
         exc = "Unexpected/unhandled parameters {'foo': 'bar'}"
         with pytest.raises(ValueError, match=exc):
             client.get("datastructure", foo="bar")
 
-    def test_getattr(self, client):
+    def test_getattr(self, client: "Client") -> None:
         with pytest.raises(AttributeError):
             client.notanendpoint()
 
-    def test_request_from_args(self, caplog, client):
+    # @pytest.mark.skip(reason="Temporarily offline on 2021-03-23")
+    @pytest.mark.network
+    def test_preview_data(self) -> None:
+        ECB = sdmx.Client("ECB")
+
+        # List of keys can be retrieved
+        keys = ECB.preview_data("EXR")
+        assert isinstance(keys, list)
+
+        # Count of keys can be determined
+        assert len(keys) > 1000
+
+        # A filter can be provided, resulting in fewer keys
+        keys = ECB.preview_data("EXR", {"CURRENCY": "CAD+CHF+CNY"})
+        N = 30
+        assert N >= len(keys)
+
+        # Result can be converted to pandas object
+        keys_df = sdmx.to_pandas(keys)
+        assert isinstance(keys_df, pd.DataFrame)
+        assert N >= len(keys_df)
+
+    def test_request_from_args(
+        self, caplog: "pytest.LogCaptureFixture", client: "Client"
+    ) -> None:
         # Raises for invalid resource type
         # TODO Move this test; this error is no longer handled in _request_from_args()
         kwargs = dict(resource_type="foo")
@@ -160,7 +238,7 @@ class TestClient:
 
     # TODO update or remove
     @pytest.mark.xfail(reason="SDMX 3.0.0 is now supported → no exception raised")
-    def test_v3_unsupported(self, client):
+    def test_v3_unsupported(self, client: "Client") -> None:
         """Client raises an exception when an SDMX 3.0 message is returned."""
         df_id, key = "DATAFLOW", ".KEY2.KEY3..KEY5"
 
@@ -181,49 +259,10 @@ class TestClient:
 
 
 @pytest.mark.network
-def test_request_get_args():
-    ESTAT = sdmx.Client("ESTAT")
-
-    # Client._make_key accepts '+'-separated values
-    args = dict(
-        resource_id="UNE_RT_A",
-        key={"geo": "EL+ES+IE"},
-        params={"startPeriod": "2007"},
-        dry_run=True,
-        use_cache=True,
-    )
-    # Store the URL
-    url = ESTAT.data(**args).url
-
-    # Using an iterable of key values gives the same URL
-    args["key"] = {"geo": ["EL", "ES", "IE"]}
-    assert ESTAT.data(**args).url == url
-
-    # Using a direct string for a key gives the same URL
-    args["key"] = "....EL+ES+IE"  # No specified values for first 4 dimensions
-    assert ESTAT.data(**args).url == url
-
-    # Giving 'provider' is redundant for a data request, causes a warning
-    with pytest.warns(UserWarning, match="'agency_id' argument is redundant"):
-        ESTAT.data(
-            "UNE_RT_A",
-            key={"geo": "EL+ES+IE"},
-            params={"startPeriod": "2007"},
-            agency_id="ESTAT",
-        )
-
-    # Using an unknown endpoint is an exception
-    with pytest.raises(KeyError):
-        ESTAT.get("badendpoint", "id")
-
-    # TODO test Client.get(obj) with IdentifiableArtefact subclasses
-
-
-@pytest.mark.network
 @pytest.mark.xfail(
     reason="Flaky; see https://github.com/khaeru/sdmx/issues/148", raises=HTTPError
 )
-def test_read_url0():
+def test_read_url0() -> None:
     """URL can be queried without instantiating Client."""
     sdmx.read_url(
         "https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/latest?"
@@ -231,32 +270,9 @@ def test_read_url0():
     )
 
 
-def test_read_url1():
+def test_read_url1() -> None:
     """Exception is raised on invalid arguments."""
     with pytest.raises(
         ValueError, match=r"{'foo': 'bar'} supplied with get\(url=...\)"
     ):
         sdmx.read_url("https://example.com", foo="bar")
-
-
-# @pytest.mark.skip(reason="Temporarily offline on 2021-03-23")
-@pytest.mark.network
-def test_request_preview_data() -> None:
-    ECB = sdmx.Client("ECB")
-
-    # List of keys can be retrieved
-    keys = ECB.preview_data("EXR")
-    assert isinstance(keys, list)
-
-    # Count of keys can be determined
-    assert len(keys) > 1000
-
-    # A filter can be provided, resulting in fewer keys
-    keys = ECB.preview_data("EXR", {"CURRENCY": "CAD+CHF+CNY"})
-    N = 30
-    assert N >= len(keys)
-
-    # Result can be converted to pandas object
-    keys_df = sdmx.to_pandas(keys)
-    assert isinstance(keys_df, pd.DataFrame)
-    assert N >= len(keys_df)

--- a/sdmx/tests/test_client.py
+++ b/sdmx/tests/test_client.py
@@ -241,7 +241,7 @@ def test_read_url1():
 
 # @pytest.mark.skip(reason="Temporarily offline on 2021-03-23")
 @pytest.mark.network
-def test_request_preview_data():
+def test_request_preview_data() -> None:
     ECB = sdmx.Client("ECB")
 
     # List of keys can be retrieved
@@ -253,9 +253,10 @@ def test_request_preview_data():
 
     # A filter can be provided, resulting in fewer keys
     keys = ECB.preview_data("EXR", {"CURRENCY": "CAD+CHF+CNY"})
-    assert len(keys) == 24
+    N = 30
+    assert N >= len(keys)
 
     # Result can be converted to pandas object
-    keys_pd = sdmx.to_pandas(keys)
-    assert isinstance(keys_pd, pd.DataFrame)
-    assert len(keys_pd) == 24
+    keys_df = sdmx.to_pandas(keys)
+    assert isinstance(keys_df, pd.DataFrame)
+    assert N >= len(keys_df)

--- a/sdmx/tests/test_dataset.py
+++ b/sdmx/tests/test_dataset.py
@@ -218,9 +218,7 @@ class TestGenericSeriesData_SiblingGroup_TS(DataMessageTest):
         # GroupKeys can be retrieved from keys of DataSet.group
         g2_key, g2 = list(data.group.items())[2]
         assert g2_key.CURRENCY == "JPY"
-        assert g2[0].attrib.TITLE == (
-            "ECB reference exchange rate, Japanese " "yen/Euro"
-        )
+        assert g2[0].attrib.TITLE == ("ECB reference exchange rate, Japanese yen/Euro")
 
         # Check group attributes of a series
         s = list(data.series)[0]
@@ -241,7 +239,7 @@ class TestGenericSeriesData_RateGroup_TS(DataMessageTest):
         g2_key, g2 = list(data.group.items())[2]
         assert g2_key.CURRENCY == "GBP"
         assert g2_key.attrib.TITLE == (
-            "ECB reference exchange rate, U.K. " "Pound sterling /Euro"
+            "ECB reference exchange rate, U.K. Pound sterling /Euro"
         )
         # Check group attributes of a series
         s = list(data.series)[0]


### PR DESCRIPTION
Around 2025-10-09, data returned by the ECB data source changed, causing one test to fail. Compare [A](https://github.com/khaeru/sdmx/actions/runs/15515080699) versus [B](https://github.com/khaeru/sdmx/actions/runs/15527164513/job/43708946215#step:5:1987). Specifically, series keys returned by the query https://data-api.ecb.europa.eu/service/data/EXR?detail=serieskeysonly changed, such that the number of keys matching a particular filter increased from 24 to 30:

```
        # A filter can be provided, resulting in fewer keys
        keys = ECB.preview_data("EXR", {"CURRENCY": "CAD+CHF+CNY"})
>       assert len(keys) == 24
E       assert 30 == 24
E        +  where 30 = len([<SeriesKey: FREQ=A, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=SP00, EXR_SUFFIX=A>, <SeriesKey: FREQ=Q, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=SP00, EXR_SUFFIX=A>, <SeriesKey: FREQ=H, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=SP00, EXR_SUFFIX=A>, <SeriesKey: FREQ=M, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=SP00, EXR_SUFFIX=A>, <SeriesKey: FREQ=D, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=SP00, EXR_SUFFIX=A>, <SeriesKey: FREQ=Q, CURRENCY=CAD, CURRENCY_DENOM=EUR, EXR_TYPE=BRC0, EXR_SUFFIX=A>, ...])
```

This PR adjusts.

Also:
- [x] Organize and type hint tests in the one module.
- [x] #232.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation.
- [x] Update doc/whatsnew.rst
