### PR TITLE
Add support for dataset level attributes for SDMX-ML 2.1

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,10 +3,12 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
 
 - Update the base URL of the :ref:`INEGI <INEGI>` source (:pull:`270`).
+- Read dataset-related attributes from SDMX-ML 2.1
+  (:pull:`276`, thanks :gh-user:`aboddie`: for :issue:`266`, :pull:`267`).
 - Read :xml:`<structure:MetadataAttributeUsage>` from SDMX-ML 3.1 (:issue:`271`, :pull:`275`).
 
   - New class :class:`.MetadataAttributeUsage`;

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -1265,16 +1265,41 @@ def _ds_start(reader, elem):
 
     ds.structured_by = dsd
 
-    # add support for dataset level attributes
-    for name, value in elem.attrib.items():
-        # dataset level attributes are unqualified
-        if QName(name).namespace:
-            continue
+    # Iterate over XML attributes with unqualified names
+    for name in filter(lambda n: QName(n).namespace is None, elem.attrib):
+        try:
+            # Retrieve a DataAttribute from the DSD → AttributeDescriptor
+            da = dsd.attributes.get(name)
+        except KeyError:
+            continue  # No attribute with `name` in the DSD; skip this XML attribute
 
-        if name in ("action", "structureRef"):
-            continue
+        # NB Could also check/validate here that da.related_to indicates a relation to
+        #    the dataset, and log/warn/error if not.
 
-        ds.attrib[name] = common.AttributeValue(value)
+        value = elem.attrib[name]  # Attribute value
+
+        # Resolve an enumerated representation to an Item in an ItemScheme, if possible
+        # Identify an enumerated representation
+        if rep_enum := list(
+            filter(
+                None,
+                [
+                    getattr(da.local_representation, "enumerated", None),
+                    da.concept_identity.core_representation.enumerated,
+                ],
+            )
+        ):
+            try:
+                # Look up the item
+                value = rep_enum[0][value]
+            except KeyError:
+                log.debug(
+                    f"Attribute value {name}={value!r} not in enumeration "
+                    + repr(rep_enum[0])
+                )
+
+        # Add to attributes of `ds`
+        ds.attrib[name] = common.AttributeValue(value=value, value_for=da)
 
     reader.push("DataSet", ds)
 

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -1265,6 +1265,18 @@ def _ds_start(reader, elem):
 
     ds.structured_by = dsd
 
+    # add support for dataset level attributes
+    for name, value in elem.attrib.items():
+        # dataset level attributes are unqualified
+        if QName(name).namespace:
+            continue
+        
+        #skip action
+        if name == 'action':
+            continue
+
+        ds.attrib[name] = common.AttributeValue(value)
+
     reader.push("DataSet", ds)
 
 

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -1270,9 +1270,8 @@ def _ds_start(reader, elem):
         # dataset level attributes are unqualified
         if QName(name).namespace:
             continue
-        
-        #skip action
-        if name in ('action', 'structureRef'):
+
+        if name in ("action", "structureRef"):
             continue
 
         ds.attrib[name] = common.AttributeValue(value)

--- a/sdmx/reader/xml/v21.py
+++ b/sdmx/reader/xml/v21.py
@@ -1272,7 +1272,7 @@ def _ds_start(reader, elem):
             continue
         
         #skip action
-        if name == 'action':
+        if name in ('action', 'structureRef'):
             continue
 
         ds.attrib[name] = common.AttributeValue(value)

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -259,7 +259,11 @@ class MessageTest:
 
 
 @pytest.fixture(scope="session")
