### PR TITLE
Support SDMX-ML 3.x MetadataAttributeUsage

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
       #   fetch-depth: 10
       #   fetch-tags: true
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with: { python-version: "3.14" }
 
     - name: Build

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         python-version: ${{ matrix.python-version }}
@@ -59,7 +59,7 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
 
   pre-commit:
     name: Code quality
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with: { python-version: "3.14" }
     - uses: actions/cache@v5
       with:

--- a/.github/workflows/sources.yaml
+++ b/.github/workflows/sources.yaml
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         python-version: ${{ env.python-version }}
@@ -92,7 +92,7 @@ jobs:
         compression-level: 1
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
 
   collect:
     needs: source
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up uv, Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         python-version: ${{ env.python-version }}
@@ -139,7 +139,7 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5
 
     # Deploy to the gh-pages environment
     environment:

--- a/doc/api/model-v30-list.rst
+++ b/doc/api/model-v30-list.rst
@@ -31,6 +31,7 @@
 :obj:`~.v30.MemberSelection`
 :obj:`~.v30.MemberValue`
 :obj:`~.v30.MetadataAttributeDescriptor`
+:obj:`~.v30.MetadataAttributeUsage`
 :obj:`~.v30.MetadataAttributeValue`
 :obj:`~.v30.MetadataConstraint`
 :obj:`~.v30.MetadataProvider`

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -31,7 +31,7 @@ and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(69.1)":
+    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(72.0)":
         print(sdmx.to_pandas(sm.get(cl)))
 
 Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,11 @@ What's new?
 .. ============
 
 - Update the base URL of the :ref:`INEGI <INEGI>` source (:pull:`270`).
+- Read :xml:`<structure:MetadataAttributeUsage>` from SDMX-ML 3.1 (:issue:`271`, :pull:`275`).
+
+  - New class :class:`.MetadataAttributeUsage`;
+    see its docstring for implementation notes.
+- Add override keyword arguments to :func:`.urn.make` (:pull:`275`).
 
 v2.25.1 (2026-01-23)
 ====================

--- a/sdmx/format/xml/v30.py
+++ b/sdmx/format/xml/v30.py
@@ -14,6 +14,7 @@ FORMAT = XMLFormat(
         ("model.DataSet", "mes:DataSet"),
         ("model.StructureSpecificDataSet", "mes:DataSet"),
         ("model.MetadataAttributeDescriptor", "str:MetadataAttributeList"),
+        ("model.MetadataStructureDefinition", "str:Metadata"),
         ("model.Metadataflow", "str:Metadataflow"),
         ("model.MetadataSet", "mes:MetadataSet"),
     ]

--- a/sdmx/model/common.py
+++ b/sdmx/model/common.py
@@ -1190,11 +1190,21 @@ class GroupRelationship(AttributeRelationship):
     group_key: "GroupDimensionDescriptor | None" = None
 
 
-@dataclass
+@dataclass(repr=False)
 @NameableArtefact._preserve("eq", "hash")
-class DataAttribute(Component):
+class AttributeComponent(Component):
+    """SDMX 3.0 AttributeComponent.
+
+    .. note:: This intermediate, abstract class is not present in the SDMX 2.1 IM.
+    """
+
     #:
     related_to: AttributeRelationship | None = None
+
+
+@dataclass
+@NameableArtefact._preserve("eq", "hash")
+class DataAttribute(AttributeComponent):
     #:
     usage_status: UsageStatus | None = None
     #:
@@ -1976,13 +1986,6 @@ class BaseDataSet(AnnotableArtefact):
 
 
 # §7.3: Metadata Structure Definition
-
-
-class AttributeComponent(Component):
-    """SDMX 3.0 AttributeComponent.
-
-    .. note:: This intermediate, abstract class is not present in the SDMX 2.1 IM.
-    """
 
 
 @dataclass

--- a/sdmx/model/v30.py
+++ b/sdmx/model/v30.py
@@ -393,6 +393,28 @@ class DataStructureDefinition(common.BaseDataStructureDefinition):
     #: A :class:`.MeasureDescriptor`.
     measures: MeasureDescriptor = field(default_factory=MeasureDescriptor)
 
