### PR TITLE
Miscellaneous improvements for 2026-W14

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -276,8 +276,8 @@ International Monetary Fund
 As of 2025-01-10, there appear to be at least *three* systems operated by the IMF from which SDMX responses are available.
 Theses are listed here from oldest to newest, and identified by the domain used in the base URL for requests.
 
-(no ID): dataservices.smdx.org
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(no ID): dataservices.imf.org
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SDMX-ML and SDMX-JSON —
 API documentation `1 <https://datahelp.imf.org/knowledgebase/articles/1952905-sdmx-2-0-and-sdmx-2-1-restful-web-service>`__,
@@ -449,36 +449,55 @@ API documentation `(en) <https://www.nbb.be/doc/dq/migratie_belgostat/en/nbb_sta
 - The web service returns a custom HTML error page rather than an SDMX error message for certain queries or an internal error.
   This appears as: ``ValueError: can't determine a SDMX reader for response content type 'text/html; charset=utf-8'``
 
+Organisation for Economic Cooperation and Development
+-----------------------------------------------------
 
 .. _OECD:
 
 .. currentmodule:: sdmx.source.oecd
 
-``OECD``: Organisation for Economic Cooperation and Development (SDMX-ML)
--------------------------------------------------------------------------
+``OECD`` (SDMX-ML)
+~~~~~~~~~~~~~~~~~~
 
 SDMX-ML —
-`Website <https://data-explorer.oecd.org/>`__,
-`documentation <https://gitlab.algobank.oecd.org/public-documentation/dotstat-migration/-/raw/main/OECD_Data_API_documentation.pdf>`__
+`Website <https://data-explorer.oecd.org/>`__ —
+Documentation `1 <https://gitlab.algobank.oecd.org/public-documentation/dotstat-migration/-/raw/main/OECD_Data_API_documentation.pdf>`__,
+`2 <https://www.oecd.org/en/data/insights/data-explainers/2024/09/api.html>`__,
+`3 <https://www.oecd.org/en/data/insights/data-explainers/2024/11/Api-best-practices-and-recommendations.html>`__
 
-- As of 2023-08-14, the site includes a disclaimer that “This is a public beta release. Not all data is available on this platform yet, as it is being progressively migrated from https://stats.oecd.org.”
-- The OECD website `describes an older SDMX-ML API <https://data.oecd.org/api/sdmx-ml-documentation/>`__, but this is an implementation of SDMX 2.0, which is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
+- This source implements the SDMX-REST 1.x API and serves SDMX-ML 2.1 and SDMX-JSON 1.0.0.
+- The OECD website `describes an older SDMX-ML API <https://data.oecd.org/api/sdmx-ml-documentation/>`__,
+  but this is an implementation of SDMX 2.0,
+  which is not supported by :mod:`sdmx` (see :ref:`sdmx-version-policy`).
 
 .. autoclass:: sdmx.source.oecd.Source
    :members:
 
 .. versionadded:: 2.12.0
 
+.. _OECD3:
+
+.. currentmodule:: sdmx.source.oecd3
+
+``OECD3``
+~~~~~~~~~
+
+- This source implements the SDMX-REST 2.x API and serves SDMX-ML 3.0.0 and SDMX-JSON 2.0.0.
+
+.. autoclass:: sdmx.source.oecd3.Source
+   :members:
+
 .. _OECD_JSON:
 
 .. currentmodule:: sdmx.source.oecd_json
 
-``OECD_JSON``: Organisation for Economic Cooperation and Development (SDMX-JSON)
---------------------------------------------------------------------------------
+``OECD_JSON``
+~~~~~~~~~~~~~
 
-SDMX-JSON —
-`Website <https://data.oecd.org/api/sdmx-json-documentation/>`__
+SDMX-JSON
 
+- As of 2026-04-04, the ``OECD`` source also returns SDMX-JSON 1.0.0,
+  when given the appropriate HTTP ``Accept:`` header.
 - Only :ref:`SDMX-JSON version 1.0 <sdmx-json>` is supported.
 
 .. versionchanged:: 2.12.0

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,6 +6,8 @@ What's new?
 Next release
 ============
 
