### PR TITLE
Address flaky TestILO.test_gh_96()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 # Development and build files
 .benchmarks
 .coverage*
+.dmypy*
 .mypy_cache
 .pytest_cache
 .ruff_cache

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,7 @@ Next release
   with lxml version 6.0.0 (`released 2025-06-26 <https://lxml.de/6.0/changes-6.0.0.html>`__)
   for SDMX-ML messages containing XHTML values.
 - Correct a broken link to :ref:`im` in the README (:pull:`233`; thanks :gh-user:`econometricsfanboy` for :issue:`232`).
+- Update the base URL of the :ref:`ILO <ILO>` source to use HTTPS instead of plain HTTP (:pull:`237`).
 
 .. _2.22.0:
 

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -199,7 +199,7 @@
   {
     "id": "ILO",
     "name": "International Labor Organization",
-    "url": "http://sdmx.ilo.org/rest",
+    "url": "https://sdmx.ilo.org/rest",
     "headers": {
       "data": {
         "Accept": "application/vnd.sdmx.structurespecificdata+xml;version=2.1"

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -348,13 +348,13 @@ class TestILO(DataSourceTest):
         "structureset": NotImplementedError,  # 501
     }
 
-    @pytest.mark.network
-    def test_gh_96(self, caplog, client):
+    def test_gh_96(self, caplog, client_with_stored_responses) -> None:
         """Test of https://github.com/khaeru/sdmx/issues/96.
 
         As of 2024-02-13, the web service no longer has the prior limitations on
         the `references` query parameter, so the special handling is removed.
         """
+        client = client_with_stored_responses
         client.get("codelist", "CL_ECO", params=dict(references="parentsandsiblings"))
 
         # As of 2024-02-13, no longer needed


### PR DESCRIPTION
TestILO.test_gh_96() is flaky, as the server often returns 503 Server Error, leading to failure of 1 or more jobs in the daily scheduled CI run. To avoid this, use a stored response via sdmx-test-data instead of making an actual/network query. The test no longer hinges on the exact performance of a 'live' server.

Also:
- Change the default base URL for the ILO source to use `https://` instead of `http://`.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, test changes only.
- [x] Update doc/whatsnew.rst