+    #: Association to a :class:`.MetatadatStructureDefinition`.
+    metadata: "MetadataStructureDefinition | None" = None
+
+    def _resolve_references(self) -> None:
+        """Resolve references to :attr:`metadata`."""
+        from sdmx.reader.xml.v30 import MetadataAttributeRef
+
+        if self.metadata is None:
+            return
+
+        # Iterate over components in the AttributeDescriptor that are
+        # MetadataAttributeUsage
+        for component in filter(
+            lambda o: isinstance(o, MetadataAttributeUsage)
+            and isinstance(o.metadata_attribute, MetadataAttributeRef),
+            self.attributes,
+        ):
+            # Resolve a reference to a MetadataAttribute in the MSD
+            mda = self.metadata.attributes.get(component.metadata_attribute.target_id)
+            # Update the component to replace the reference
+            component.metadata_attribute = mda
+
 
 @dataclass(repr=False)
 @IdentifiableArtefact._preserve("hash")
@@ -436,7 +458,7 @@ class IdentifiableObjectSelection:
     """SDMX 3.0 IdentifiableObjectSelection."""
 
 
-@dataclass
+@dataclass(repr=False)
 @MaintainableArtefact._preserve("hash")
 class MetadataStructureDefinition(common.BaseMetadataStructureDefinition):
     """SDMX 3.0 MetadataStructureDefinition."""