+- Add :ref:`OECD3` source (:pull:`278`, thanks :gh-user:`dosse` for :issue:`272`),
+  update documentation URLs.
 - Update the base URL of the :ref:`INEGI <INEGI>` source (:pull:`270`).
 - Read dataset-related attributes from SDMX-ML 2.1
   (:pull:`276`, thanks :gh-user:`aboddie`: for :issue:`266`, :pull:`267`).
@@ -13,7 +15,11 @@ Next release
 
   - New class :class:`.MetadataAttributeUsage`;
     see its docstring for implementation notes.
+- Use "*" as the default provider and resource ID in SDMX-REST 2.x (SDMX 3) URLs (:pull:`278`).
 - Add override keyword arguments to :func:`.urn.make` (:pull:`275`).
+- Bug fix for reading SDMX-ML 3.x where certain elements
+  (for instance, :xml:`<structure:Code>`)
+  had no internal whitespace whatsoever (:pull:`278`).
 
 v2.25.1 (2026-01-23)
 ====================

--- a/sdmx/reader/xml/v30.py
+++ b/sdmx/reader/xml/v30.py
@@ -35,12 +35,13 @@ class MetadataAttributeRef(BaseReference):
 
 
 class Reference(BaseReference):
-    """Parse SDMX-ML 3.0 references."""
+    """Parse SDMX-ML 3.x references."""
 
     @classmethod
     def info_from_element(cls, elem):
         try:
-            result = sdmx.urn.match(elem.text)
+            # Parse the element text as a URN. Elements with no text are not references.
+            result = sdmx.urn.match(elem.text or "")
             # If the URN doesn't specify an item ID, it is probably a reference to a
             # MaintainableArtefact, so target_id and id are the same
             result.update(target_id=result["item_id"] or result["id"])

--- a/sdmx/rest/v30.py
+++ b/sdmx/rest/v30.py
@@ -12,7 +12,7 @@ from collections import ChainMap
 from . import common
 from .common import PathParameter, QueryParameter, Resource
 
