### PR TITLE
Adjust expectation in test_doc_usage_data()

### DIFF
--- a/.github/workflows/sources.yaml
+++ b/.github/workflows/sources.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Set up uv, Python
       uses: astral-sh/setup-uv@v7
       with:
-        activate-enviroment: true
+        activate-environment: true
         python-version: ${{ env.python-version }}
 
     - name: Install the package and dependencies

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -364,7 +364,8 @@ API documentation `(main) <https://data.imf.org/en/Resource-Pages/IMF-API>`__, `
 ------------------------------------------------------------------
 
 SDMX-ML —
-`Website <https://sdmx.snieg.mx/infrastructure>`__.
+Website (es) `1 <https://sdmx.snieg.mx/infrastructure>`__,
+`2 <https://sdmx.snieg.mx/practice-guide>`__.
 
 - Spanish name: Instituto Nacional de Estadística y Geografía.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,6 +6,8 @@ What's new?
 .. Next release
 .. ============
 
+- Update the base URL of the :ref:`INEGI <INEGI>` source (:pull:`270`).
+
 v2.25.1 (2026-01-23)
 ====================
 

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -267,7 +267,7 @@
   },
   {
     "id": "INEGI",
-    "url": "http://sdmx.snieg.mx/service/rest",
+    "url": "https://sdmx.snieg.mx/servicev6/rest",
     "name": "Instituto Nacional de Estadística y Geografía (MX)",
     "supports": {
       "actualconstraint": false,

--- a/sdmx/tests/test_docs.py
+++ b/sdmx/tests/test_docs.py
@@ -225,15 +225,14 @@ def test_doc_usage_data():
 
     assert type(data) is GenericDataSet
 
-    # This message doesn't explicitly specify the remaining dimensions; unless
-    # they are inferred from the SeriesKeys, then the DimensionDescriptor is
-    # not complete
+    # This message doesn't explicitly specify the remaining dimensions; unless they are
+    # inferred from the SeriesKeys, then the DimensionDescriptor is not complete
     # assert data.structured_by.dimensions[-1] == 'TIME_PERIOD'
     # data.dim_at_obs
 
     series_keys = list(data.series)
 
-    assert len(series_keys) == 22
+    assert 16 <= len(series_keys)
 
     series_keys[5]
 


### PR DESCRIPTION
The number of series keys returned by the target service changed from 22 to 16. This broke the test suite, e.g. [here](https://github.com/khaeru/sdmx/actions/runs/21466589290/job/61829944089#step:5:2414).

The PR adjusts.

Also:
- Correct a typo in the "sources" CI workflow, introduced in #268.
- Update the base URL for the INEGI source.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation.
- [x] Update doc/whatsnew.rst.