-def installed_schemas(worker_id, mock_gh_api, tmp_path_factory):
+def installed_schemas(
+    worker_id: str,
+    mock_gh_api: responses.RequestsMock,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[Path]:
     """Fixture that ensures schemas are installed locally in a temporary directory."""
     from sdmx.format.xml.common import install_schemas
 
@@ -278,7 +282,7 @@ def installed_schemas(worker_id, mock_gh_api, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def mock_gh_api():
+def mock_gh_api() -> Iterator[responses.RequestsMock]:
     """Mock GitHub API responses to avoid hitting rate limits.
 
     For each API endpoint URL queried by :func:.`_gh_zipball`, return a pared-down JSON

--- a/sdmx/testing/data.py
+++ b/sdmx/testing/data.py
@@ -306,6 +306,7 @@ def add_specimens(target: list[tuple[Path, str, str | None]], base: Path) -> Non
             ("INSEE", "CNA-2010-CONSO-SI-A17.xml"),
             ("INSEE", "IPI-2010-A21.xml"),
             ("IMF", "PCPS.xml"),
+            ("IMF_RES", "WEO-data.xml"),  # khaeru/sdmx#266
             ("ESTAT", "demography-xs.xml"),
             ("ESTAT", "esms.xml"),
             ("ESTAT", "footer.xml"),
@@ -340,6 +341,7 @@ def add_specimens(target: list[tuple[Path, str, str | None]], base: Path) -> Non
             ("IMF", "hierarchicalcodelist-0.xml"),
             ("IMF", "hierarchicalcodelist-1.xml"),
             ("IMF", "structureset-0.xml"),
+            ("IMF_RES", "WEO-structure.xml"),  # khaeru/sdmx#266
             ("IMF_STA", "availableconstraint_CPI.xml"),  # khaeru/sdmx#161
             ("IMF_STA", "DSD_BOP.xml"),  # khaeru/sdmx#271
             ("IMF_STA", "DSD_GFS.xml"),  # khaeru/sdmx#164

--- a/sdmx/tests/reader/test_xml_v21.py
+++ b/sdmx/tests/reader/test_xml_v21.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from itertools import chain
+from pathlib import Path
 from typing import cast
 
 import pandas
@@ -16,6 +17,7 @@ from sdmx.format.xml.v21 import qname
 from sdmx.model import common, v21
 from sdmx.model.v21 import ContentConstraint, Facet, FacetType, FacetValueType
 from sdmx.reader.xml.v21 import Reader, XMLParseError
+from sdmx.testing.data import SpecimenCollection
 from sdmx.writer.xml import Element as E
 
 
@@ -346,6 +348,51 @@ def test_gh_218(caplog, installed_schemas, specimen) -> None:
         == len(contact.uri)
         == len(contact.x400)
     )
+
+
+def test_gh_266(installed_schemas: Path, specimen: SpecimenCollection) -> None:
+    """Test of https://github.com/khaeru/sdmx/pull/266."""
+    with specimen("IMF_RES/WEO-structure.xml") as f:
+        # Specimen is XSD-valid
+        validate_xml(f, installed_schemas)
+        f.seek(0)
+        sm = cast(sdmx.message.StructureMessage, sdmx.read_sdmx(f))
+    with specimen("IMF_RES/WEO-data.xml") as f:
+        # Specimen is XSD-valid
+        validate_xml(f, installed_schemas)
+        f.seek(0)
+        # Data message can be read
+        dm = cast(sdmx.message.DataMessage, sdmx.read_sdmx(f, dsd=sm.structure[0]))
+
+    ds = dm.data[0]  # Retrieve 1 data set
+
+    # Expected number of attributes were read
+    assert 14 == len(ds.attrib)
+
+    # Non-enumerated attributes are available
+    assert ds.attrib["FULL_DESCRIPTION"].value.startswith("The World Economic Outlook ")
+    assert 885 == len(ds.attrib["FULL_DESCRIPTION"].value)
+    assert ds.attrib["FULL_DESCRIPTION"].value.endswith(" for certain years.")
+
+    # Enumerated attributes are Codes/Items (with .urn attribute) resolved to members of
+    # Codelists
+    assert (
+        "Code=IMF:CL_ACCESS_SHARING_LEVEL(1.0.2).PUBLIC_OPEN"
+        in ds.attrib["ACCESS_SHARING_LEVEL"].value.urn
+    )
+    assert "Code=IMF:CL_DEPARTMENT(1.0.2).RES" in ds.attrib["DEPARTMENT"].value.urn
+    assert "Code=IMF:CL_LANGUAGE(1.1.0).EN" in ds.attrib["LANGUAGE"].value.urn
+    assert "Code=IMF:CL_ORGANIZATION(2.4.0).IMF" in ds.attrib["PUBLISHER"].value.urn
+    assert (
+        "Code=IMF:CL_SEC_CLASSIFICATION(1.0.1).PUB"
+        in ds.attrib["SECURITY_CLASSIFICATION"].value.urn
+    )
+
+    # Special, comma-separated format for "TOPIC_DATASET" attribute is not parsed
+    topics = ds.attrib["TOPIC_DATASET"].value
+    assert isinstance(topics, str)
+    # …but individual values resolve within the respective codelist
+    assert all(id_ in sm.codelist["CL_TOPIC"] for id_ in topics.split(","))
 
 
 # Each entry is a tuple with 2 elements:


### PR DESCRIPTION
- Supersedes #267, picking up and expanding the changes made there by @aboddie.
- Closes #266.

The tests use two new specimens suggested at https://github.com/khaeru/sdmx/issues/266#issuecomment-3740374969 and added [here](https://github.com/khaeru/sdmx-test-data/commit/a2b44bf014b379c983c124b6837e173d2d497b80).

### PR checklist
- [x] Checks all ✅
- ~Update documentation~
- [x] Update doc/whatsnew.rst
