### PR TITLE
Update SGR base URL; add SGR3

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -511,8 +511,8 @@ SDMX-JSON
 
 .. _SGR:
 
-``SGR``: SDMX Global Registry
------------------------------
+``SGR``, ``SGR3``: SDMX Global Registry
+---------------------------------------
 
 SDMX-ML —
 `Website <https://registry.sdmx.org/overview.html>`__

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,8 +3,11 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Update the base URL for the :ref:`SGR` source
+  and add a new source `SGR3` (:pull:`289`).
 
 v2.26.0 (2026-04-04)
 ====================

--- a/sdmx/source/sgr3.py
+++ b/sdmx/source/sgr3.py
@@ -1,0 +1,5 @@
+from . import sgr
+
+
+class Source(sgr.Source):
+    _id = "SGR3"

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -414,6 +414,19 @@
     ]
   },
   {
+    "id": "SGR3",
+    "url": "https://registry.sdmx.org/sdmx/v2",
+    "name": "SDMX Global Registry",
+    "supports": {
+      "actualconstraint": false,
+      "metadataflow": false,
+      "structureset": false
+    },
+    "versions": [
+      "3.0.0"
+    ]
+  },
+  {
     "id": "SPC",
     "name": "Pacific Data Hub DotStat by The Pacific Community (SPC)",
     "url": "https://stats-nsi-stable.pacificdata.org/rest",

--- a/sdmx/sources.json
+++ b/sdmx/sources.json
@@ -402,13 +402,16 @@
   },
   {
     "id": "SGR",
-    "url": "https://registry.sdmx.org/ws/rest",
+    "url": "https://registry.sdmx.org/ws/public/sdmxapi/rest",
     "name": "SDMX Global Registry",
     "supports": {
       "actualconstraint": false,
       "metadataflow": false,
       "structureset": false
-    }
+    },
+    "versions": [
+      "2.1"
+    ]
   },
   {
     "id": "SPC",

--- a/sdmx/tests/test_source.py
+++ b/sdmx/tests/test_source.py
@@ -17,7 +17,7 @@ def test_get_source(caplog):
 def test_list_sources():
     source_ids = list_sources()
     # Correct number of sources, excluding those created for testing
-    assert 35 == len(set(source_ids) - {"MOCK", "TEST"})
+    assert 36 == len(set(source_ids) - {"MOCK", "TEST"})
 
     # Listed alphabetically
     assert "ABS" == source_ids[0]

--- a/sdmx/tests/test_sources.py
+++ b/sdmx/tests/test_sources.py
@@ -648,10 +648,7 @@ class TestSGR(DataSourceTest):
 
 
 class TestSGR3(DataSourceTest):
-    """Query the `SGR` source using SDMX 3.0."""
-
-    source_id = "SGR"
-    endpoint_args = {"codelist": dict(params=dict(format="sdmx-3.0"))}
+    source_id = "SGR3"
 
 
 class TestSPC(DataSourceTest):


### PR DESCRIPTION
The SDMX Global Registry (SGR) service's base URL changed around 2026-05-31. This did not cause failures in the "pytest" workflow scheduled jobs, but did result in unexpected failures ("X") in the "data-sources" workflow (reflected at https://khaeru.github.io/sdmx/) and failures in downstream packages.

This PR:
- Updates the API base URL.
- Adds a new source `SGR3` for the distinct SDMX-REST 2.0.0 (SDMX 3.x) endpoint.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