--- a/sdmx/model/v30.py
+++ b/sdmx/model/v30.py
@@ -41,6 +41,7 @@ __all__ = [
     "MetadataProviderScheme",
     "Measure",
     "MeasureDescriptor",
+    "MetadataAttributeUsage",
     "DataflowRelationship",
     "MeasureRelationship",
     "ObservationRelationship",
@@ -340,6 +341,24 @@ class MeasureDescriptor(ComponentList[Measure]):
     """
 
     _Component = Measure
+
+
+@dataclass(repr=False)
+@NameableArtefact._preserve("eq", "hash")
+class MetadataAttributeUsage(common.AttributeComponent):
+    """SDMX 3.x MetadataAttributeUsage.
+
+    The existence, name, and attributes of this class are ambiguous in the SDMX IM as
+    of version 3.1. See https://github.com/sdmx-twg/sdmx-im/issues/53 for details. This
+    implementation follows “Interpretation B” recorded there, wherein
+    MetadataAttributeUsage (referer) occurring within the AttributeDescriptor of a
+    DataStructureDefinition is distinct from the referent MetadataAttribute occuring
+    within the MetadataAttributeDescriptor of a MetadataStructureDefinition.
+    """
+
+    #: Association to a MetadataAttribute within a MetadataAttributeDescriptor and
+    #: MetadataStructureDefinition.
+    metadata_attribute: common.MetadataAttribute | None = None
 
 
 class DataflowRelationship(common.AttributeRelationship):

--- a/sdmx/reader/xml/common.py
+++ b/sdmx/reader/xml/common.py
@@ -568,21 +568,22 @@ class XMLEventReader(BaseReader):
             obj.maintainer = maint
 
         # Maybe retrieve an existing object of the same class, ID, and version (if any)
-        existing = self.get_single(cls, obj.id, version=obj.version)
+        for version in (obj.version, None):
+            existing = self.get_single(cls, obj.id, version=version)
+            if existing and (
+                existing.compare(obj, strict=True, log_level=logging.CRITICAL)
+                or match_maintainable_urn_or_version(existing, obj)
+            ):
+                if elem is not None:
+                    # Update `existing` from `obj` to preserve references
+                    # If `existing` was a forward reference <Ref/>, its URN was not stored.
+                    for attr in list(kwargs.keys()) + ["urn"]:
+                        setattr(existing, attr, getattr(obj, attr))
 
-        if existing and (
-            existing.compare(obj, strict=True, log_level=logging.CRITICAL)
-            or (existing.urn or sdmx.urn.make(existing)) == sdmx.urn.make(obj)
-        ):
-            if elem is not None:
-                # Update `existing` from `obj` to preserve references
-                # If `existing` was a forward reference <Ref/>, its URN was not stored.
-                for attr in list(kwargs.keys()) + ["urn"]:
-                    setattr(existing, attr, getattr(obj, attr))
+                # Discard candidate `obj`, return the existing
+                return existing
 
-            # Discard the candidate
-            obj = existing
-        elif obj.is_external_reference:
+        if obj.is_external_reference:
             # A new external reference. Ensure it has a URN.
             obj.urn = obj.urn or sdmx.urn.make(obj)
             # Push onto the stack to be located by next calls
@@ -594,6 +595,16 @@ class XMLEventReader(BaseReader):
 def add_localizations(target: common.InternationalString, values: Sequence) -> None:
     """Add localized strings from *values* to *target*."""
     target.localizations.update({locale: label for locale, label in values})
+
+
+def match_maintainable_urn_or_version(
+    a: common.MaintainableArtefact, b: common.MaintainableArtefact
+) -> bool:
+    """Filter condition for :meth:`XMLEventReader.maintainable`."""
+    urn_b = sdmx.urn.make(b)
+    return ((a.urn or sdmx.urn.make(a)) == urn_b) or (
+        a.version is None and sdmx.urn.make(a, version=b.version) == urn_b
+    )
 
 
 def matching_class(cls):

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -30,7 +30,7 @@ import sdmx.urn
 from sdmx import message
 from sdmx.exceptions import XMLParseError  # noqa: F401
 from sdmx.format import Version
-from sdmx.model import common, v21
+from sdmx.model import common, v21, v30
 from sdmx.tools import dimensions_to_attributes
 
 from .common import (
@@ -319,14 +319,20 @@ def _structures(reader, elem):
     msg = reader.get_single(message.StructureMessage)
 
     # Populate dictionaries by ID
-    for attr, name in msg.iter_collections():
+    for attr, cls in msg.iter_collections():
+        # Target StructureMessage attribute/collection
         target = getattr(msg, attr)
 
+        # Retrieve all objects of cls
+        objects = reader.pop_all(cls, subclass=True)
+
+        if len(objects) and isinstance(objects[0], v30.DataStructureDefinition):
+            # Resolve references to MetadataAttributes
+            for o in objects:
+                o._resolve_references()
+
         # Store using maintainer, ID, and version
-        tmp = {
-            (getattr(obj.maintainer, "id", None), obj.id, obj.version): obj
-            for obj in reader.pop_all(name, subclass=True)
-        }
+        tmp = {(getattr(o.maintainer, "id", None), o.id, o.version): o for o in objects}
 
         # TODO Move this to StructureMessage
         # Construct string IDs
@@ -1051,11 +1057,17 @@ def _structure_start(reader: Reader, elem):
 def _structure_end(reader, elem):
     obj = reader.pop_single("current DSD")
 
-    if obj:
-        # Collect annotations, name, and description
-        obj.annotations = list(reader.pop_all(reader.model.Annotation))
-        add_localizations(obj.name, reader.pop_all("Name"))
-        add_localizations(obj.description, reader.pop_all("Description"))
+    if obj is None:
+        return
+
+    # Collect annotations, name, and description
+    obj.annotations = list(reader.pop_all(reader.model.Annotation))
+    add_localizations(obj.name, reader.pop_all("Name"))
+    add_localizations(obj.description, reader.pop_all("Description"))
+
+    if isinstance(obj, v30.DataStructureDefinition):
+        # Pop and resolve a reference to a MSD
+        obj.metadata = reader.pop_resolved_ref("Metadata")
 
 
 @end("str:Dataflow str:Metadataflow")

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -353,9 +353,9 @@ def _structures(reader, elem):
     com:AnnotationTitle com:AnnotationType com:AnnotationURL com:None com:URN com:Value
     mes:DataSetAction :ReportPeriod md:ReportPeriod mes:DataSetID mes:Email mes:Fax
     mes:ID mes:Telephone mes:Test mes:Timezone mes:URI mes:X400 str:CodelistAliasRef
-    str:DataType str:Email str:Expression str:NullValue str:OperatorDefinition
-    str:PersonalisedName str:Result str:RulesetDefinition str:Telephone str:URI
-    str:VtlDefaultName str:VtlScalarType
+    str:DataType str:Email str:Expression str:MetadataAttributeReference str:NullValue
+    str:OperatorDefinition str:PersonalisedName str:Result str:RulesetDefinition
+    str:Telephone str:URI str:VtlDefaultName str:VtlScalarType
     """
 )
 def _text(reader, elem):

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -395,8 +395,8 @@ def _localization(reader, elem):
     """
     com:Structure com:StructureUsage :ObjectReference md:ObjectReference
     str:AttachmentGroup str:CodeID str:ConceptIdentity str:ConceptRole
-    str:DimensionReference str:Enumeration str:Parent str:Source str:Structure
-    str:StructureUsage str:Target
+    str:DimensionReference str:Enumeration str:Metadata str:Parent str:Source
+    str:Structure str:StructureUsage str:Target
     """
 )
 def _ref(reader: Reader, elem):