-#: v2.1.0-specific path and query parameters.
+#: SDMX-REST v2.1.0-specific path and query parameters.
 PARAM: dict[str, common.Parameter] = {
     # Path parameters
     "component_id": PathParameter("component_id"),
@@ -22,7 +22,8 @@ PARAM: dict[str, common.Parameter] = {
     "context_d": PathParameter(
         "context", {"datastructure", "dataflow", "provisionagreement", "*"}, "*"
     ),
-    "provider_id": PathParameter("provider_id"),
+    "provider_id": PathParameter("provider_id", default="*"),
+    "resource_id": PathParameter("resource_id", default="*"),
     "version": PathParameter("version", set(), "+"),
     #
     # Query parameters
@@ -42,7 +43,7 @@ PARAM: dict[str, common.Parameter] = {
 class URL(common.URL):
     """Utility class to build SDMX-REST API v2.1.0 URLs."""
 
-    _all_parameters = ChainMap(common.PARAM, PARAM)
+    _all_parameters = ChainMap(PARAM, common.PARAM)
 
     def handle_availability(self):
         """Handle URL parameters for availability endpoints."""

--- a/sdmx/source/oecd3.py
+++ b/sdmx/source/oecd3.py
@@ -1,0 +1,18 @@
+from .oecd import Source as OECD
+
+
+class Source(OECD):
+    _id = "OECD3"
+
+    def modify_request_args(self, kwargs):
+        """Supply explicit agency ID for OECD3.
+
+        This hook sets the agency_id to "*" for structure queries if it is not given
+        explicitly. This avoids that the (package-specific) source ID "OECD3" is used.
+        """
+        super().modify_request_args(kwargs)
+
+        # NB this is an indirect test for resource_type != 'data'; because of the way
+        #    the hook is called, resource_type is not available directly.
+        if "key" not in kwargs:
+            kwargs.setdefault("agency_id", "*")

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -387,6 +387,14 @@
     }
   },
   {
+    "id": "OECD3",
+    "url": "https://sdmx.oecd.org/public/rest/v2",
+    "name": "Organisation for Economic Co-operation and Development",
+    "versions": [
+      "3.0.0"
+    ]
+  },
+  {
     "id": "OECD_JSON",
     "data_content_type": "JSON",
     "url": "https://stats.oecd.org/SDMX-JSON",

--- a/sdmx/testing/data.py
+++ b/sdmx/testing/data.py
@@ -326,6 +326,7 @@ def add_specimens(target: list[tuple[Path, str, str | None]], base: Path) -> Non
             ("ESTAT", "apro_mk_cola-structure.xml"),
             ("ESTAT", "demography-structure.xml"),
             ("ESTAT", "esms-structure.xml"),
+            ("ESTAT", "CL_FREQ.xml"),
             ("ESTAT", "GOV_10Q_GGNFA.xml"),
             ("ESTAT", "HCL_WSTATUS_SCL_BNSPART.xml"),
             ("ESTAT", "HCL_WSTATUS_SCL_WSTATUSPR.xml"),

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -17,7 +17,7 @@ def test_get_source(caplog):
 def test_list_sources():
     source_ids = list_sources()
     # Correct number of sources, excluding those created for testing
-    assert 34 == len(set(source_ids) - {"MOCK", "TEST"})
+    assert 35 == len(set(source_ids) - {"MOCK", "TEST"})
 
     # Listed alphabetically
     assert "ABS" == source_ids[0]

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -605,6 +605,19 @@ class TestOECD(DataSourceTest):
     }
 
 
+class TestOECD3(DataSourceTest):
+    source_id = "OECD3"
+    endpoint_args = {
+        "actualconstraint": dict(resource_id="CR_A_DSD_DEBT_TRANS_COLL@DF_MICRO"),
+        "data": dict(
+            context="dataflow",
+            resource_id="DSD_MSTI@DF_MSTI",
+            last_n_observations=100,
+            headers={"Accept-Encoding": "compress, gzip"},
+        ),
+    }
+
+
 class TestOECD_JSON(DataSourceTest):
     source_id = "OECD_JSON"
 

--- a/sdmx/tests/writer/test_xml.py
+++ b/sdmx/tests/writer/test_xml.py
@@ -467,6 +467,7 @@ class TestRoundTripMetadata(RoundTripTests):
             True,
             marks=[pytest.mark.skip(reason="Slow")],
         ),
+        ("ESTAT/CL_FREQ.xml", True),
         ("IMF/ECOFIN_DSD-structure.xml", True),
         ("IMF/datastructure-0.xml", True),
         ("IMF/hierarchicalcodelist-1.xml", True),

--- a/sdmx/writer/xml.py
+++ b/sdmx/writer/xml.py
@@ -298,7 +298,7 @@ def i11lstring(obj, name) -> list[etree._Element]:
 
 
 @writer
-def _a(obj: model.Annotation):
+def _a(obj: common.BaseAnnotation):
     elem = Element("com:Annotation")
     if obj.id:
         elem.attrib["id"] = obj.id


### PR DESCRIPTION
- [x] Address parsing failures from the ESTAT3 source, e.g. [here](https://github.com/khaeru/sdmx/actions/runs/23972218651/job/69923564630#step:5:634):
  ```
  ______________________ TestESTAT3.test_endpoint[codelist] ______________________

  E           RuntimeError: 69 uncollected items
  ```
  This occurred due to incorrect handling of `<str:Code>` elements that contained no text nodes whatsoever—not even whitespace. In these cases, `elem.text = None` would raise an exception, leading to them being interpreted as forward references.
- [x] Write both .v21.Annotation and .v30.Annotation to SDMX-ML. This was missed in #227.
- [x] Add `OECD3` source; partly addresses #272. 

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
