### PR TITLE
Adjust for requests ≥2.34, requests-cache ≥1.3

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -45,8 +45,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install the package and dependencies
-      # TEMPORARY Work around https://github.com/khaeru/sdmx/issues/273
-      run: uv pip install "requests-cache < 1.3" .[tests]
+      run: uv pip install .[tests]
 
     - name: Run pytest
       run: |

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -80,7 +80,27 @@ Contents and layout
 .. _recorded-responses:
 
 The :file:`recorded/` directory contains **recorded HTTP responses** from certain SDMX-REST web services.
-These files are stored using the :mod:`requests_cache` :doc:`file system backend <requests-cache:user_guide/backends/filesystem>`; see those docs for the name and format of the files.
+These files are stored using the :mod:`requests_cache` :doc:`file system backend <requests-cache:user_guide/backends/filesystem>`;
+see those docs for the name and format of the files.
+To record a new response, use a temporary script similar to:
+
+.. code-block:: python
+
+   from requests_cache import CachedSession
+   from sdmx import Client
+
+   session = CachedSession(
+       "./recorded",  # or other path to sdmx-test-data/recorded/
+       backend="filesystem",
+       serializer="json",
+   )
+
+   # Exactly the client and request to be used in a test/cached
+   client = sdmx.Client("ISTAT", session=session)
+   client.dataflow("47_850", params={"references": "datastructure"})
+
+This should create a new .json file in the directory.
+Commit and push the file, using a pull request if appropriate.
 
 .. _sdmx-test-data:
 

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -31,7 +31,7 @@ and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(72.0)":
+    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(73.0)":
         print(sdmx.to_pandas(sm.get(cl)))
 
 Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.

--- a/sdmx/testing/__init__.py
+++ b/sdmx/testing/__init__.py
@@ -307,7 +307,7 @@ def mock_gh_api() -> Iterator[responses.RequestsMock]:
 
 
 @pytest.fixture(scope="session")
-def session_with_pytest_cache(pytestconfig):
+def session_with_pytest_cache(pytestconfig: pytest.Config) -> Iterator[Session]:
     """Fixture:  A :class:`.Session` that caches within :file:`.pytest_cache`.
 
     This subdirectory is ephemeral, and tests **must** pass whether or not it exists and
@@ -318,7 +318,7 @@ def session_with_pytest_cache(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def session_with_stored_responses(pytestconfig):
+def session_with_stored_responses(pytestconfig: pytest.Config) -> Iterator[Session]:
     """Fixture: A :class:`.Session` returns only stored responses from sdmx-test-data.
 
     This session…

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -1,6 +1,7 @@
 """Tests against the actual APIs for specific data sources."""
 
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -9,6 +10,7 @@ import pytest
 import sdmx
 from sdmx import Client
 from sdmx.exceptions import HTTPError, XMLParseError
+from sdmx.session import Session
 
 log = logging.getLogger(__name__)
 
@@ -43,12 +45,14 @@ class DataSourceTest:
     xfail_common: ClassVar[dict[str, Any]] = {}
 
     @pytest.fixture(scope="class")
-    def client(self, session_with_pytest_cache):
+    def client(self, session_with_pytest_cache: Session) -> Iterator[Client]:
         """A Client that uses :func:`.session_with_pytest_cache`."""
         yield Client(self.source_id, session=session_with_pytest_cache)
 
     @pytest.fixture(scope="class")
-    def client_with_stored_responses(self, session_with_stored_responses):
+    def client_with_stored_responses(
+        self, session_with_stored_responses: Session
+    ) -> Iterator[Client]:
         """A Client that uses :func:`.session_with_stored_responses`."""
         yield Client(self.source_id, session=session_with_stored_responses)
 
@@ -476,7 +480,7 @@ class TestISTAT(DataSourceTest):
         "actualconstraint": dict(resource_id="CONS_92_143"),
     }
 
-    def test_gh_75(self, client_with_stored_responses):
+    def test_gh_75(self, client_with_stored_responses: Client) -> None:
         """Test of https://github.com/dr-leo/pandaSDMX/pull/75.
 
         - As of the original report on 2019-06-02, the 4th dimension was ``TIPO_DATO``,


### PR DESCRIPTION
1. Drop the work-around for #273 that was added in #274.
   - This workaround excludes requests-cache v1.3.2, which contains a fix necessary for compatibility with requests ≥2.34.0 (requests-cache/requests-cache#1151)
   - Because of this incompatibility, CI jobs such as [this one](https://github.com/khaeru/sdmx/actions/runs/25983039126/job/76375220268#step:5:7519) were failing with exceptions like `NameError: name 'RequestsCookieJar' is not defined`.
2. Resolve #273 directly. This is done in khaeru/sdmx-test-data@cd7899341b46e179e9f19b638478d70197e12c74 by updating the specimens, whose format appears to have changed in requests-cache 1.3.x. From [the release notes](https://requests-cache.readthedocs.io/en/stable/project_info/history.html) it is not clear exactly *how* it changed.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation.
- ~Update doc/whatsnew.rst~ N/A: CI changes only