--- a/sdmx/reader/xml/v30.py
+++ b/sdmx/reader/xml/v30.py
@@ -202,6 +202,31 @@ def _ar(reader: Reader, elem):
         return common.DimensionRelationship(**args)
 
 
+@end("str:MetadataAttributeUsage")
+def _mau(reader: Reader, elem):
+    # Prepare arguments for constructing the MAU
+    # - Pop the ID of the MetadataAttribute in the MSD from the stack.
+    # - Add the URN of the MetadataAttributeUsage. NB This is distinct from the URN of
+    #   the referenced MA.
+    # - Construct a reference based on the element
+    args = dict(
+        id=reader.pop_single("MetadataAttributeReference"),
+        urn=elem.attrib["urn"],
+        metadata_attribute=MetadataAttributeRef(elem.attrib["urn"]),
+    )
+
+    # Collect Attributerelationship(s); same as .reader.xml.v21._component_end
+    if ar := reader.pop_all(common.AttributeRelationship, subclass=True):
+        assert len(ar) == 1, ar
+        args["related_to"] = ar[0]
+    else:
+        # log.debug(f"Invalid SDMX-ML 3.x: no AttributeRelationship for {elem}")
+        pass
+
+    # Construct an MAU object referencing the MA
+    return v30.MetadataAttributeUsage(**args)
+
+
 # §5.4: Data Set
 
 

--- a/sdmx/reader/xml/v30.py
+++ b/sdmx/reader/xml/v30.py
@@ -13,6 +13,27 @@ from .common import BaseReference, NotReference, XMLEventReader
 log = logging.getLogger(__name__)
 
 
+class MetadataAttributeRef(BaseReference):
+    """Reference class for :class:`.MetadataAttributeUsage` only."""
+
+    maintainable = False
+    cls = v30.MetadataStructureDefinition
+    target_cls = common.MetadataAttribute
+
+    def __init__(self, urn: str) -> None:
+        # Parse information about the target from the urn=… XML attribute
+        info = sdmx.urn.match(urn)
+
+        self.agency = common.Agency(id=info["agency"])
+        self.id = info["id"]
+        self.version = info["version"]
+        self.target_id = info["item_id"]
+
+    @classmethod
+    def info_from_element(cls, elem):  # pragma: no cover
+        raise NotImplementedError
+
+
 class Reference(BaseReference):
     """Parse SDMX-ML 3.0 references."""
 

--- a/sdmx/testing/data.py
+++ b/sdmx/testing/data.py
@@ -341,6 +341,7 @@ def add_specimens(target: list[tuple[Path, str, str | None]], base: Path) -> Non
             ("IMF", "hierarchicalcodelist-1.xml"),
             ("IMF", "structureset-0.xml"),
             ("IMF_STA", "availableconstraint_CPI.xml"),  # khaeru/sdmx#161
+            ("IMF_STA", "DSD_BOP.xml"),  # khaeru/sdmx#271
             ("IMF_STA", "DSD_GFS.xml"),  # khaeru/sdmx#164
             ("INSEE", "CNA-2010-CONSO-SI-A17-structure.xml"),
             ("INSEE", "dataflow.xml"),

