### PR TITLE
Adjust CI failures due to UNICEF/CD2030

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -31,7 +31,7 @@ and :func:`.to_pandas` to convert to :class:`.pandas.Series`:
 
 .. ipython:: python
 
-    for cl in "ESTAT:AGE(15.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(73.0)":
+    for cl in "ESTAT:AGE(16.0)", "ESTAT:SEX(1.13)", "ESTAT:UNIT(75.0)":
         print(sdmx.to_pandas(sm.get(cl)))
 
 Next, we download a **data set** containing a portion of the data in this data flow, structured by this DSD.

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -598,12 +598,15 @@ SDMX-ML or SDMX-JSON —
 `Web interface <https://sdmx.data.unicef.org/>`__ —
 `Data browser <https://sdmx.data.unicef.org/databrowser/index.html>`__
 
-- This source always returns structure-specific messages for SDMX-ML data queries; even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
+- This source always returns structure-specific messages for SDMX-ML data queries;
+  even when the HTTP header ``Accept: application/vnd.sdmx.genericdata+xml`` is given.
 
 .. _CD2030:
 
-- UNICEF also serves data for the `Countdown to 2030 <https://www.countdown2030.org/about>`_ initiative under a data flow with the ID ``CONSOLIDATED``.
-  The structures can be obtained by giving the `provider` argument to a structure query, and then used to query the data:
+- UNICEF also serves data for the `Countdown to 2030 <https://www.countdown2030.org/about>`_ initiative
+  under a data flow with the ID ``CONSOLIDATED``.
+  The structures can be obtained by giving the `provider` argument to a structure query,
+  and then querying the data:
 
   .. code-block:: python
 
@@ -615,7 +618,9 @@ SDMX-ML or SDMX-JSON —
      dsd = UNICEF.dataflow("CONSOLIDATED", provider="CD2030").structure[0]
 
      # Use the DSD to construct a query for indicator D5 (“Births”)
-     client.data("CONSOLIDATED", key=dict(INDICATOR="D5"), dsd=dsd)
+     UNICEF.data("CONSOLIDATED", key=dict(INDICATOR="D5"), dsd=dsd)
+
+  .. note:: As of **2026-07-22**, these data flows appear to be no longer available.
 
 - The example query from the UNICEF API documentation (also used in the :mod:`sdmx` test suite) returns XML like:
 

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -738,6 +738,7 @@ class TestUNICEF(DataSourceTest):
         assert "TRGT_CME" == c.parent.id
 
     @pytest.mark.network
+    @pytest.mark.xfail(reason="Data not available since 2026-07-22")
     def test_cd2030(self, client):
         """Test that :ref:`Countdown to 2030 <CD2030>` data can be queried."""
         dsd = client.dataflow("CONSOLIDATED", agency_id="CD2030").structure[0]


### PR DESCRIPTION
Since about 2026-07-22, all "pytest" workflow CI jobs have failed with:
```
FAILED sdmx/tests/test_sources.py::TestUNICEF::test_cd2030 - requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://sdmx.data.unicef.org/ws/public/sdmxapi/rest/dataflow/CD2030/CONSOLIDATED/latest?references=all
```

See for example [here](https://github.com/khaeru/sdmx/actions/runs/29900312440/job/88859368513#step:5:2533) (failing) versus the previous daily run [here](https://github.com/khaeru/sdmx/actions/runs/29810452348/job/88570047054#step:5:2315) (passing).

This appears to occur because the source is no longer serving this dataflow.
A brief web search does not turn up any information about the removal.

The PR adjusts by Xfailing the offending test, and adding a notice in the documentation.
Neither are removed, in case the disappearance is temporary.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- ~Update doc/whatsnew.rst~ N/A
