### PR TITLE
Add data source LU1 (Luxembourg STATEC)

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -421,6 +421,17 @@ SDMX-ML —
 - This web service returns the non-standard HTTP content-type "application/force-download"; :mod:`sdmx` replaces it with "application/xml".
 
 
+.. _LU1:
+
+``LU1``: STATEC (Luxembourg)
+----------------------------
+
+SDMX-ML —
+`Website <https://lustat.statec.lu/>`__
+
+- LUSTAT is the data dissemination platform of STATEC, the national statistical institute of Luxembourg.
+
+
 .. _NB:
 
 ``NB``: Norges Bank (Norway)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,7 +6,7 @@ What's new?
 Next release
 ============
 
-- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT).
+- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT) (:pull:`283`).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :ref:`LU1` data source: Luxembourg STATEC (LUSTAT).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -343,6 +343,18 @@
     }
   },
   {
+    "id": "LU1",
+    "name": "Luxembourg STATEC",
+    "url": "https://lustat.statec.lu/rest",
+    "supports": {
+      "agencyscheme": false,
+      "dataconsumerscheme": false,
+      "metadataflow": false,
+      "metadatastructure": false,
+      "structureset": false
+    }
+  },
+  {
     "id": "NB",
     "name": "Norges Bank (NO)",
     "url": "https://data.norges-bank.no/api",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -17,7 +17,7 @@ def test_get_source(caplog):
 def test_list_sources():
     source_ids = list_sources()
     # Correct number of sources, excluding those created for testing
-    assert 35 == len(set(source_ids) - {"MOCK", "TEST"})
+    assert 36 == len(set(source_ids) - {"MOCK", "TEST"})
 
     # Listed alphabetically
     assert "ABS" == source_ids[0]

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -577,6 +577,23 @@ class TestLSD(DataSourceTest):
     }
 
 
+class TestLU1(DataSourceTest):
+    """Luxembourg STATEC (LUSTAT)."""
+
+    source_id = "LU1"
+
+    endpoint_args = {
+        "data": dict(resource_id="DF_A1100", params=dict(lastNObservations=1)),
+    }
+
+    xfail = {
+        "metadata": NotImplementedError,  # Internal to sdmx1
+        "organisationscheme": HTTPError,  # 400 Bad Request
+        "registration": ValueError,  # Internal to sdmx1
+        "structure": NotImplementedError,  # 501 Not Implemented
+    }
+
+
 class TestNB(DataSourceTest):
     """Norges Bank.
 


### PR DESCRIPTION
Adds the Luxembourg national statistical office (STATEC, dissemination platform LUSTAT) as data source `LU1`.

`LU1` is the service's own SDMX agency id — every dataflow and structure is maintained under it — so a bare `Client("LU1").dataflow()` works without an explicit `agency_id`.

I'm Dinh Nguyen-Xuan, from the Statistics Department of the International Monetary Fund. I really appreciate the `sdmx1` package and am exploring ways to help enhance it.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