--- a/sdmx/tests/reader/test_xml_v30.py
+++ b/sdmx/tests/reader/test_xml_v30.py
@@ -1,3 +1,7 @@
+from typing import cast
+
+import sdmx
+from sdmx.model import common
 from sdmx.reader.xml.v30 import Reader
 
 
@@ -7,3 +11,37 @@ class TestReader:
 
         r = Reader()
         assert r.model is sdmx.model.v30
+
+
+class TestMetadataAttributeUsage:
+    def test_gh_271(self, specimen) -> None:
+        """Check that :class:`.MetadataAttributeUsage` is read correctly.
+
+        cf. :issue:`271`.
+        """
+        # Message containing <structure:MetadataAttributeUsage> can be read
+        with specimen("IMF_STA/DSD_BOP.xml") as f:
+            msg = cast(sdmx.message.StructureMessage, sdmx.read_sdmx(f))
+
+        # Retrieve references to DSD and MSD
+        dsd = msg.structure["DSD_BOP"]
+        msd = msg.metadatastructure["MSD_REF_IMF_DATASET"]
+
+        # Retrieve a single MetadataAttributeUsage from the DSD
+        component = dsd.attributes.get("METHODOLOGY")
+        # MAU has a DimensionRelationship
+        assert isinstance(component.related_to, common.DimensionRelationship)
+        assert 5 == len(component.related_to.dimensions)
+        # MAU has an association to a MetadataAttribute
+        mda1 = component.metadata_attribute
+        assert isinstance(mda1, common.MetadataAttribute)
+
+        # DSD has an association to the MSD
+        assert dsd.metadata is msd
+
+        # MSD also contains a component with the same ID
+        mda2 = msd.attributes.get("METHODOLOGY")
+
+        # These are the same object instances
+        assert mda1 is mda2
+        assert id(mda1) == id(mda2)

--- a/sdmx/tests/test_model.py
+++ b/sdmx/tests/test_model.py
@@ -183,6 +183,7 @@ V30_ONLY = [
     "Measure",
     "Dataflow",  # Instead of DataflowDefinition
     "HierarchyAssociation",
+    "MetadataAttributeUsage",
     "DataflowRelationship",
     "MeasureRelationship",
     "ObservationRelationship",

--- a/sdmx/urn.py
+++ b/sdmx/urn.py
@@ -109,12 +109,22 @@ def expand(value: str) -> str:
 
 
 def make(
-    obj, maintainable_parent: "MaintainableArtefact | None" = None, strict: bool = False
+    obj,
+    maintainable_parent: "MaintainableArtefact | None" = None,
+    strict: bool = False,
+    **kwargs,
 ) -> str:
     """Create an SDMX URN for `obj`.
 
     If `obj` is not :class:`.MaintainableArtefact`, then `maintainable_parent` must be
-    supplied in order to construct the URN.
+    supplied in order to construct the URN. If `kwargs` are supplied, they must be
+    fields/attributes of :class:`.URN`, and override values derived from `obj` and/or
+    `maintainable_parent`.
+
+    Returns
+    -------
+    str
+        String representation of the URN.
     """
     from sdmx.model.common import MaintainableArtefact
     from sdmx.model.v21 import PACKAGE
@@ -134,9 +144,10 @@ def make(
     elif strict and ma.version is None:
         raise ValueError(f"Cannot construct URN for {ma!r} without version")
 
-    return str(
-        URN(
-            None,
+    # Merge default values for each field with `kwargs`
+    kwargs = (
+        dict(
+            value=None,
             package=PACKAGE[obj.__class__.__name__],
             klass=obj.__class__.__name__,
             agency=ma.maintainer.id,
@@ -144,7 +155,9 @@ def make(
             version=str(ma.version) if ma.version else "",
             item_id=item_id,
         )
+        | kwargs
     )
+    return str(URN(**kwargs))
 
 
 def match(value: str) -> dict[str, str]:


### PR DESCRIPTION
Closes #271.

This PR implements **“Interpretation B”** per sdmx-twg/sdmx-im#53. The SDMX TWG has not responded to indicate whether this will be the correction preferred in the standard, but it's the only one for which a coherent implementation can be guessed. If some other interpretation is later provided, a further issue/PR can adjust.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
