### PR TITLE
Add data source LU1 (Luxembourg STATEC)

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -421,6 +421,17 @@ SDMX-ML —
 - This web service returns the non-standard HTTP content-type "application/force-download"; :mod:`sdmx` replaces it with "application/xml".
 
 
+.. _LU1:
+
+``LU1``: STATEC (Luxembourg)
+----------------------------
+
+SDMX-ML —
+`Website <https://lustat.statec.lu/>`__
+
+- LUSTAT is the data dissemination platform of STATEC, the national statistical institute of Luxembourg.
+
+
 .. _NB:
 
 ``NB``: Norges Bank (Norway)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add ``LU1`` data source: Luxembourg STATEC (LUSTAT).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,7 +6,7 @@ What's new?
 Next release
 ============
 
-- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT).
+- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT) (:pull:`282`).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,7 +6,7 @@ What's new?
 Next release
 ============
 
-- Add ``LU1`` data source: Luxembourg STATEC (LUSTAT).
+- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -343,6 +343,20 @@
     }
   },
   {
+    "id": "LU1",
+    "name": "Luxembourg STATEC",
+    "url": "https://lustat.statec.lu/rest",
+    "supports": {
+      "agencyscheme": false,
+      "dataconsumerscheme": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "organisationscheme": false,
+      "structure": false,
+      "structureset": false
+    }
+  },
+  {
     "id": "NB",
     "name": "Norges Bank (NO)",
     "url": "https://data.norges-bank.no/api",

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -351,8 +351,6 @@
       "dataconsumerscheme": false,
       "metadataflow": false,
       "metadatastructure": false,
-      "organisationscheme": false,
-      "structure": false,
       "structureset": false
     }
   },

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -587,8 +587,10 @@ class TestLU1(DataSourceTest):
     }
 
     xfail = {
-        "metadata": NotImplementedError,  # /metadata not in SDMX-REST v2.1
-        "registration": ValueError,  # /registration not in SDMX-REST v2.1
+        "metadata": NotImplementedError,  # Internal to sdmx1
+        "organisationscheme": HTTPError,  # 400 Bad Request
+        "registration": ValueError,  # Internal to sdmx1
+        "structure": NotImplementedError,  # 501 Not Implemented
     }
 
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -577,6 +577,21 @@ class TestLSD(DataSourceTest):
     }
 
 
+class TestLU1(DataSourceTest):
+    """Luxembourg STATEC (LUSTAT)."""
+
+    source_id = "LU1"
+
+    endpoint_args = {
+        "data": dict(resource_id="DF_A1100", params=dict(lastNObservations=1)),
+    }
+
+    xfail = {
+        "metadata": NotImplementedError,  # /metadata not in SDMX-REST v2.1
+        "registration": ValueError,  # /registration not in SDMX-REST v2.1
+    }
+
+
 class TestNB(DataSourceTest):
     """Norges Bank.
 


### PR DESCRIPTION
## Summary

Adds the Luxembourg national statistical office — **STATEC**, dissemination platform **LUSTAT** — as data source `LU1`.

| | |
|---|---|
| id / SDMX agency | `LU1` |
| Office | STATEC (Luxembourg) |
| URL | https://lustat.statec.lu/rest |
| Format | SDMX-ML, SDMX-REST 2.1 |
| Dataflows | 904 |

`LU1` is the service's own SDMX agency id, so a bare `Client("LU1").dataflow()` resolves without an explicit `agency_id` argument.

## Changes

- **`sdmx/sources.json`** — new `LU1` entry. The `supports` block disables the five structural endpoints the service answers with **HTTP 404** (`agencyscheme`, `dataconsumerscheme`, `metadataflow`, `metadatastructure`, `structureset`).
- **`sdmx/tests/test_sources.py`** — `TestLU1(DataSourceTest)` with `endpoint_args` for the `data` endpoint and an `xfail` mapping for the endpoints that return **400** (`organisationscheme` → `HTTPError`) or **501** (`structure` → `NotImplementedError`), alongside the usual sdmx-internal `metadata` / `registration` entries. This mirrors `TestUY110`.
- **`doc/sources.rst`** — `LU1` source section.
- **`doc/whatsnew.rst`** — changelog entry.

The 404-vs-400/501 split follows the policy under *"Handling and testing limitations and (un)supported endpoints"* in `doc/sources.rst`: each endpoint was probed live to record its actual HTTP status.

## Verification

`DataSourceTest` against the live service — `pytest -m source -k TestLU1 --sdmx-fetch-data`:

```
13 passed, 21 xfailed, 0 failed
```

---

The `whatsnew.rst` bullet uses the `:ref:` role; I'll add the `:pull:` reference in a follow-up commit once this PR is numbered.
