### PR TITLE
Adjust for packaging v26, pandas v3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       # On 'pull_request' and some 'push' events,
       # setuptools-scm or versioningit will give
       # '0.1.dev1'. To confirm that the build system
@@ -38,10 +38,8 @@ jobs:
       #   fetch-depth: 10
       #   fetch-tags: true
 
-    - uses: astral-sh/setup-uv@v5
-      with:
-        cache-dependency-glob: "**/pyproject.toml"
-        python-version: "3.13"
+    - uses: astral-sh/setup-uv@v7
+      with: { python-version: "3.14" }
 
     - name: Build
       run: uv build

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -36,12 +36,12 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
-        cache-dependency-glob: "**/pyproject.toml"
+        activate-environment: true
         python-version: ${{ matrix.python-version }}
 
     - name: Install the package and dependencies
@@ -66,13 +66,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v5
-      with:
-        cache-dependency-glob: "**/pyproject.toml"
-        # TEMPORARY Use Python 3.12 to avoid https://github.com/python/mypy/issues/18216
-        python-version: "3.12"
-    - uses: actions/cache@v4
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with: { python-version: "3.14" }
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/pre-commit
         key: ${{ github.job }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/sources.yaml
+++ b/.github/workflows/sources.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  python-version: 3.13
+  python-version: 3.14
 
 jobs:
   source:
@@ -63,12 +63,12 @@ jobs:
     name: ${{ matrix.source }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
-        cache-dependency-glob: "**/pyproject.toml"
+        activate-enviroment: true
         python-version: ${{ env.python-version }}
 
     - name: Install the package and dependencies
@@ -85,7 +85,7 @@ jobs:
           --numprocesses=auto
 
     - name: Upload ${{ matrix.source }} results as a build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: source-tests-${{ matrix.source }}
         path: source-tests/*.json
@@ -100,19 +100,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
-        cache-dependency-glob: "**/pyproject.toml"
+        activate-environment: true
         python-version: ${{ env.python-version }}
 
     - name: Install the package and dependencies
       run: uv pip install .[tests]
 
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         path: source-tests
         pattern: source-tests-*
@@ -122,7 +122,7 @@ jobs:
       run: uv run --no-sync python -m sdmx.testing.report
 
     - name: Upload report as a pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with: { path: source-tests }
 
   # This job is as described at https://github.com/actions/deploy-pages

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -31,7 +31,7 @@ and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(69.0)":
+    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(69.1)":
         print(sdmx.to_pandas(sm.get(cl)))
 
 Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,13 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- :mod:`sdmx` is tested and compatible with `pandas version 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
+  released 2026-01-21 (:pull:`268`).
+- :mod:`sdmx` is compatible with, and requires at minimum `packaging version 26.0 <https://packaging.pypa.io/en/stable/changelog.html>`_,
+  released 2026-01-20 (:pull:`268`).
 
 v2.25.0 (2025-12-24)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "lxml >= 3.6",
+  "packaging >= 26",
   "pandas >= 1.0",
   "platformdirs >= 4.1",
   "python-dateutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
   "filelock",
   "GitPython",
   "Jinja2",
-  "pytest >= 5",
+  "pytest >= 9",
   "pytest-cov",
   "pytest-xdist",
   "pytest-rerunfailures",
@@ -92,17 +92,21 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-addopts = """
-  sdmx
-  --cov sdmx --cov-report=
-  -m "not experimental and not source"
-"""
+[tool.pytest]
+addopts = [
+  "sdmx",
+  "--cov=sdmx",
+  "--cov-report=",
+  "-m not experimental and not source",
+]
 markers = [
   "experimental: test of experimental features",
   "network: tests requiring a network connection",
   "source: slower, network tests of individual SDMX web services",
 ]
+minversion = "9.0"
+strict_config = true
+strict_markers = true
 
 [tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]

--- a/sdmx/convert/pandas.py
+++ b/sdmx/convert/pandas.py
@@ -890,9 +890,7 @@ def convert_itemscheme(c: "PandasConverter", obj: common.ItemScheme):
 
     # Convert to DataFrame
     result: pd.DataFrame | pd.Series = pd.DataFrame.from_dict(
-        items,
-        orient="index",
-        dtype=object,  # type: ignore [arg-type]
+        items, orient="index", dtype=str
     ).rename_axis(obj.id, axis="index")
 
     if len(result) and not result["parent"].str.len().any():

--- a/sdmx/model/version.py
+++ b/sdmx/model/version.py
@@ -4,8 +4,12 @@ from collections.abc import Callable
 from dataclasses import InitVar, dataclass, field, replace
 from functools import cache
 from itertools import zip_longest
+from typing import TYPE_CHECKING
 
 import packaging.version
+
+if TYPE_CHECKING:
+    from packaging.version import CmpKey
 
 #: Regular expressions (:class:`re.Pattern`) for version strings.
 #:
@@ -91,6 +95,9 @@ class Version(packaging.version._BaseVersion):
     #: Same as :attr:`packaging.version.Version.local`.
     local: tuple[str | int, ...] = field(default_factory=tuple)
 
+    # Placeholder for comparison key
+    _key: "CmpKey" = field(default_factory=tuple)  # type: ignore [assignment]
+
     def __post_init__(self, value: str | None) -> None:
         # Parse as a SDMX-compatible version
         for kind, pattern in VERSION_PATTERNS.items():
@@ -118,10 +125,10 @@ class Version(packaging.version._BaseVersion):
             # Update fields with the parsed segments and components
             self.epoch = v.epoch
             self.release = v.release
-            self.pre = v._version.pre
-            self.post = v._version.post
-            self.dev = v._version.dev
-            self.local = v._version.local or ()
+            self.pre = v._pre
+            self.post = v._post
+            self.dev = v._dev
+            self.local = v._local or ()
 
         # Set _BaseVersion._key for comparison
         self._key = packaging.version._cmpkey(

--- a/sdmx/tests/convert/test_pandas.py
+++ b/sdmx/tests/convert/test_pandas.py
@@ -2,10 +2,10 @@
 
 from typing import TYPE_CHECKING, cast
 
-import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+from pandas.api.types import is_string_dtype
 from pytest import raises
 
 import sdmx
@@ -199,7 +199,8 @@ def test_data_arguments(specimen) -> None:
 
     # 'dtype=None' prevents conversion of obs_value to numeric type; remains str/object
     result = sdmx.to_pandas(msg, dtype=None)
-    assert np.dtype("O") == result.dtype
+
+    assert is_string_dtype(result)
 
 
 def test_data_decimal() -> None:


### PR DESCRIPTION
Two dependencies had major version releases this week, each of which caused breakage in the code and/or test failures:
- [packaging v26.0](https://packaging.pypa.io/en/stable/changelog.html).
  This caused exceptions like:
  ```
  AttributeError: 'Version' object has no attribute '_key' and no __dict__ for setting new attributes
  ```
- [pandas v3.0.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html)

The PR adjusts.

Also:
- Bump minimum [pytest version to 9.0](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05).
  - Use updated/native TOML configuration format.
  - Add strict_config, strict_markers options.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst
